### PR TITLE
PP-1335 Handle malformed responses in base client

### DIFF
--- a/app/utils/base_client.js
+++ b/app/utils/base_client.js
@@ -56,7 +56,15 @@ var _request = function request(methodName, url, args, callback) {
     });
 
     res.on('end', () => {
-      data = data ? JSON.parse(data) : null;
+      try {
+        data = JSON.parse(data);
+      } catch(e) {
+        //if response exists but is not parsable, log it and carry on
+        if (data) {
+          logger.info('Response from %s in unexpected format: %s', url, data);
+        }
+        data = null;
+      }
       callback(data, res);
     });
   });


### PR DESCRIPTION
We expect to always receive JSON when talking to internal services. However if we don't, previously base client just blew up. This commit adds a try catch around JSON parsing the response from downstream service to handle non JSON responses (cases of which were observed in ZAP tests).