### PR TITLE
 remove json enpopint from all routes

### DIFF
--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -1,12 +1,7 @@
 var logger = require('winston');
 
 function response(accept, res, template, data) {
-  if (accept === "application/json") {
-    res.setHeader('Content-Type', 'application/json');
-    res.json(data);
-  } else {
     res.render(template, data);
-  }
 }
 
 module.exports = {

--- a/test/enforce_status_views_tests.js
+++ b/test/enforce_status_views_tests.js
@@ -4,6 +4,8 @@ var request = require('supertest');
 var portfinder = require('portfinder');
 var app = require(__dirname + '/../server.js').getApp;
 var should = require('chai').should();
+var helper = require(__dirname + '/utils/test_helpers.js');
+
 
 var cookie = require(__dirname + '/utils/session.js');
 
@@ -12,72 +14,74 @@ var default_connector_response_for_get_charge = require(__dirname + '/utils/test
 var connector_response_for_put_charge = require(__dirname + '/utils/test_helpers.js').connector_response_for_put_charge;
 
 portfinder.getPort(function (err, connectorPort) {
-    var chargeId = '23144323';
-    var frontendCardDetailsPath = '/card_details';
+  var chargeId = '23144323';
+  var frontendCardDetailsPath = '/card_details';
 
-    describe('The /card_details endpoint', function () {
-        var card_details_not_allowed_statuses = [
-            'AUTHORISATION SUBMITTED',
-            'AUTHORISATION SUCCESS',
-            'AUTHORISATION REJECTED',
-            'READY_FOR_CAPTURE',
-            'AUTHORISATION SUBMITTED',
-            'SYSTEM ERROR',
-            'SYSTEM CANCELLED',
-            'CAPTURED'
-        ];
+  describe('The /card_details endpoint', function () {
+    var card_details_not_allowed_statuses = [
+      'AUTHORISATION SUBMITTED',
+      'AUTHORISATION SUCCESS',
+      'AUTHORISATION REJECTED',
+      'READY_FOR_CAPTURE',
+      'AUTHORISATION SUBMITTED',
+      'SYSTEM ERROR',
+      'SYSTEM CANCELLED',
+      'CAPTURED'
+    ];
 
 
-        card_details_not_allowed_statuses.forEach(function (status) {
-            it('should error when the payment status is ' + status, function (done) {
-                var cookieValue = cookie.create(chargeId);
-                connector_response_for_put_charge(connectorPort, chargeId, 204 , {});
-                default_connector_response_for_get_charge(connectorPort, chargeId, status);
+    card_details_not_allowed_statuses.forEach(function (status) {
+      it('should error when the payment status is ' + status, function (done) {
+        var cookieValue = cookie.create(chargeId);
+        connector_response_for_put_charge(connectorPort, chargeId, 204 , {});
+        default_connector_response_for_get_charge(connectorPort, chargeId, status);
 
-                get_charge_request(app, cookieValue, chargeId)
-                    .expect(404, {
-                        'message': 'Page cannot be found'
-                    }).end(done);
-            });
-        });
+        get_charge_request(app, cookieValue, chargeId)
+          .expect(404)
+          .expect(function(res){
+            helper.expectTemplateTohave(res,"message",'Page cannot be found');
+          })
+          .end(done);
+      });
     });
+  });
 
-    describe('The /confirm endpoint', function () {
-        var confirm_not_allowed_statuses = [
-            'AUTHORISATION SUBMITTED',
-            'CREATED',
-            'AUTHORISATION REJECTED',
-            'READY_FOR_CAPTURE',
-            'AUTHORISATION SUBMITTED',
-            'SYSTEM ERROR',
-            'SYSTEM CANCELLED',
-            'CAPTURED'
-        ];
+  describe('The /confirm endpoint', function () {
+    var confirm_not_allowed_statuses = [
+      'AUTHORISATION SUBMITTED',
+      'CREATED',
+      'AUTHORISATION REJECTED',
+      'READY_FOR_CAPTURE',
+      'AUTHORISATION SUBMITTED',
+      'SYSTEM ERROR',
+      'SYSTEM CANCELLED',
+      'CAPTURED'
+    ];
 
 
-        confirm_not_allowed_statuses.forEach(function (status) {
+    confirm_not_allowed_statuses.forEach(function (status) {
 
-            var fullSessionData = {
-                'amount': 1000,
-                'paymentDescription': 'Test Description',
-                'cardNumber': "************5100",
-                'expiryDate': "11/99",
-                'cardholderName': 'T Eulenspiegel',
-                'address': 'Kneitlingen, Brunswick, Germany',
-                'serviceName': 'Pranks incorporated'
-            };
+      var fullSessionData = {
+        'amount': 1000,
+        'paymentDescription': 'Test Description',
+        'cardNumber': "************5100",
+        'expiryDate': "11/99",
+        'cardholderName': 'T Eulenspiegel',
+        'address': 'Kneitlingen, Brunswick, Germany',
+        'serviceName': 'Pranks incorporated'
+      };
 
-            it('should error when the payment status is ' + status, function (done) {
+      it('should error when the payment status is ' + status, function (done) {
 
-                default_connector_response_for_get_charge(connectorPort, chargeId, status);
-                request(app)
-                    .get(frontendCardDetailsPath + '/' + chargeId + '/confirm')
-                    .set('Cookie', ['frontend_state=' + cookie.create(chargeId, fullSessionData)])
-                    .set('Accept', 'application/json')
-                    .expect(404, {
-                        'message': 'Page cannot be found'
-                    }).end(done);
-            });
-        });
+        default_connector_response_for_get_charge(connectorPort, chargeId, status);
+        request(app)
+          .get(frontendCardDetailsPath + '/' + chargeId + '/confirm')
+          .set('Cookie', ['frontend_state=' + cookie.create(chargeId, fullSessionData)])
+          .expect(function(res){
+            helper.expectTemplateTohave(res,"message",'Page cannot be found');
+          })
+          .end(done);
+      });
     });
+  });
 });

--- a/test/utils/mock_templates.js
+++ b/test/utils/mock_templates.js
@@ -1,0 +1,8 @@
+function TemplateEngine() {
+}
+
+TemplateEngine.__express = function (templatePath, templateData, next) {
+   next("", JSON.stringify(templateData));
+};
+
+module.exports = TemplateEngine;

--- a/test/utils/test_helpers.js
+++ b/test/utils/test_helpers.js
@@ -4,6 +4,7 @@ var should = require('chai').should();
 var frontendCardDetailsPath = '/card_details';
 
 var connectorChargePath = '/v1/frontend/charges/';
+var chai_expect = require('chai').expect;
 
 var nock = require('nock');
 
@@ -82,5 +83,8 @@ module.exports = {
                 'method': 'POST'
             }]
         });
+    },
+    expectTemplateTohave: function(res,key,value){
+        return chai_expect(JSON.parse(res.text)[key]).to.deep.equal(value);
     }
 };


### PR DESCRIPTION
remove JSON endpoint from all routes
update tests as the test relied on said JSON endpoint
made a view mock that just returns JSON just for the tests
made a helper to deal with checking against these details (not ideal i dont think, probs a better way to do it somehow)

the test now will give you line numbers for broken tests which it wasn't doing very well previously, maybe something to investigate more in the future
