### PR TITLE
PP-1776 Compatibility fix to show relevant view on CAPTURE_APPROVED

### DIFF
--- a/app/utils/views.js
+++ b/app/utils/views.js
@@ -149,6 +149,11 @@ module.exports = function() {
         analyticsPage: "/problem"
       },
 
+      CAPTURE_APPROVED: {
+        view: "errors/incorrect_state/capture_failure",
+        analyticsPage: "/problem"
+      },
+
       AUTHORISATION_3DS_REQUIRED: {
         view: "errors/incorrect_state/auth_3ds_required",
         analyticsPage: "/3ds_required"


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

Added a new view that maps the newly introduced state CAPTURE_APPROVED which provisionally represents an error. This compatibility fix allows to show a relevant view expressing the payment was unsuccessful as opposed as a generic system error view.

View shows before the fix:
<img width="1277" alt="screen shot 2017-03-22 at 10 47 39" src="https://cloud.githubusercontent.com/assets/138029/24195235/dd427d98-0ef0-11e7-8769-0be5f4b20e8e.png">
View shown after the fix:
<img width="1280" alt="screen shot 2017-03-22 at 10 51 59" src="https://cloud.githubusercontent.com/assets/138029/24195237/df87183e-0ef0-11e7-8b36-daf98bd59cd6.png">

