### PR TITLE
PP-656 Improve healthchecks so they are consistent and more useful

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -20,6 +20,12 @@ module.exports.bind = function (app) {
       response(req.headers.accept, res, 'greeting', data);
     });
 
+    app.get('/healthcheck', function (req, res) {
+      var data = {'ping': {'healthy': true}};
+      res.writeHead(200, {"Content-Type": "application/json"});
+      res.end(JSON.stringify(data));
+    });
+
   // charges
   var card = paths.card;
   var middlewareStack = [

--- a/test/healthcheck_ft_tests.js
+++ b/test/healthcheck_ft_tests.js
@@ -1,0 +1,17 @@
+var request = require('supertest');
+var app = require(__dirname + '/../server.js').getApp;
+
+describe('The /healthcheck endpoint returned json', function () {
+
+  it('should return 200 and be healthy', function (done) {
+      var expectedResponse = {'ping': {'healthy': true}};
+      request(app)
+          .get('/healthcheck')
+          .set('Accept', 'application/json')
+          .expect(200)
+          .expect(function(res) {
+            response = JSON.parse(res.text);
+            expectedResponse.ping.healthy.should.equal(response.ping.healthy);
+          }).end(done);
+  });
+});


### PR DESCRIPTION
## WHAT
- The Node.JS healthcheck endpoint '/greeting', although it is on
  the application port, returns an HTML response with a 'hello world'
  message.
- The Healthcheck should be available on the same endpoint of the
  Dropwiward apps which is '/healthcheck' and it should return an HTTP
  200 code and a JSON response body of {'healthy': true}.
- After speaking with @mcgoooo about what to test, we decided that
  if connector is unavailable, the connector healthcheck should pick it
  up.
## HOW
- In order to test locally:
1. `msl reset && msl -a up`
2. `cd ~/WORKSPACE/pay-selfservice`
3. `msl run`
4. `curl -i -H "accept: application/json" selfservice.pymnt.localdomain/healthcheck`
5. You should see the application response. Try and shutdown the selfservice_db_1 container to get a 503 response.
## WHO
- Dev or WebOps
