### PR TITLE
[REVIEW ONLY] PP-1282 Renaming `confirmation_details` to `card_details`

### DIFF
--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -13,12 +13,11 @@ module.exports = function() {
       description: charge.description,
       links: charge.links,
       status: charge.status,
-      cardBrand: charge.card_brand,
       email: charge.email,
       gatewayAccount: _normaliseGatewayAccountDetails(charge.gateway_account)
     };
-     if (charge.confirmation_details) {
-       chargeObj.confirmationDetails = _normaliseConfirmationDetails(charge.confirmation_details);
+     if (charge.card_details) {
+       chargeObj.cardDetails = _normaliseConfirmationDetails(charge.card_details);
      }
      return chargeObj;
   },
@@ -44,11 +43,11 @@ module.exports = function() {
     }
   },
 
-  _normaliseConfirmationDetails = function(confirmationDetails){
-    confirmationDetails.cardNumber = '************' + confirmationDetails.last_digits_card_number;
-    delete confirmationDetails.last_digits_card_number;
-    var normalisedDetails = humps.camelizeKeys(confirmationDetails);
-    normalisedDetails.billingAddress = _normaliseAddress(confirmationDetails.billing_address);
+  _normaliseConfirmationDetails = function(cardDetails){
+    cardDetails.cardNumber = '************' + cardDetails.last_digits_card_number;
+    delete cardDetails.last_digits_card_number;
+    var normalisedDetails = humps.camelizeKeys(cardDetails);
+    normalisedDetails.billingAddress = _normaliseAddress(cardDetails.billing_address);
     return normalisedDetails;
   },
 

--- a/app/views/confirm.html
+++ b/app/views/confirm.html
@@ -14,23 +14,23 @@ Confirm your details.
     <table class="confirm-details">
         <tr>
             <td>Card number:</td>
-            <td id="card-number" class="details">{{charge.confirmationDetails.cardNumber}}</td>
+            <td id="card-number" class="details">{{charge.cardDetails.cardNumber}}</td>
         </tr>
         <tr>
             <td>Card brand:</td>
-            <td id="card-brand" class="details">{{charge.cardBrand}}</td>
+            <td id="card-brand" class="details">{{charge.cardDetails.cardBrand}}</td>
         </tr>
         <tr>
             <td>Expiry date:</td>
-            <td id="expiry-date" class="details">{{charge.confirmationDetails.expiryDate}}</td>
+            <td id="expiry-date" class="details">{{charge.cardDetails.expiryDate}}</td>
         </tr>
         <tr>
             <td>Name on card:</td>
-            <td id="cardholder-name" class="details">{{charge.confirmationDetails.cardholderName}}</td>
+            <td id="cardholder-name" class="details">{{charge.cardDetails.cardholderName}}</td>
         </tr>
         <tr>
             <td>Billing address:</td>
-            <td id="address" class="details">{{charge.confirmationDetails.billingAddress}}</td>
+            <td id="address" class="details">{{charge.cardDetails.billingAddress}}</td>
         </tr>
         <tr>
             <td>Payment for:</td>

--- a/test/charge_ft_tests.js
+++ b/test/charge_ft_tests.js
@@ -688,11 +688,11 @@ describe('chargeTests',function(){
         .expect(200)
         .expect(function(res){
           helper.templateValueNotUndefined(res,"csrf");
-          helper.templateValue(res,"charge.confirmationDetails.cardNumber","************1234");
-          helper.templateValue(res,"charge.cardBrand","Visa");
-          helper.templateValue(res,"charge.confirmationDetails.expiryDate","11/99");
-          helper.templateValue(res,"charge.confirmationDetails.cardholderName","Test User");
-          helper.templateValue(res,"charge.confirmationDetails.billingAddress","line1, line2, city, postcode, United Kingdom");
+          helper.templateValue(res,"charge.cardDetails.cardNumber","************1234");
+          helper.templateValue(res,"charge.cardDetails.cardBrand","Visa");
+          helper.templateValue(res,"charge.cardDetails.expiryDate","11/99");
+          helper.templateValue(res,"charge.cardDetails.cardholderName","Test User");
+          helper.templateValue(res,"charge.cardDetails.billingAddress","line1, line2, city, postcode, United Kingdom");
           helper.templateValue(res,"charge.gatewayAccount.serviceName","Pranks incorporated");
           helper.templateValue(res,"charge.amount","23.45");
           helper.templateValue(res,"charge.description","Payment Description");

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -74,7 +74,7 @@ describe('The confirm view', function () {
   it('should render cardNumber, expiryDate, amount and cardholder details fields', function () {
     var templateData = {
       charge: {
-        'confirmationDetails': {
+        "cardDetails": {
           'cardNumber': "************5100",
           'expiryDate': "11/99",
           'cardholderName': 'Francisco Blaya-Gonzalvez',

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -87,7 +87,6 @@ function raw_successful_get_charge(status, returnUrl, chargeId) {
     'amount': 2345,
     'description': "Payment Description",
     'status': status,
-    'card_brand': 'Visa',
     'return_url': returnUrl,
     'email': "bob@bob.bob",
     'links': [{
@@ -149,7 +148,8 @@ function raw_successful_get_charge(status, returnUrl, chargeId) {
     }
   };
   if (status == "AUTHORISATION SUCCESS") {
-    charge.confirmation_details = {
+    charge.card_details = {
+      'card_brand': 'Visa',
       'cardholder_name': 'Test User',
       'last_digits_card_number': '1234',
       'expiry_date': '11/99',

--- a/test/utils/normalise_test.js
+++ b/test/utils/normalise_test.js
@@ -14,7 +14,6 @@ var unNormalisedCharge = {
     href: "http://foo"
   }],
   status: "status",
-  card_brand: "Visa",
   email: "bobbybobby@bobby.bob",
   gateway_account: {
     analytics_id: 'bla-1234',
@@ -38,7 +37,6 @@ var normalisedCharge = {
     href: "http://foo"
   }],
   status: "status",
-  cardBrand: "Visa",
   email: "bobbybobby@bobby.bob",
   gatewayAccount: {
     analyticsId: 'bla-1234',


### PR DESCRIPTION
## WHAT
This PR must wait for connector `release 79` goes production.

This PR adopts to the `card_details` connector API charge response. This is a renaming of `confirmation_details` attribute.  
 - Also Charge model will contain `cardDetails` instead of `confirmationDetails`. 
 - cardDetails will also include the `cardBrand` instead of it at Charge level.