### PR TITLE
PP-195 add and style payments summary to card details page

### DIFF
--- a/app/assets/sass/forms/_forms.scss
+++ b/app/assets/sass/forms/_forms.scss
@@ -70,10 +70,10 @@ fieldset {
 
 // Form title
 .form-title {
-  @include bold-48;
+  @include bold-36;
   padding: $gutter-half 0 $gutter;
   @include media(tablet) {
-    padding: $gutter 0 ($gutter*2);
+    padding: $gutter 0 $gutter;
     width: $half;
   }
   @include media($min-width: 900px) {

--- a/app/assets/sass/helpers/_tables.scss
+++ b/app/assets/sass/helpers/_tables.scss
@@ -3,8 +3,10 @@ table {
   width: $full-width;
   td {
     @include core-19;
-    border-bottom: 1px solid $border-colour;
     padding: 0.75em 1.25em 0.5625em 0;
 
+    &.details {
+      font-weight: bold;
+    }
   }
 }

--- a/app/views/charge.html
+++ b/app/views/charge.html
@@ -6,14 +6,13 @@ Enter your card details.
 
 {{$content}}
 
-<main id="content" role="main">
+<main id="content" role="main" class="content-wrapper">
 
     {{#service_url}}
         <a id="back" href="{{service_url}}" class="previous-page">Back</a>
     {{/service_url}}
 
     <h1 class="form-title">Pay by card</h1>
-    <p>Total Amount: <span id="amount">£{{amount}}</span></p>
 
     <form id="cardDetails" name="cardDetails" method="POST" action="{{post_card_action}}" class="form">
         <input id="chargeId" name="chargeId" type="hidden" value="{{charge_id}}" />
@@ -75,6 +74,17 @@ Enter your card details.
             <input id="submitCardDetails" type="submit" class="button" value="Make payment" name="submitCardDetails">
         </div>
     </form>
+
+    <aside class="payment-summary">
+      <div class="inner js-stick-at-top-when-scrolling">
+        <h2>Payment summary</h2>
+        <p><strong id="service-name">Example Government Service</strong></p>
+        <p>
+          Amount to pay:
+          <span id="amount" class="amount">£{{amount}}</span></p>
+        </p>
+      </div>
+    </aside>
 
 </main>
 

--- a/app/views/confirm.html
+++ b/app/views/confirm.html
@@ -6,37 +6,37 @@ Confirm your details.
 
 {{$content}}
 
-<main id="content" role="main">
+<main id="content" role="main" class="content-wrapper">
 
     <a id="back" href="{{backUrl}}" class="previous-page">Back</a>
 
-    <h1>Check your details are correct before confirming</h1>
+    <h1 class="form-title">Check your details are correct before confirming</h1>
 
 
     <table class="confirm-details">
         <tr>
             <td>Name on card:</td>
-            <td id="cardholderName">{{cardholderName}}</td>
+            <td id="cardholderName" class="details">{{cardholderName}}</td>
         </tr>
         <tr>
             <td>Card number:</td>
-            <td id="cardNumber">{{cardNumber}}</td>
+            <td id="cardNumber" class="details">{{cardNumber}}</td>
         </tr>
         <tr>
             <td>Expiry date:</td>
-            <td id="expiryDate">{{expiryDate}}</td>
+            <td id="expiryDate" class="details">{{expiryDate}}</td>
         </tr>
         <tr>
             <td>Billing address:</td>
-            <td id="address">{{address}}</td>
+            <td id="address" class="details">{{address}}</td>
         </tr>
         <tr>
             <td>Payment of:</td>
-            <td id="serviceName">{{serviceName}}</td>
+            <td id="serviceName" class="details">{{serviceName}}</td>
         </tr>
         <tr>
             <td>Amount to pay:</td>
-            <td id="amount">£{{amount}}</td>
+            <td id="amount" class="details">£{{amount}}</td>
         </tr>
 
     </table>

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -1,3 +1,8 @@
 <!-- Javascript -->
-<script src="/public/javascripts/jquery-1.11.3.js"></script>
-<script src="/public/javascripts/application.js"></script>
+<script src="/public/javascripts/jquery-2.1.4.min.js"></script>
+<script src="/public/javascripts/stick-at-top-when-scrolling.js"></script>
+<script type="text/javascript">
+  $(function(){
+    GOVUK.stickAtTopWhenScrolling.init();
+  });
+</script>


### PR DESCRIPTION
Associated JIRA story -
https://payments-platform.atlassian.net/browse/PP-195

This commits adds and updates the payment amount summary to match the
alpha design, layout and function.

I have:
• updated the js reference in /scripts.html to point at the correct scripts and included a js init for the stick to top when scrolling function
• updated markup with appropriate classes to adopt correct styles
• added static dummy service name "Example Government Service"
• tweaked css with some minor style changes

Before -
![screen shot 2015-10-15 at 11 38 59](https://cloud.githubusercontent.com/assets/1692222/10511482/6341c870-7331-11e5-8ef5-cc9d991cfbb3.png)

After -
![screen shot 2015-10-15 at 11 38 37](https://cloud.githubusercontent.com/assets/1692222/10511490/6ed2925a-7331-11e5-9e11-0b2fa64692e1.png)
