### PR TITLE
PP-1649 Upgraded NodeJs to 6.10.0-alpine LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM node:6.7.0
+FROM node:6.10.0-alpine
 
-ADD docker/upgrade-base.sh /upgrade-base.sh
+RUN apk update && apk upgrade
+
+# Install packages needed for production
+RUN apk add --update bash python make g++ libc6-compat
 
 ENV PORT 9000
 ENV ENABLE_NEWRELIC no


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- The following packages had to be added the the base image to allow the NodeJs application to compile and run selfservice on `alpine`:
   - `bash`
   - `python`
   - `make`
   - `g++`


