### PR TITLE
PP-1099 Add analytics information to charge controller

### DIFF
--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -1,7 +1,8 @@
 var Charge = require('../models/charge.js'),
   StateModel = require('../models/state.js'),
   views = require('../utils/views.js'),
-  CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER;
+  CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER,
+  ANALYTICS_ERROR = require('../utils/analytics.js').ANALYTICS_ERROR;
 
 var logger = require('winston');
 
@@ -24,5 +25,5 @@ module.exports.return = function (req, res) {
   if (cancelStates.indexOf(req.chargeData.status) === -1) return doRedirect();
   
   logger.warn('Return controller cancelling payment', {'chargeId': req.chargeId});
-  chargeModel.cancel(req.chargeId).then(doRedirect, ()=> _views.display(res, 'SYSTEM_ERROR'));
+  chargeModel.cancel(req.chargeId).then(doRedirect, ()=> _views.display(res, 'SYSTEM_ERROR', ANALYTICS_ERROR));
 };

--- a/app/controllers/secure_controller.js
+++ b/app/controllers/secure_controller.js
@@ -5,6 +5,7 @@ var paths = require('../paths.js'),
   session = require('../utils/session.js'),
   csrf = require('csrf'),
   CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER,
+  ANALYTICS_ERROR = require('../utils/analytics.js').ANALYTICS_ERROR,
   stateService = require('../services/state_service.js');
 
 module.exports.new = function (req, res) {
@@ -37,7 +38,7 @@ module.exports.new = function (req, res) {
     },
 
     apiFail = function () {
-      views.create().display(res, 'SYSTEM_ERROR');
+      views.create().display(res, 'SYSTEM_ERROR', ANALYTICS_ERROR);
     };
   init();
 };

--- a/app/controllers/static_controller.js
+++ b/app/controllers/static_controller.js
@@ -2,6 +2,7 @@
 "use strict";
 var views = require('../utils/views.js');
 var logger= require('winston');
