### PR TITLE
PP-101 Make the cookie name unique

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -61,7 +61,7 @@ module.exports.bindRoutesTo = function (app) {
     }
 
     function chargeState(req, chargeId) {
-        return req.session_state[createChargeIdSessionKey(chargeId)];
+        return req.frontend_state[createChargeIdSessionKey(chargeId)];
     }
 
     function validChargeIdInTheRequest(req, res, chargeId) {
@@ -77,7 +77,7 @@ module.exports.bindRoutesTo = function (app) {
     }
 
     function validChargeIdOnTheSession(req, res, chargeId) {
-        if (!req.session_state[createChargeIdSessionKey(chargeId)]) {
+        if (!req.frontend_state[createChargeIdSessionKey(chargeId)]) {
             logger.error('Unexpected: chargeId=' + chargeId + ' could not be found on the session');
             response(req.headers.accept, res, ERROR_VIEW, {
                 'message': ERROR_MESSAGE

--- a/app/controllers/secure_controller.js
+++ b/app/controllers/secure_controller.js
@@ -23,9 +23,9 @@ module.exports.bindRoutesTo = function(app) {
     var chargeId = req.params.chargeId;
     var sessionChargeIdKey = 'ch_' + chargeId;
 
-    logger.info('req.session_state[' + sessionChargeIdKey + ']=' + req.session_state[sessionChargeIdKey])
+    logger.info('req.frontend_state[' + sessionChargeIdKey + ']=' + req.frontend_state[sessionChargeIdKey])
 
-    if(!req.session_state[sessionChargeIdKey]) {
+    if(!req.frontend_state[sessionChargeIdKey]) {
       var connectorUrl = process.env.CONNECTOR_TOKEN_URL.replace('{chargeTokenId}', chargeTokenId);
 
       logger.info('trying to validate token=' + chargeTokenId);
@@ -72,7 +72,7 @@ module.exports.bindRoutesTo = function(app) {
           client.delete(connectorUrl, function(tokenDeleteData, tokenDeleteResponse) {
             logger.info('response from the connector=' + tokenDeleteResponse.statusCode);
             if(tokenDeleteResponse.statusCode === 204) {
-              req.session_state[sessionChargeIdKey] = {};
+              req.frontend_state[sessionChargeIdKey] = {};
               redirectToCardDetails(res, chargeId);
               return;
             }

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ var port = (process.env.PORT || 3000);
 var app = express();
 
 app.use(clientSessions({
-  cookieName: 'session_state',
+  cookieName: 'frontend_state',
   secret: process.env.SESSION_ENCRYPTION_KEY
 }));
 

--- a/test/charge_ft_tests.js
+++ b/test/charge_ft_tests.js
@@ -38,7 +38,7 @@ portfinder.getPort(function(err, connectorPort) {
     return request(app)
         .post(frontendCardDetailsPath)
         .set('Content-Type', 'application/x-www-form-urlencoded')
-        .set('Cookie', ['session_state=' + cookieValue])
+        .set('Cookie', ['frontend_state=' + cookieValue])
         .set('Accept', 'application/json')
         .send(data);
   }
@@ -311,7 +311,7 @@ portfinder.getPort(function(err, connectorPort) {
 
       request(app)
         .post(frontendCardDetailsPath)
-        .set('Cookie', ['session_state=' + cookieValue])
+        .set('Cookie', ['frontend_state=' + cookieValue])
         .send({
           'chargeId'  : chargeId,
           'cardNo'    : '5105 1051 0510 5100',
@@ -383,7 +383,7 @@ portfinder.getPort(function(err, connectorPort) {
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId + '/confirm')
-        .set('Cookie', ['session_state=' + cookie.create(chargeId, fullSessionData)])
+        .set('Cookie', ['frontend_state=' + cookie.create(chargeId, fullSessionData)])
         .set('Accept', 'application/json')
         .expect(200, {
           'cardNumber': "************5100",
@@ -407,7 +407,7 @@ portfinder.getPort(function(err, connectorPort) {
 
         request(app)
             .get(frontendCardDetailsPath + '/' + chargeId + '/confirm')
-            .set('Cookie', ['session_state=' + cookie.create(chargeId, sessionData)])
+            .set('Cookie', ['frontend_state=' + cookie.create(chargeId, sessionData)])
             .set('Accept', 'application/json')
             .expect(200, {
               'message': 'Session expired'
@@ -425,7 +425,7 @@ portfinder.getPort(function(err, connectorPort) {
 
       request(app)
           .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
-          .set('Cookie', ['session_state=' + cookie.create(chargeId)])
+          .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
           .set('Accept', 'application/json')
           .expect(303, {})
           .expect('Location', 'http://www.example.com/service')
@@ -438,7 +438,7 @@ portfinder.getPort(function(err, connectorPort) {
 
       request(app)
           .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
-          .set('Cookie', ['session_state=' + cookie.create(chargeId)])
+          .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
           .set('Accept', 'application/json')
           .expect(200,
             {
@@ -472,7 +472,7 @@ portfinder.getPort(function(err, connectorPort) {
 
       request(app)
           .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
-          .set('Cookie', ['session_state=' + cookie.create(chargeId)])
+          .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
           .set('Accept', 'application/json')
           .expect(200, {'message': 'There is a problem with the payments platform'}, done);
     });
@@ -484,7 +484,7 @@ portfinder.getPort(function(err, connectorPort) {
 
       request(app)
           .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
-          .set('Cookie', ['session_state=' + cookie.create(chargeId)])
+          .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
           .set('Accept', 'application/json')
           .expect(200, {'message': 'There is a problem with the payments platform'}, done);
     });
@@ -493,7 +493,7 @@ portfinder.getPort(function(err, connectorPort) {
       default_connector_response_for_get_charge(connectorPort, chargeId, aHappyState);
       request(app)
           .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
-          .set('Cookie', ['session_state=' + cookie.create(chargeId)])
+          .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
           .set('Accept', 'application/json')
           .expect(200, {'message': 'There is a problem with the payments platform'}, done);
     });

--- a/test/enforce_status_views_tests.js
+++ b/test/enforce_status_views_tests.js
@@ -72,7 +72,7 @@ portfinder.getPort(function (err, connectorPort) {
                 default_connector_response_for_get_charge(connectorPort, chargeId, status);
                 request(app)
                     .get(frontendCardDetailsPath + '/' + chargeId + '/confirm')
-                    .set('Cookie', ['session_state=' + cookie.create(chargeId, fullSessionData)])
+                    .set('Cookie', ['frontend_state=' + cookie.create(chargeId, fullSessionData)])
                     .set('Accept', 'application/json')
                     .expect(404, {
                         'message': 'Page cannot be found'

--- a/test/replay_attack_protection_ft_tests.js
+++ b/test/replay_attack_protection_ft_tests.js
@@ -58,7 +58,7 @@ describe('dummy feature - trigger', function() {
         request(app)
           .get(frontendChargePath + '/' + chargeId + '?chargeTokenId=' + chargeTokenId)
           .set('Accept', 'application/json')
-          .set('Cookie', ['session_state=' + cookieValue])
+          .set('Cookie', ['frontend_state=' + cookieValue])
           .expect('Location', frontendCardDetailsPath + '/' + chargeId)
           .expect(303)
           .end(done);

--- a/test/utils/session.js
+++ b/test/utils/session.js
@@ -1,7 +1,7 @@
 var clientSessions = require("client-sessions");
 
 var sessionConfig = {
-    'cookieName': 'session_state',
+    'cookieName': 'frontend_state',
     'secret':     process.env.SESSION_ENCRYPTION_KEY
 };
 

--- a/test/utils/test_helpers.js
+++ b/test/utils/test_helpers.js
@@ -52,7 +52,7 @@ module.exports = {
     get_charge_request: function (app, cookieValue, chargeId) {
         return request(app)
             .get(frontendCardDetailsPath + '/' + chargeId)
-            .set('Cookie', ['session_state=' + cookieValue])
+            .set('Cookie', ['frontend_state=' + cookieValue])
             .set('Accept', 'application/json');
     },
 


### PR DESCRIPTION
Make the cookie name unique so it doesn't interfere with other things running on the the same host (disturbs things even on other ports). This is to address the 'demoservice' hack we've been doing in our dev environments, however will also help us in production (where many things may be on the same domain name hidden behind a rewrite proxy such as nginx) as well as on dev.
