### PR TITLE
PP-1753 Add tests for the return controller

### DIFF
--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -2,30 +2,32 @@ var Charge = require('../models/charge.js'),
   StateModel = require('../models/state.js'),
   views = require('../utils/views.js'),
   CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER,
-    withAnalyticsError = require('../utils/analytics.js').withAnalyticsError;
+  withAnalyticsError = require('../utils/analytics.js').withAnalyticsError;
 
 var logger = require('winston');
+
+let CANCELABLE_STATES = [
+  StateModel.CREATED,
+  StateModel.ENTERING_CARD_DETAILS,
+  StateModel.AUTH_SUCCESS,
+  StateModel.AUTH_READY,
+  StateModel.CAPTURE_READY,
+  StateModel.AUTH_3DS_REQUIRED,
+  StateModel.AUTH_3DS_READY
+];
 
 module.exports.return = function (req, res) {
   'use strict';
 
-  var correlationId = req.headers[CORRELATION_HEADER] || '',
+  let correlationId = req.headers[CORRELATION_HEADER] || '',
    _views = views.create({}),
   doRedirect = () => res.redirect(req.chargeData.return_url),
-  chargeModel = Charge(correlationId),
-  
-  cancelStates = [
-    StateModel.CREATED, 
-    StateModel.ENTERING_CARD_DETAILS,
-    StateModel.AUTH_SUCCESS,
-    StateModel.AUTH_READY,
-    StateModel.CAPTURE_READY,
-    StateModel.AUTH_3DS_REQUIRED,
-    StateModel.AUTH_3DS_READY
-  ];
+  chargeModel = Charge(correlationId);
 
-  if (cancelStates.indexOf(req.chargeData.status) === -1) return doRedirect();
-  
-  logger.warn('Return controller cancelling payment', {'chargeId': req.chargeId});
-  chargeModel.cancel(req.chargeId).then(doRedirect, ()=> _views.display(res, 'SYSTEM_ERROR', withAnalyticsError()));
+  if (CANCELABLE_STATES.includes(req.chargeData.status)) {
+    chargeModel.cancel(req.chargeId).then(
+      () => logger.warn('Return controller cancelled payment', {'chargeId': req.chargeId}),
+      () => _views.display(res, 'SYSTEM_ERROR', withAnalyticsError()));
+  }
+    doRedirect();
 };

--- a/test/controllers/return_controller_test.js
+++ b/test/controllers/return_controller_test.js
@@ -1,0 +1,86 @@
+/*jslint node: true */
+
+require(__dirname + '/../test_helpers/html_assertions.js');
+var proxyquire = require('proxyquire')
+var should = require('chai').should();
+var assert = require('assert');
+var q = require('q');
+var sinon = require('sinon');
+var paths = require('../../app/paths.js');
+
+
+let requireReturnController = function (mockedCharge) {
+  return proxyquire(__dirname + '/../../app/controllers/return_controller.js', {
+    '../models/charge.js': mockedCharge,
+    'csrf': function () {
+      return {
+        secretSync: function () {
+          return 'foo';
+        }
+      }
+    }
+  })
+};
+
+describe('return controller', function () {
+  let mockCharge = {
+      cancelSucceeds: () => (cancelSucceeds) => {
+        return {
+          cancel: () => {
+            let defer = q.defer();
+            cancelSucceeds ? defer.resolve() : defer.reject();
+            return defer.promise;
+          }
+        };
+      }
+    };
+
+  let request, response;
+
+  beforeEach(function () {
+    request = {
+      chargeId: 'aChargeId',
+      headers:{'x-Request-id': 'unique-id'}
+    };
+
+    response = {
+      redirect: sinon.spy(),
+      render: sinon.spy(),
+      status: sinon.spy()
+    };
+  });
+
+  it('should redirect to the original service for terminal (non-cancelable) states', function () {
+    request.chargeData = {
+      status: "CAPTURED",
+      return_url: 'http://a_return_url.com'
+    };
+
+    requireReturnController(mockCharge.cancelSucceeds(true)).return(request, response);
+    assert(response.redirect.calledWith('http://a_return_url.com'));
+  });
+
+  it('should redirect to the original service for cancelable states', function () {
+    request.chargeData = {
+      status: "CREATED",
+      return_url: 'http://a_return_url.com'
+    };
+    requireReturnController(mockCharge.cancelSucceeds(true)).return(request, response);
+    setTimeout(function(){
+      assert(response.redirect.calledWith('http://a_return_url.com'));
+      done();
+    },0);
+  });
+
+  it('should show an error if cancel fails', function () {
+    request.chargeData = {
+      status: "CREATED",
+      return_url: 'http://a_return_url.com'
+    };
+    requireReturnController(mockCharge.cancelSucceeds(false)).return(request, response);
+    setTimeout(function(){
+      assert(response.render.calledWith("errors/system_error", { viewName: 'SYSTEM_ERROR' }));
+      done();
+    },0);
+  });
+});


### PR DESCRIPTION
- Having a duplicate of the connector's logic (ie. the`CANCELABLE_STATES` structure) in frontend is not ideal, as any change in connector can potentially put the controller out of sync, returning spurious results.
- A major refactor is out of the scope of this fix, but we should keep it in mind nevertheless

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


