### PR TITLE
PP-1751 Updated product page to add support page

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "winston": "2.2.x",
     "appmetrics": "1.1.2",
     "appmetrics-statsd": "1.0.1",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/1.0.1/pay-product-page-1.0.1.tgz"
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/1.1.0/pay-product-page-1.1.0.tgz"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

Updated `pay-product-page` to the latest version which includes the following changes:

Added a call to action on the product page and a support page that this call to action links to.
This support page sits within the product page domain and has information about how to get
in touch with Pay. The support link in the header also goes to this page.

https://github.com/alphagov/pay-product-page/pull/5



