### PR TITLE
PP-696 retrieve confirmation details from charge object

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -80,12 +80,10 @@ module.exports = {
 
     var awaitingAuth = function() {
       logging.failedChargePost(409,authUrl);
-      session.store(req);
       res.redirect(303, Charge.urlFor('authWaiting', req.chargeId));
     },
 
     successfulAuth = function() {
-      session.store(req);
       res.redirect(303, Charge.urlFor('confirm', req.chargeId));
     },
 
@@ -170,7 +168,7 @@ module.exports = {
 
   confirm: function (req, res) {
     var charge = normalise.charge(req.chargeData, req.chargeId),
-      chargeSession = session.retrieve(req, charge.id),
+      serviceSession = session.retrieve(req, charge.id),
       confirmPath = paths.generateRoute('card.confirm', {chargeId: charge.id}),
       _views = views.create({
         success: {
@@ -178,10 +176,11 @@ module.exports = {
           locals: {
             charge: charge,
             confirmPath: confirmPath,
-            session: chargeSession,
+            session: serviceSession,
             post_cancel_action: paths.generateRoute("card.cancel", {chargeId: charge.id}),
           }
         }
+
       });
 
     var init = function () {

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -64,6 +64,7 @@ module.exports = function() {
     var defer = q.defer();
     var url = connectorurl('show',{chargeId: chargeId});
 
+    //todo here we call connector to get the charge
     logger.debug('Calling connector to get charge -', {
       service: 'connector',
       method: 'GET',

--- a/app/utils/session.js
+++ b/app/utils/session.js
@@ -1,6 +1,3 @@
-var hashCardNumber  = require('../utils/charge_utils.js').hashOutCardNumber;
-var normalise       = require('../services/normalise_charge.js');
-
 module.exports = function() {
   'use strict';
 
@@ -10,22 +7,11 @@ module.exports = function() {
 
   retrieve = function(req, chargeId) {
     return req.frontend_state[createChargeIdSessionKey(chargeId)];
-  },
-
-  store = function(req) {
-    var chargeSession  = retrieve(req, req.chargeId);
-    var plainCardNumber = normalise.creditCard(req.body.cardNo);
-    var expiryDate = normalise.expiryDate(req.body.expiryMonth, req.body.expiryYear);
-
-    chargeSession.cardNumber = hashCardNumber(plainCardNumber);
-    chargeSession.expiryDate = expiryDate;
-    chargeSession.cardholderName = req.body.cardholderName;
-    chargeSession.address = normalise.addressForView(req.body);
   };
+
 
   return {
     retrieve: retrieve,
-    createChargeIdSessionKey: createChargeIdSessionKey,
-    store: store
+    createChargeIdSessionKey: createChargeIdSessionKey
   };
 }();

--- a/app/views/confirm.html
+++ b/app/views/confirm.html
@@ -14,19 +14,19 @@ Confirm your details.
     <table class="confirm-details">
         <tr>
             <td>Card number:</td>
-            <td id="card-number" class="details">{{session.cardNumber}}</td>
+            <td id="card-number" class="details">{{charge.confirmationDetails.cardNumber}}</td>
         </tr>
         <tr>
             <td>Expiry date:</td>
-            <td id="expiry-date" class="details">{{session.expiryDate}}</td>
+            <td id="expiry-date" class="details">{{charge.confirmationDetails.expiryDate}}</td>
         </tr>
         <tr>
             <td>Name on card:</td>
-            <td id="cardholder-name" class="details">{{session.cardholderName}}</td>
+            <td id="cardholder-name" class="details">{{charge.confirmationDetails.cardholderName}}</td>
         </tr>
         <tr>
             <td>Billing address:</td>
-            <td id="address" class="details">{{session.address}}</td>
+            <td id="address" class="details">{{charge.confirmationDetails.billingAddress}}</td>
         </tr>
         <tr>
             <td>Payment for:</td>

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "grunt-sass": "1.0.x",
     "grunt-text-replace": "0.3.x",
     "hogan.js": "3.0.x",
+    "humps": "^1.1.0",
     "i18n": "0.8.x",
     "latest-version": "2.0.x",
     "lodash": "4.2.x",

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -73,13 +73,13 @@ describe('The confirm view', function () {
 
   it('should render cardNumber, expiryDate, amount and cardholder details fields', function () {
     var templateData = {
-      session: {
-        'cardNumber': "************5100",
-        'expiryDate': "11/99",
-        'cardholderName': 'Francisco Blaya-Gonzalvez',
-        'address': '1 street lane, avenue city, AB1 3DF'
-      },
       charge: {
+        'confirmationDetails': {
+          'cardNumber': "************5100",
+          'expiryDate': "11/99",
+          'cardholderName': 'Francisco Blaya-Gonzalvez',
+          'billingAddress': '1 street lane, avenue city, AB1 3DF'
+        },
         'amount': "10.00",
         'description': "Payment Description & <xss attack> assessment"
       }

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -34,8 +34,9 @@ function init_connector_url() {
 }
 
 
+
 function raw_successful_get_charge(status, returnUrl, chargeId) {
-  return {
+  var charge = {
     'amount': 2345,
     'description': "Payment Description",
     'status': status,
@@ -54,7 +55,23 @@ function raw_successful_get_charge(status, returnUrl, chargeId) {
       'rel': 'cardCapture',
       'method': 'POST'
     }]
+  };
+  if (status == "AUTHORISATION SUCCESS") {
+    charge.confirmation_details = {
+      'cardholder_name': 'Test User',
+      'last_digits_card_number': '1234',
+      'expiry_date': '11/99',
+      'billing_address': {
+        'line1': 'line1',
+        'line2': 'line2',
+        'city': 'city',
+        'postcode': 'postcode',
+        'county': 'county',
+        'country': 'GB'
+      }
+    }
   }
+  return charge;
 }
 
 module.exports = {


### PR DESCRIPTION
## WHAT
- The frontend cookie now contains only serviceName and cardTypes, everything else
     comes directly from connector, in the charge object
- Introduced a new library to convert snake_case to camelCase for json keys
  
  with @PauloPortugal
  ## HOW
  
  _Steps to test or reproduce:_
