### PR TITLE
PP-1735 Change copy on the 3DS page

### DIFF
--- a/app/views/auth_3ds_required.html
+++ b/app/views/auth_3ds_required.html
@@ -13,7 +13,7 @@ Payment in progress
 
 <main id="content" class="content-wrapper threeds-required">
     <h1 class="form-title">Payment in progress</h1>
-    <p class="lede">Follow the steps below.</p>
+    <p class="lede">You may need to complete some extra verification steps.</p>
     <iframe class="iframe-3ds" src="3ds_required_out">
     </iframe>
 </main>


### PR DESCRIPTION
## WHAT
- `Follow the steps below` was not appropriate in case 3ds was triggered but not necessary, because the user got redirected to authorisation without any further action. For this reason, we are rewording the text which is going to be displayed above the 3DS iframe.

## HOW 
_Steps to test or reproduce:_


