### PR TITLE
PP-226 minor css update to improve mobile view for 1/4 form fields

### DIFF
--- a/app/assets/sass/forms/_forms.scss
+++ b/app/assets/sass/forms/_forms.scss
@@ -251,7 +251,10 @@ fieldset {
 
 .form-control-1-4 {
   @extend .form-control;
-  width: 25%;
+  width: $two-thirds;
+  @include media(tablet) {
+    width: $one-quarter;
+  }
 }
 
 .form-control-1-8 {


### PR DESCRIPTION
So that form field that have 1/4 or .form-control-1-4 class are not
too narrow on mobile I have updated the css to make them 3/4 for
mobile and 1/4 for tablet and wider screens.

JIRA story -
https://payments-platform.atlassian.net/browse/PP-226

Before -
![screen shot 2015-10-20 at 14 02 20](https://cloud.githubusercontent.com/assets/1692222/10607709/3ec0dca6-7733-11e5-9d62-351a937443e6.png)

After -
![screen shot 2015-10-20 at 14 02 03](https://cloud.githubusercontent.com/assets/1692222/10607714/481fa5ac-7733-11e5-922d-487c27fb720a.png)
