### PR TITLE
Include alternative FT UI tests definitions

### DIFF
--- a/test/greeting_ft_tests.js
+++ b/test/greeting_ft_tests.js
@@ -1,13 +1,18 @@
-var responseTo = require(__dirname + '/utils/test_helpers.js').responseTo;
+var getTo = require(__dirname + '/utils/test_helpers.js').get;
 var app = require(__dirname + '/../server.js').getApp;
 
 describe('The /greeting endpoint returned json', function () {
 
-  it('should contain the following elements', responseTo(app, '/greeting').contains(
-    {
-      'greeting': 'Hello',
-      'name': 'World'
-    }
-  ));
+  it('should contain the following elements',
+
+    getTo(app, '/greeting')
+      .is(200)
+      .contains(
+      {
+        'greeting': 'Hello',
+        'name': 'World'
+      })
+
+  );
 
 });

--- a/test/utils/test_helpers.js
+++ b/test/utils/test_helpers.js
@@ -3,22 +3,67 @@ var should = require('chai').should();
 var cheerio = require('cheerio');
 
 module.exports = {
-  responseTo: function (app, endpoint) {
 
+  get: function (app, endpoint) {
     return {
-      contains: function(expectedResponse) {
-        return function(done) {
-          request(app)
-            .get(endpoint)
-            .set('Accept', 'application/json')
-            .expect(200)
-            .end(function(err, res) {
-              response = JSON.parse(res.text);
-              Object.keys(expectedResponse).map(function(key){
-                expectedResponse[key].should.equal(response[key]);
-              });
-              done();
-            });
+      is: function(responseCode) {
+        return {
+          contains: function(expectedResponse) {
+            return function(done) {
+              request(app)
+                .get(endpoint)
+                .set('Accept', 'application/json')
+                .expect(responseCode)
+                .end(function(err, res) {
+                  response = JSON.parse(res.text);
+                  Object.keys(expectedResponse).map(function(key){
+                    expectedResponse[key].should.equal(response[key]);
+                  });
+                  done();
+                });
+            }
+          }
+        }
+      }
+    }
+  },
+
+  post: function(app, endpoint) {
+    return {
+      withData: function(payload) {
+        return {
+          is: function(responseCode) {
+            return {
+              location: function(location) {
+                return function(done) {
+                  request(app)
+                    .post(endpoint)
+                    .set('Accept', 'application/json')
+                    .send(payload)
+                    .expect('Location', location)
+                    .expect(responseCode)
+                    .end(done);
+                }
+              },
+
+              contains: function(expectedResponse) {
+                return function(done) {
+                  request(app)
+                    .post(endpoint)
+                    .set('Accept', 'application/json')
+                    .send(payload)
+                    .expect(responseCode)
+                    .end(function(err, res) {
+                      response = JSON.parse(res.text);
+                      Object.keys(expectedResponse).map(function(key){
+                        expectedResponse[key].should.equal(response[key]);
+                      });
+                      done();
+                    });
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR is just a suggestion. We can discuss it and cancel it if we don't like it.

The PR changes the FT test definitions so that they match what we originally discussed, which was to leave the 'it' block as thin as possible. The drawback is that the DSL defined in the test_helpers file gets wicked, but this is likely to converge and do not change after a point.
