### PR TITLE
PP-1336 POST incorrectly logged as a GET in frontend

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -128,7 +128,7 @@ module.exports = {
       var correlationId = req.headers[CORRELATION_HEADER] || '';
 
       client.post(authUrl, withCorrelationHeader(args, correlationId), function (data, json) {
-        logger.info('[%s] - %s to %s ended - total time %dms', correlationId ,'GET', authUrl, new Date() - startTime);
+        logger.info('[%s] - %s to %s ended - total time %dms', correlationId ,'POST', authUrl, new Date() - startTime);
         var response = responses[json.statusCode];
         if (!response) return unknownFailure();
         response();


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

We were logging a `POST` request to `connector.pymnt.internal/v1/frontend/charges/{transactionId}/cards` as `GET`. This is very confusing when investigating the logs.


