### PR TITLE
PP-1751 Update pay-product-page to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "winston": "2.2.x",
     "appmetrics": "1.1.2",
     "appmetrics-statsd": "1.0.1",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/1.1.0/pay-product-page-1.1.0.tgz"
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/1.1.1/pay-product-page-1.1.1.tgz"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
## WHAT
The latest version includes the following changes:

- Fix indentation of the support page's body
- Fix image not showing up in the call of action
- Fix link to 'contact the team' leading to the support page


