### PR TITLE
Bump to Node 6.9.5 and Alpine, not Debian, baselayer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:6.9.5-alpine
 RUN apk update
 RUN apk upgrade
 
-RUN apk add python make
+RUN apk add python make g++
 
 ENV PORT 9000
 ENV ENABLE_NEWRELIC no


### PR DESCRIPTION
## WHAT

Opening to trigger a build - experiment - I've got absolutely no idea what'll break with the 6.7 -> 6.9 update.

## HOW 

Let's see.


