### PR TITLE
PP-1299 Fix empty analytics data if auth is rejected

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -203,7 +203,6 @@ module.exports = {
   },
 
   capture: function (req, res) {
-    
     var charge = normalise.charge(req.chargeData, req.chargeId);
     var _views = views.create();
 
@@ -225,7 +224,6 @@ module.exports = {
   },
 
   captureWaiting: function (req, res) {
-
     var charge = normalise.charge(req.chargeData, req.chargeId);
     var _views = views.create();
 

--- a/app/middleware/state_enforcer.js
+++ b/app/middleware/state_enforcer.js
@@ -4,7 +4,7 @@ var _             = require('lodash');
 var stateService  = require('../services/state_service.js');
 var paths         = require('../paths.js');
 
-
+var ANALYTICS_ERROR = require('../utils/analytics.js').ANALYTICS_ERROR;
 module.exports = function(req,res,next){
   'use strict';
 
@@ -12,7 +12,8 @@ module.exports = function(req,res,next){
   var currentState      = req.chargeData.status,
   locals            = {
     chargeId: req.chargeId,
-    returnUrl: paths.generateRoute('card.return', {chargeId: req.chargeId})
+    returnUrl: paths.generateRoute('card.return', {chargeId: req.chargeId}),
+    analytics: ANALYTICS_ERROR.analytics
   };
 
   var init = function(){

--- a/test/analytics_ui_tests.js
+++ b/test/analytics_ui_tests.js
@@ -55,7 +55,7 @@ describe('Frontend analytics', function () {
     it('should be enabled in error with return url view', function() {
         var msg = 'error processing your payment!';
         var return_url = 'http://some.return.url';
-        var body = renderTemplate('error', {
+        var body = renderTemplate('error_with_return_url', {
             'message' : msg,
             'return_url': return_url,
             'analytics': googleAnalyticsCustomDimensions
@@ -63,4 +63,29 @@ describe('Frontend analytics', function () {
         body.should.containSelector('script').withText(googleAnalyticsScript);
         checkGACustomDimensions(body);
     });
+
+    it('should be enabled when waiting for auth', function() {
+        var body = renderTemplate('auth_waiting', {
+            'analytics': googleAnalyticsCustomDimensions
+        });
+        body.should.containSelector('script').withText(googleAnalyticsScript);
+        checkGACustomDimensions(body);
+    });
+
+    it('should be enabled when waiting for capture', function() {
+        var body = renderTemplate('capture_waiting', {
+            'analytics': googleAnalyticsCustomDimensions
+        });
+        body.should.containSelector('script').withText(googleAnalyticsScript);
+        checkGACustomDimensions(body);
+    });
+
+    it('should be enabled when user cancels a payment', function() {
+        var body = renderTemplate('user_cancelled', {
+            'analytics': googleAnalyticsCustomDimensions
+        });
+        body.should.containSelector('script').withText(googleAnalyticsScript);
+        checkGACustomDimensions(body);
+    });
+
 });

--- a/test/middleware/state_enforcer_test.js
+++ b/test/middleware/state_enforcer_test.js
@@ -60,6 +60,11 @@ describe('state enforcer', function () {
     assert(status.calledWith(200));
     assert(render.calledWith("errors/incorrect_state/auth_success",
       { chargeId: 1,
+        analytics: {
+          analyticsId: "Service unavailable",
+          type: "Service unavailable",
+          paymentProvider: "Service unavailable"
+        },
         returnUrl: '/return/1',
         viewName: 'AUTHORISATION_SUCCESS' }
     ));


### PR DESCRIPTION
## WHAT
- When we have an unknown failure from connector (and auth rejected is
  amongst them), state_enforcer does a "catch all" and renders an error
  view. We added the `ANALYTICS_ERROR` to that view.

with @PauloPortugal
