### PR TITLE
PP-1194 fix race condition on card id

### DIFF
--- a/app/models/card.js
+++ b/app/models/card.js
@@ -6,11 +6,10 @@ var client      = new Client();
 var q           = require('q');
 var changeCase  = require('change-case');
 var paths       = require('../paths.js');
-var allowed;
 var logger  = require('winston');
 
 
-var checkCard = function(cardNo) {
+var checkCard = function(cardNo,allowed) {
   var defer = q.defer();
   var CARDID_HOST = process.env.CARDID_HOST;
 
@@ -79,8 +78,8 @@ var allConnectorCardTypes = function(){
 };
 
 module.exports = function(allowedCards){
-  var withdrawalTypes = [];
-  allowed = _.clone(allowedCards);
+  var withdrawalTypes = [],
+  allowed             = _.clone(allowedCards);
 
   if (_.filter(allowedCards,{debit: true}).length !== 0) withdrawalTypes.push('debit');
   if (_.filter(allowedCards,{credit: true}).length !== 0) withdrawalTypes.push('credit');
@@ -88,7 +87,7 @@ module.exports = function(allowedCards){
   return {
     withdrawalTypes: withdrawalTypes,
     allowed: _.clone(allowed),
-    checkCard: checkCard,
+    checkCard: (cardNo)=> { return checkCard(cardNo, allowed); },
     allConnectorCardTypes: allConnectorCardTypes
   };
 };

--- a/app/utils/charge_validation_backend.js
+++ b/app/utils/charge_validation_backend.js
@@ -3,7 +3,6 @@
 
 var chargeValidator = require('./charge_validation.js');
 var q               = require('q');
-var Card            = require('../models/card')();
 var _               = require('lodash');
 var normalise       = require('../services/normalise_charge.js');
 
@@ -19,7 +18,7 @@ module.exports = function(translations, logger, cardModel) {
     var logger = require('winston');
     var defer = q.defer();
     var validation = validator.verify(req.body);
-    Card.checkCard(normalise.creditCard(req.body.cardNo)).then(function(cardBrand){
+    cardModel.checkCard(normalise.creditCard(req.body.cardNo)).then(function(cardBrand){
       logger.debug("Card supported - ", {'cardBrand': cardBrand});
       defer.resolve({validation: validation, cardBrand: cardBrand});
     },function(err){


### PR DESCRIPTION
the `var allowed` statement on line 9 of `card.js` declared a variable in the [scope of the module](https://nodejs.org/api/modules.html#modules_the_module_wrapper). Because nodejs [caches modules](https://nodejs.org/api/modules.html#modules_caching) when they are loaded, each module is effectively a singleton. Therefore that `allowed` variable would be shared between all invocations of the `checkCard` function, even when requests are executing in parallel.

This fix removes the use of a module scoped variable, and instead passes it in by binding it using a closure created in the module constructor (`card.js:90`).

A further fix was required to `charge_validation_backend.js` which was erroneously creating its own `Card` model instance, rather than using the one passed to it in the `cardModel` variable.
