### PR TITLE
PP-645 preserve user data if an input contains an error

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -14,6 +14,7 @@ var hashCardNumber = require('../utils/charge_utils.js').hashOutCardNumber;
 var CHARGE_VIEW = 'charge';
 var CONFIRM_VIEW = 'confirm';
 var AUTH_WAITING_VIEW = 'auth_waiting';
+var preserveProperties = ['cardholderName','addressLine1', 'addressLine2', 'addressCity', 'addressPostcode'];
 
 module.exports = {
   new: function (req, res) {
@@ -47,7 +48,7 @@ module.exports = {
     var checkResult = validateCharge.verify(req.body);
 
     if (checkResult.hasError) {
-      _.merge(checkResult, charge);
+      _.merge(checkResult, charge, _.pick(req.body, preserveProperties));
       checkResult.post_card_action = paths.card.create.path;
       res.render(CHARGE_VIEW, checkResult);
       return;

--- a/app/views/charge.html
+++ b/app/views/charge.html
@@ -111,7 +111,12 @@ Enter your card details.
                     {{highlightErrorFields.cardholderName}}
                   </p>
               {{/highlightErrorFields.cardholderName}}
-              <input id="cardholder-name" type="text" name="cardholderName" maxlength="200" class="form-control-1-2 form-control" />
+              <input id="cardholder-name"
+                      type="text"
+                      name="cardholderName"
+                      maxlength="200"
+                      class="form-control-1-2 form-control"
+                      value="{{ cardholderName }}" />
           </label>
       </div>
       <div class="form-group{{#highlightErrorFields.cvc}} error{{/highlightErrorFields.cvc}}" data-validation="cvc">
@@ -156,9 +161,20 @@ Enter your card details.
                     {{highlightErrorFields.addressLine1}}
                 </p>
               {{/highlightErrorFields.addressLine1}}
-              <input id="address-line-1" type="text" name="addressLine1" maxlength="100" class="form-control-1-2" />
+              <input id="address-line-1"
+                     type="text"
+                     name="addressLine1"
+                     maxlength="100"
+                     class="form-control-1-2"
+                     value ="{{ addressLine1 }}" />
           </label>
-          <input id="address-line-2" type="text" name="addressLine2" maxlength="100" class="form-control-1-2" data-last-of-form-group />
+          <input id="address-line-2"
+                 type="text"
+                 name="addressLine2"
+                 maxlength="100"
+                 class="form-control-1-2"
+                 data-last-of-form-group
+                 value ="{{ addressLine2 }}" />
       </div>
       <div class="form-group{{#highlightErrorFields.addressCity}} error{{/highlightErrorFields.addressCity}}" data-validation="addressCity">
           <label id="address-city-lbl" for="address-city" class="form-label-bold">
@@ -173,7 +189,12 @@ Enter your card details.
                     {{highlightErrorFields.addressCity}}
                 </p>
               {{/highlightErrorFields.addressCity}}
-              <input id="address-city" type="text" name="addressCity" maxlength="100" class="form-control-1-4" />
+              <input id="address-city"
+                     type="text"
+                     name="addressCity"
+                     maxlength="100"
+                     class="form-control-1-4"
+                     value="{{ addressCity }}"  />
           </label>
       </div>
       <div class="form-group{{#highlightErrorFields.addressPostcode}} error{{/highlightErrorFields.addressPostcode}}" data-validation="addressPostcode">
@@ -190,7 +211,12 @@ Enter your card details.
                     {{highlightErrorFields.addressPostcode}}
                 </p>
               {{/highlightErrorFields.addressPostcode}}
-              <input id="address-postcode" type="text" name="addressPostcode" maxlength="10" class="form-control-1-8" />
+              <input id="address-postcode"
+                     type="text"
+                     name="addressPostcode"
+                     maxlength="10"
+                     class="form-control-1-8"
+                     value = "{{ addressPostcode }}" />
           </label>
       </div>
       <div>

--- a/test/charge_ft_tests.js
+++ b/test/charge_ft_tests.js
@@ -75,6 +75,12 @@ describe('chargeTests',function(){
     return card_data;
   }
 
+  function full_form_card_data(card_number) {
+    var card_data = minimum_form_card_data(card_number);
+    card_data.addressLine2 = 'bla bla';
+    return card_data;
+  }
+
   function minimum_form_card_data(card_number) {
     return {
       'returnUrl': RETURN_URL,
@@ -381,6 +387,24 @@ describe('chargeTests',function(){
 
           })
           .end(done);
+    });
+
+    it('preserve cardholder name, address lines when a card is submitted with validation errors', function (done) {
+      var cookieValue = cookie.create(chargeId, {});
+      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
+      var cardData = full_form_card_data('4242');
+      post_charge_request(cookieValue, cardData)
+        .expect(200)
+        .expect(function(res){
+          helper.templateValue(res,"cardholderName",cardData.cardholderName);
+          helper.templateValue(res,"addressLine1",cardData.addressLine1);
+          helper.templateValue(res,"addressLine2",cardData.addressLine2);
+          helper.templateValue(res,"addressCity",cardData.addressCity);
+          helper.templateValue(res,"addressPostcode",cardData.addressPostcode);
+          helper.templateValueUndefined(res,"cardNo");
+          helper.templateValueUndefined(res,"cvc");
+        })
+        .end(done);
     });
 
     it('should ignore empty/null address lines when second address line populated', function (done) {

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -48,6 +48,25 @@ describe('The charge view', function() {
      body.should.containInputWithIdAndName('address-postcode', 'addressPostcode', 'text').withAttribute('maxlength', '10').withLabel('address-postcode-lbl', 'Postcode');
      body.should.containInputWithIdAndName('charge-id', 'chargeId', 'hidden').withAttribute('value', '1234');
   });
+
+  it('should populate form data if reserved in response', function(){
+    var responseData = {
+      'id' : '1234',
+      'cardholderName' : 'J. Vardy',
+      'addressLine1' : '1 High Street',
+      'addressLine2' : 'blah blah',
+      'addressCity' : 'Leicester City',
+      'addressPostcode' : 'CT16 1FB'
+    };
+    var body = renderTemplate('charge', responseData);
+
+    body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('value', responseData.cardholderName);
+    body.should.containInputWithIdAndName('address-line-1', 'addressLine1', 'text').withAttribute('value', responseData.addressLine1);
+    body.should.containInputWithIdAndName('address-line-2', 'addressLine2', 'text').withAttribute('value', responseData.addressLine2);
+    body.should.containInputWithIdAndName('address-city', 'addressCity', 'text').withAttribute('value', responseData.addressCity);
+    body.should.containInputWithIdAndName('address-postcode', 'addressPostcode', 'text').withAttribute('value', responseData.addressPostcode);
+
+  });
 });
 
 describe('The confirm view', function () {

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -105,6 +105,11 @@ module.exports = {
     return chai_expect(_.result(body,key)).to.not.be.undefined;
   },
 
+  templateValueUndefined: function(res,key){
+    var body = JSON.parse(res.text);
+    return chai_expect(_.result(body,key)).to.be.undefined;
+  },
+
   unexpectedPromise: function(data){
     throw new Error('Promise was unexpectedly fulfilled.');
   },


### PR DESCRIPTION
**WHAT**
(As per story), This is for Javascript disabled browsers. This is done by merging (only the selected fields that required preserving) to the response data set.

**HOW**
The two lines in `charge_controller.js` does the trick. And the charge.html is updated with the values if available.   

**WHO**
Any dev.
