### PR TITLE
PP-582 Add logging middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "luhn": "2.1.x",
     "minimist": "0.0.x",
     "moment": "2.11.x",
+    "morgan": "1.7.x",
     "newrelic": "1.25.x",
     "node-rest-client": "1.8.x",
     "node-sass": "3.4.x",
@@ -73,7 +74,7 @@
     "string": "3.3.x",
     "throng": "4.0.x",
     "uk-postcode": "0.1.x",
-    "winston": "1.1.x"
+    "winston": "2.2.x"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/server.js
+++ b/server.js
@@ -1,35 +1,43 @@
-if(process.env.ENABLE_NEWRELIC == 'yes') require('newrelic');
-var express = require('express');
-var path = require('path');
-var favicon = require('serve-favicon');
-var router = require(__dirname + '/app/router.js');
-var bodyParser = require('body-parser');
-var clientSessions = require("client-sessions");
-var frontendCookie = require(__dirname + '/app/utils/cookies.js').frontendCookie;
-var logger = require('winston');
-var noCache = require(__dirname + '/app/utils/no_cache.js');
+if (process.env.ENABLE_NEWRELIC == 'yes') require('newrelic');
+var express           = require('express');
+var path              = require('path');
+var favicon           = require('serve-favicon');
+var router            = require(__dirname + '/app/router.js');
+var bodyParser        = require('body-parser');
+var clientSessions    = require("client-sessions");
+var frontendCookie    = require(__dirname + '/app/utils/cookies.js').frontendCookie;
+var logger            = require('winston');
+var loggingMiddleware = require('morgan');
+var noCache           = require(__dirname + '/app/utils/no_cache.js');
 var customCertificate = require(__dirname + '/app/utils/custom_certificate.js');
-var i18n = require('i18n');
-var port = (process.env.PORT || 3000);
-var argv = require('minimist')(process.argv.slice(2));
-var app = express();
-var session = require('./app/utils/session.js');
-var environment = require('./app/services/environment.js');
-var staticify = require("staticify")(path.join(__dirname, "public"));
-var compression = require('compression')
-var oneYear = 86400000 * 365;
-var publicCaching =  { maxAge: oneYear }
+var i18n              = require('i18n');
+var port              = (process.env.PORT || 3000);
+var argv              = require('minimist')(process.argv.slice(2));
+var app               = express();
+var session           = require('./app/utils/session.js');
+var environment       = require('./app/services/environment.js');
+var staticify         = require("staticify")(path.join(__dirname, "public"));
+var compression       = require('compression');
+var oneYear           = 86400000 * 365;
+var publicCaching     = {maxAge: oneYear};
+
 i18n.configure({
-    locales:['en'],
-    directory: __dirname + '/locales',
-    objectNotation: true,
-    defaultLocale: 'en',
-    register: global
+  locales: ['en'],
+  directory: __dirname + '/locales',
+  objectNotation: true,
+  defaultLocale: 'en',
+  register: global
 });
-app.set('settings', { getVersionedPath: staticify.getVersionedPath });
+app.set('settings', {getVersionedPath: staticify.getVersionedPath});
+logger.stream = {
+  write: function (message) {
+    logger.info(message);
+  }
+};
+app.use(/\/((?!images|public|stylesheets|javascripts).)*/, loggingMiddleware('combined', {'stream': logger.stream}));
 
 app.use(i18n.init);
-app.use(compression())
+app.use(compression());
 app.use(staticify.middleware);
 
 app.enable('trust proxy');
@@ -48,23 +56,21 @@ app.set('vendorViews', __dirname + '/govuk_modules/govuk_template/views/layouts'
 app.set('views', __dirname + '/app/views');
 
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.urlencoded({extended: true}));
+
+app.use('/javascripts', express.static(__dirname + '/public/assets/javascripts', publicCaching));
+app.use('/images', express.static(__dirname + '/public/images', publicCaching));
+app.use('/stylesheets', express.static(__dirname + '/public/assets/stylesheets', publicCaching));
+
+app.use('/public', express.static(__dirname + '/public', publicCaching));
+app.use('/public', express.static(__dirname + '/govuk_modules/govuk_template/assets', publicCaching));
+app.use('/public', express.static(__dirname + '/govuk_modules/govuk_frontend_toolkit', publicCaching));
 
 
-app.use('/javascripts', express.static(__dirname + '/public/assets/javascripts',publicCaching));
-app.use('/images', express.static(__dirname + '/public/images',publicCaching));
-app.use('/stylesheets', express.static(__dirname + '/public/assets/stylesheets',publicCaching));
-
-app.use('/public', express.static(__dirname + '/public',publicCaching));
-app.use('/public', express.static(__dirname + '/govuk_modules/govuk_template/assets',publicCaching));
-app.use('/public', express.static(__dirname + '/govuk_modules/govuk_frontend_toolkit',publicCaching));
-
-
-
-app.use(favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images','favicon.ico')));
+app.use(favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images', 'favicon.ico')));
 app.use(function (req, res, next) {
   res.locals.assetPath = '/public/';
-  if(typeof process.env.ANALYTICS_TRACKING_ID === "undefined") {
+  if (typeof process.env.ANALYTICS_TRACKING_ID === "undefined") {
     logger.warn('Google Analytics Tracking ID [ANALYTICS_TRACKING_ID] is not set');
     res.locals.analyticsTrackingId = ""; //to not break the app
   } else {
@@ -76,9 +82,9 @@ app.use(function (req, res, next) {
   next();
 });
 
-app.use(function(req,res,next){
-    noCache(res);
-    next();
+app.use(function (req, res, next) {
+  noCache(res);
+  next();
 });
 
 if (!environment.isProduction()) {


### PR DESCRIPTION
## WHAT
- The aim is to log all the incoming requests with logging level as INFO.
- Added a logging middleware and its output must be added to current the current app logging stream, so streaming these middleware logs _(morgan)_ to the current app logger _(winston)._
- Public assets are excluded from the logging middleware.
## HOW
- Run the application, each request should be logged (excluding public assets).
## WHO
- [X] Developers
- [] WebOps
