### PR TITLE
Move startup command to shell script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN mkdir -p /app && cp -a /tmp/node_modules /app/
 
 RUN npm install && npm run compile && npm test && npm prune --production
 
-CMD NODE_ENV=production npm start
+CMD bash ./docker-startup.sh

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+NODE_ENV=production npm start


### PR DESCRIPTION
As part of https://github.com/alphagov/pay-infra/pull/699 we have
changed the way that we build docker containers which are deployed to
production. In particular we will be using `docker commit` to snapshot
an image from a container.

It turns out that when using `docker commit` it will use the last
command passed to `docker run` as the `Config/Cmd` setting (from docker
inspect output). This is normally provided by the `CMD` directive from
the `Dockerfile`[1], it can be over-ridden when running the container but
it seems like we don't do that. So, it's important that the `Config/Cmd`
setting is correct.

So, I'm standardising the startup command to invoke `docker-startup.sh`
so it's consistent with selfservice.

[1] http://goinbigdata.com/docker-run-vs-cmd-vs-entrypoint/

## How to test 

The change will only be evident when the container is deployed into an AWS environment. We want to see that the container starts up successfully.

Suggested test method: deploy the container built by the branch build into the [test environment](https://build.ci.pymnt.uk/job/deploy-frontend/96/) and check that smoke tests pass. 