### PR TITLE
This setting tells node.js to trust X-Forwarded headers.

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,6 +19,8 @@ app.set('view engine', 'html');
 app.set('vendorViews', __dirname + '/govuk_modules/govuk_template/views/layouts');
 app.set('views', __dirname + '/app/views');
 
+app.enable('trust proxy');
+
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 


### PR DESCRIPTION
It does not do this by default.