+var ANALYTICS_ERROR = require('../utils/analytics.js').ANALYTICS_ERROR;
 
 module.exports = {
   privacy: function(req,res){
@@ -9,12 +10,12 @@ module.exports = {
   },
   humans: function(req,res){
     var _views = views.create();
-    _views.display(res, "HUMANS");
+    _views.display(res, "HUMANS", ANALYTICS_ERROR);
 
   },
   naxsi_error: function(req,res){
     logger.error('NAXSI ERROR:- ' + req.headers["x-naxsi_sig"]);
     var _views = views.create();
-    _views.display(res, "NAXSI_SYSTEM_ERROR");
+    _views.display(res, "NAXSI_SYSTEM_ERROR", ANALYTICS_ERROR);
   }
 };

--- a/app/models/token.js
+++ b/app/models/token.js
@@ -53,7 +53,7 @@ module.exports = function(correlationId) {
   },
 
   clientUnavailable = function(error, defer) {
-    defer.reject(new Error('CLIENT_UNAVAILABLE'),error);
+    defer.reject(new Error('CLIENT_UNAVAILABLE'), error);
   };
 
   return {

--- a/app/utils/analytics.js
+++ b/app/utils/analytics.js
@@ -1,0 +1,28 @@
+var _ = require('lodash');
+
+const ANALYTICS_ERROR = {
+  analytics: {
+    analyticsId: "Service unavailable",
+    type: "Service unavailable",
+    paymentProvider: "Service unavailable"
+  }
+};
+
+module.exports = function () {
+  'use strict';
+
+  var withAnalytics = function(charge, param) {
+    return _.merge(
+        {
+          analytics: {
+            analyticsId: charge.gatewayAccount.analyticsId,
+            type: charge.gatewayAccount.type,
+            paymentProvider: charge.gatewayAccount.paymentProvider
+          }}, param);
+  };
+  return {
+    ANALYTICS_ERROR: ANALYTICS_ERROR,
+    withAnalytics: withAnalytics
+  };
+}();
+

--- a/app/views/auth_waiting.html
+++ b/app/views/auth_waiting.html
@@ -12,7 +12,7 @@ Processing your payment
 
 {{$content}}
 
-<main id="content" ="content-wrapper">
+<main id="content" class="content-wrapper">
     <h1 class="form-title">Checking card details</h1>
     <p class="lede">Your payment details are being checked.</p>
     <div id="spinner">

--- a/app/views/includes/analytics.html
+++ b/app/views/includes/analytics.html
@@ -6,5 +6,9 @@
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', '{{analyticsTrackingId}}', 'auto');
     ga('set', 'anonymizeIp', true);
-    ga('send', 'pageview');
+    ga('send', 'pageview', {
+      'analytics_id':'{{analytics.analyticsId}}',
+      'type':'{{analytics.type}}',
+      'provider': '{{analytics.paymentProvider}}'
+    });
 </script>

--- a/test/charge_ft_tests.js
+++ b/test/charge_ft_tests.js
@@ -141,6 +141,9 @@ describe('chargeTests',function(){
           'status': status,
           'return_url': "http://www.example.com/service",
           'gateway_account': {
+            'analytics_id': 'test-1234',
+            'type': 'test',
+            'payment_provider': 'sandbox',
             'service_name': 'Pranks incorporated',
             'card_types': [{
               'type': 'CREDIT',
@@ -166,6 +169,9 @@ describe('chargeTests',function(){
             helper.templateValue(res,"amount",'23.45');
             helper.templateValue(res,"id",chargeId);
             helper.templateValue(res,"description","Payment Description");
+            helper.templateValue(res,"gatewayAccount.paymentProvider", "sandbox");
+            helper.templateValue(res,"gatewayAccount.analyticsId", "test-1234");
+            helper.templateValue(res,"gatewayAccount.type", "test");
             helper.templateValue(res,"post_card_action",frontendCardDetailsPath);
           })
           .end(done);

--- a/test/controllers/charge_controller_test.js
+++ b/test/controllers/charge_controller_test.js
@@ -74,11 +74,31 @@ describe('card details endpoint', function () {
       "externalId": "dh6kpbb4k82oiibbe4b9haujjk",
       "status": status,
       "gatewayAccount": {
-        "service_name": "Service Name"
+        "serviceName": "Service Name",
+        "analyticsId": "test-1234",
+        "type": "test",
+        "paymentProvider": "sandbox"
       }
     };
   };
 
+  var aResponseWithStatus = function (status) {
+    return {
+      "externalId": "dh6kpbb4k82oiibbe4b9haujjk",
+      "status": status,
+      "gatewayAccount": {
+        "serviceName": "Service Name",
+        "analyticsId": "test-1234",
+        "type": "test",
+        "paymentProvider": "sandbox"
+      },
+      "analytics": {
+        "analyticsId": "test-1234",
+        "type": "test",
+        "paymentProvider": "sandbox"
+      }
+    };
+  };
   before(function () {
 
     request = {
@@ -103,8 +123,9 @@ describe('card details endpoint', function () {
     // That is to differentiate from next test.
     var emptyChargeModel = {};
 
+    var expectedCharge = aResponseWithStatus('ENTERING CARD DETAILS');
     requireChargeController(emptyChargeModel, mockedNormalise).new(request, response);
-    expect(response.render.calledWith('charge', mockedNormalisedCharge)).to.be.true;
+    expect(response.render.calledWithMatch('charge', expectedCharge)).to.be.true;
   });
 
   it('should update to enter card details if charge is in CREATED', function () {
@@ -114,8 +135,9 @@ describe('card details endpoint', function () {
     var mockedNormalisedCharge = aChargeWithStatus('CREATED');
     var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge);
 
+    var expectedCharge = aResponseWithStatus('CREATED');
     requireChargeController(charge, mockedNormalise).new(request, response);
-    expect(response.render.calledWith('charge', mockedNormalisedCharge)).to.be.true;
+    expect(response.render.calledWithMatch('charge', expectedCharge)).to.be.true;
 
   });
 
@@ -127,7 +149,14 @@ describe('card details endpoint', function () {
     var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge);
 
     requireChargeController(charge, mockedNormalise).new(request, response);
-    expect(response.render.calledWith('error', {"message":"Page cannot be found","viewName":"NOT_FOUND"})).to.be.true;
+    expect(response.render.calledWith('error', {"message":"Page cannot be found",
+        "viewName":"NOT_FOUND",
+        "analytics" : {
+          "analyticsId": "Service unavailable",
+          "type": "Service unavailable",
+          "paymentProvider": "Service unavailable"
+        }
+    })).to.be.true;
 
   });
 });

--- a/test/controllers/secure_controller_test.js
+++ b/test/controllers/secure_controller_test.js
@@ -89,7 +89,10 @@ describe('secure controller', function () {
         "externalId": "dh6kpbb4k82oiibbe4b9haujjk",
         "status": "CREATED",
         "gatewayAccount": {
-          "service_name": "Service Name"
+          "service_name": "Service Name",
+          "analytics_id": "bla-1234",
+          "type": "live",
+          "payment_provider": "worldpay"
         }
       };
     });
@@ -98,7 +101,15 @@ describe('secure controller', function () {
       it('should display the generic error page', function (done) {
         requireSecureController(mockCharge.withFailure(), mockToken.withSuccess()).new(request, response);
         setTimeout(function(){
-          expect(response.render.calledWith('errors/system_error', {viewName: 'SYSTEM_ERROR'})).to.be.true;
+          expect(response.render.calledWith('errors/system_error',
+              {
+                viewName: 'SYSTEM_ERROR',
+                analytics : {
+                  "analyticsId": "Service unavailable",
+                  "type": "Service unavailable",
+                  "paymentProvider": "Service unavailable"
+                }
+              })).to.be.true;
           done()
         },0);
       });
@@ -108,7 +119,15 @@ describe('secure controller', function () {
       describe('and not destroyed successfully', function () {
         it('should display the generic error page', function () {
           requireSecureController(mockCharge.withSuccess(), mockToken.withFailure()).new(request, response);
-          expect(response.render.calledWith('errors/system_error', {viewName: 'SYSTEM_ERROR'})).to.be.true;
+          expect(response.render.calledWith('errors/system_error',
+              {
+                viewName: 'SYSTEM_ERROR',
+                analytics : {
+                  "analyticsId": "Service unavailable",
+                  "type": "Service unavailable",
+                  "paymentProvider": "Service unavailable"
+                }
+              })).to.be.true;
         });
       });
 

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -104,6 +104,9 @@ function raw_successful_get_charge(status, returnUrl, chargeId) {
       'method': 'POST'
     }],
     'gateway_account': {
+      'analytics_id': 'test-1234',
+      'type': 'test',
+      'payment_provider': 'sandbox',
       'service_name': 'Pranks incorporated',
       'card_types': [
         {
@@ -186,7 +189,7 @@ module.exports = {
   },
 
   get_charge_request: function (app, cookieValue, chargeId, query) {
-    query = (query === undefined) ? "" : query;
+    query = query || "";
     return request(app)
       .get(frontendCardDetailsPath + '/' + chargeId + query)
       .set('Cookie', ['frontend_state=' + cookieValue])

--- a/test/utils/normalise_test.js
+++ b/test/utils/normalise_test.js
@@ -17,6 +17,9 @@ var unNormalisedCharge = {
   card_brand: "Visa",
   email: "bobbybobby@bobby.bob",
   gateway_account: {
+    analytics_id: 'bla-1234',
+    type: 'live',
+    payment_provider: 'worldpay',
   service_name: 'Pranks incorporated',
       card_types: [{
     type: 'CREDIT',
@@ -38,6 +41,9 @@ var normalisedCharge = {
   cardBrand: "Visa",
   email: "bobbybobby@bobby.bob",
   gatewayAccount: {
+    analyticsId: 'bla-1234',
+    type: 'live',
+    paymentProvider: 'worldpay',
     serviceName: 'Pranks incorporated',
     cardTypes: [{
       brand: 'VISA',


### PR DESCRIPTION
## WHAT

_A brief description of the pull request:_
- While rendering any page containing charge information, we now append
  analytics information coming from connector
- If there's an error (ie. CHARGE NOT FOUND) where the charge is simply
  not there, we add "Service undefined" as analytics id, as discussed
  during the kick off

**_NOTE**_: depends on https://github.com/alphagov/pay-connector/pull/284

with @simad 
## HOW

_Steps to test or reproduce:_

```
cd $WORKSPACE/pay-scripts
msl reset && msl -a up && ./run-endtoend.sh
```
