### PR TITLE
PP-1378 Fix to start NodeJs app in production mode when NODE_ENV=production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ WORKDIR /app
 # copy cached node_modules to /app/node_modules
 RUN mkdir -p /app && cp -a /tmp/node_modules /app/
 
-RUN npm install && npm test && npm prune --production
+RUN npm install && npm run compile && npm test && npm prune --production
 
 CMD NODE_ENV=production npm start

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -249,7 +249,7 @@ module.exports = function(grunt){
     'compress'
   ]);
 
-  grunt.registerTask('test', ['env:test','generate-assets', 'mochaTest']);
+  grunt.registerTask('test', ['env:test', 'mochaTest']);
   grunt.registerTask('lint', ['jshint']);
 
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     }
   },
   "scripts": {
-    "prestart": "grunt default",
-    "start": "forever --minUptime 1000 --spinSleepTime 500 start.js",
-    "stop": "forever stop start.js",
+    "compile": "grunt generate-assets",
+    "clean": "grunt clean",
+    "start": "node_modules/forever/bin/forever --minUptime 1000 --spinSleepTime 500 start.js",
+    "stop": "node_modules/forever/bin/forever stop start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
     "test": "grunt lint && npm run grunt-test",
     "lint": "node ./node_modules/.bin/jshint --verbose ./app/*.js ./test/*.js",


### PR DESCRIPTION
## WHAT
- NPM supports a `scripts` setting in the package.json called `prestart` where one can configure a command line action to be executed before starting the app. The `prestart` was configured to launch the app in development mode, simply not handing the control back over to NPM and therefore short cicuiting the `start` for production.  `prestart` has been removed.
- A new NPM `scripts` setting called `compile` has been introduced that currently only serves the purpose of generating the assets.
- The `Gruntfile` script has also been modified to stop generating assets before running the tests.
- Dockerfile explicitly calls the `compile` NPM script prior to running the tests.

# HOW TO TEST
- Run the application with `msl up` (from https://github.com/alphagov/pay-scripts/pull/370) and check that NodeJs is in production mode running under the supervision of `forever`.
- Run the application with `msl run` (from https://github.com/alphagov/pay-scripts/pull/370) and check that NodeJs is in production mode running under the supervision of `forever`.
- Run the tests locally with `npm run compile && npm test`