### PR TITLE
PP-1355 Add keep-alive for cardid http calls

### DIFF
--- a/app/models/card.js
+++ b/app/models/card.js
@@ -16,7 +16,10 @@ var checkCard = function(cardNo,allowed, correlationId) {
   var cardUrl = CARDID_HOST + "/v1/api/card";
   var clientArgs = {
     data: {"cardNumber": parseInt(cardNo) },
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json" },
+    requestConfig: {
+      keepAlive: true
+    }
   };
 
   client.post(cardUrl ,withCorrelationHeader(clientArgs, correlationId), function(data, response) {


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
 * Calls to carid from frontend is taking a long time, where cardid is taking
   very little time processing the request. The latency is on the http request
   and thus enabling keep-alive to improve the latencies.


