### PR TITLE
PP-839 Explicitily camelCase `cardTypes`

### DIFF
--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -5,6 +5,7 @@ var q       = require('q');
 var logger  = require('winston');
 var paths   = require('../paths.js');
 var State   = require('./state.js');
+var humps   = require("humps");
 
 module.exports = function() {
   'use strict';
@@ -183,6 +184,12 @@ module.exports = function() {
         });
         defer.reject(new Error('GET_FAILED'));
         return;
+      }
+
+      // TODO: the conditional statement will need to be removed once PP-839 pay-connector is merged to master
+      if (data.gatewayAccount && data.gatewayAccount.card_types) {
+        data.gatewayAccount.cardTypes = humps.camelizeKeys(data.gatewayAccount.card_types);
+        delete data.gatewayAccount.card_types;
       }
       defer.resolve(data);
     }).on('error', function(err){


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
- As part of the work carried by PP-839, the response from connector
  is always in snake_case, so we need to explicitily camelCase cardTypes
- The conditional statement will need to be removed once PP-839 pay-connector
  is merged to master
## HOW

_Steps to test or reproduce:

```
cd $WORKSPACE
msl reset && msl -a up && ./run-endtoend.sh
```

with @simad
