### PR TITLE
PP-1562 Add and install `Pay Product Page` NodeJs dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,14 @@ module.exports = function(grunt){
           src: '**',
           dest: 'govuk_modules/govuk_template/'
         }]
+    },
+    payProductPage: {
+      files: [{
+        expand: true,
+        cwd: 'node_modules/pay-product-page',
+        src: ['**', '!package.json'],
+        dest: 'public',
+      }]
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "uk-postcode": "0.1.x",
     "winston": "2.2.x",
     "appmetrics": "1.1.2",
-    "appmetrics-statsd": "1.0.1"
+    "appmetrics-statsd": "1.0.1",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/1.0.0/pay-product-page.tgz"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

`Pay Product Page` has been bundled up as a NodeJs package for convenience and released on GitHub under https://github.com/alphagov/pay-product-page/releases.
The targeted release of Pay Product Pages (version 1.0.0) is pulled as a dependency then copied to the relevant location by Grunt during the compile phase (`npm run compile`).


