### PR TITLE
Pp 157 node sass upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.1-SNAPSHOT",
   "private": true,
   "license": "MIT",
+  "engines" : {
+    "node" : ">5.6.0"
+  },
   "scripts": {
     "start": "node start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",


### PR DESCRIPTION
- Upgrade node-sass to 3.4.2, 3.4.0 won't build on darwin (OS X) with Node 5.6.0.
- Be explicit about the node.js version required to run - >=5.6.0
