### PR TITLE
PP-1191 Validating payment email length

### DIFF
--- a/app/utils/charge_validation_fields.js
+++ b/app/utils/charge_validation_fields.js
@@ -2,6 +2,7 @@ var luhn = require('./luhn');
 var ukPostcode = require("uk-postcode");
 var creditCardType = require('credit-card-type');
 var validateEmail = require('rfc822-validate');
+var EMAIL_MAX_LENGTH = 254;
 
 module.exports = function(Card){
   "use strict";
@@ -77,9 +78,9 @@ module.exports = function(Card){
     },
 
     email: function(email){
-      var valid = validateEmail(email);
-      if (valid) return true;
-      return "message";
+      if (email && email.length > EMAIL_MAX_LENGTH) return "invalid_length";
+      if (!validateEmail(email)) return "message";
+      return true;
     },
 
     creditCardType: creditCardType,

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "node-rest-client": "2.0.x",
     "node-sass": "3.10.x",
     "q": "1.4.x",
+    "randomstring": "^1.1.5",
     "readdir": "0.0.x",
     "rfc822-validate": "1.0.x",
     "serve-favicon": "2.3.x",

--- a/test/unit/validation_tests.js
+++ b/test/unit/validation_tests.js
@@ -1,3 +1,4 @@
+var randomString = require('randomstring');
 var validationLib = require(__dirname + '/../../app/utils/charge_validation_fields');
 var cardFactory = require(__dirname + '/../../app/models/card.js');
 var card = cardFactory();
@@ -8,6 +9,7 @@ var expect = chai.expect;
 
 describe('form validations', function () {
   it('should allow a correctly formatted email', function(){
+    expect(fieldValidators.email("bob@bob")).to.equal(true);
     expect(fieldValidators.email("bob@bobbington.cbobbjb")).to.equal(true);
     expect(fieldValidators.email("b@bobbington.cbobbjb.dwf")).to.equal(true);
     expect(fieldValidators.email("customer/department=shipping@example.com")).to.equal(true);
@@ -16,5 +18,9 @@ describe('form validations', function () {
   it('should deny an incorrectly formatted email', function(){
     expect(fieldValidators.email("@bobbington.cbobbjb.dwf")).to.equal("message");
     expect(fieldValidators.email(123)).to.equal("message");
+  });
+
+  it('should deny a correctly formated email with the incorrect length', function(){
+    expect(fieldValidators.email(randomString.generate(255)+"@bobbington.cbobbjb")).to.equal("invalid_length");
   });
 });


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
- The email length validation should be enforced on `pay-frontend` as per discussion with Ian and David Isley
## HOW

_Steps to test or reproduce:_

```
cd $WORKSPACE/pay-scripts
msl reset && msl -a up && ./run-endtoend.sh
```
