### PR TITLE
PP-1562 Upgrade product page to version 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "winston": "2.2.x",
     "appmetrics": "1.1.2",
     "appmetrics-statsd": "1.0.1",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/1.0.0/pay-product-page.tgz"
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/1.0.1/pay-product-page-1.0.1.tgz"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

A new release version 1.0.1 (https://github.com/alphagov/pay-product-page/releases/tag/1.0.1) of pay-product-page (https://github.com/alphagov/pay-product-page/pull/3) has been prepared to fix a slight overside in the breadcrumb showing `Pay` instead of `GOV.UK Pay`. This PR is just to pull the new version.


