### PR TITLE
PP-1386 [M&M] Introducing appmetrics+statsd for metrics

### DIFF
--- a/app/utils/metrics.js
+++ b/app/utils/metrics.js
@@ -1,0 +1,20 @@
+/*jslint node: true */
+"use strict";
+var appmetrics = require('appmetrics');
+var metricsHost = process.env.METRICS_HOST || "localhost";
+var metricsPort = process.env.METRICS_PORT || 8125;
+var metricsPrefix = "frontend.";
+
+function initialiseMonitoring () {
+  appmetrics.configure({'mqtt':'off'});
+  var appmetricsStatsd = require('appmetrics-statsd');
+
+  return appmetricsStatsd.StatsD(null, metricsHost, metricsPort, metricsPrefix);
+}
+
+module.exports = function() {
+
+  return {
+    metrics: initialiseMonitoring()
+  };
+}();

--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
     "string": "3.3.x",
     "throng": "4.0.x",
     "uk-postcode": "0.1.x",
-    "winston": "2.2.x"
+    "winston": "2.2.x",
+    "appmetrics": "1.1.2",
+    "appmetrics-statsd": "1.0.1"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ var staticify         = require("staticify")(path.join(__dirname, "public"));
 var compression       = require('compression');
 var oneYear           = 86400000 * 365;
 var publicCaching     = {maxAge: oneYear};
+var applicationMetrics= require('./app/utils/metrics.js').metrics;
 
 i18n.configure({
   locales: ['en'],


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_
* See https://github.com/alphagov/pay-selfservice/pull/246
  for the same PR for self-service
* appmetrics-statsd library allows us to capture nodejs
  runtime metrics as well as custom metrics. Runtime
  metrics are through appmetrics while custom metrics
  can be captured using statsd. The library combines both.
* The current version of appmetrics-statsd doesn't allow for
  turning off mqtt. This has been raised with the maintainers
  and they are in the midst of rolling out a new release with a fix.
  Until then we can still use it - RuntimeTools/appmetrics#341.
  The library tries to connect to mqtt, but there wont be any mqtt
  actions performed as there there's no mqtt running.
* This change only initialises the appmetrics-statsd library and
  sends nodejs runtime metrics to a statsd endpoint.
* The statsd endpoint is expected to be available through the METRICS_HOST
  variable, if not 'localhost' is used.
* The prefix provided in metrics.js serves as the root node name for the
  application in graphite metrics.

with @imranbohoran
## HOW 
_Steps to test or reproduce:_



