### PR TITLE
PP-1776 Compatibility fix to show relevant view on CAPTURE_APPROVED

### DIFF
--- a/app/utils/views.js
+++ b/app/utils/views.js
@@ -139,9 +139,16 @@ module.exports = function() {
         analyticsPage: "/success_return"
       },
 
-      CAPTURE_FAILURE: {
-        view: "errors/incorrect_state/capture_failure",
-        analyticsPage: "/capture_failure"
+      CAPTURE_APPROVED: {
+        view: "errors/charge_confirm_state_completed",
+        locals: {status: 'successful'},
+        analyticsPage: "/success_return"
+      },
+
+      CAPTURE_APPROVED_RETRY: {
+        view: "errors/charge_confirm_state_completed",
+        locals: {status: 'successful'},
+        analyticsPage: "/success_return"
       },
 
       CAPTURE_ERROR: {
@@ -149,7 +156,7 @@ module.exports = function() {
         analyticsPage: "/capture_failure"
       },
 
-      CAPTURE_APPROVED: {
+      CAPTURE_FAILURE: {
         view: "errors/incorrect_state/capture_failure",
         analyticsPage: "/capture_failure"
       },


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

As part of PP-1776, Connector will mark a charge as `CAPTURE_APPROVED` to record the capture intend so that it can be picked up subsequently by a scheduled job. On the rare occasion where the actual capture failed, Connector marks the charge as `CAPTURE_APPROVED_RETRY` for later retrieval. From a frontend point of view both statuses `CAPTURE_APPROVED` and `CAPTURE_APPROVED_RETRY` should be treated as a successful capture from now on.

With this when the charge is `CAPTURE_APPROVED` or `CAPTURE_APPROVED_RETRY` or `CAPTURED` the successful screen is shown.
<img width="1280" alt="screen shot 2017-04-05 at 10 22 21" src="https://cloud.githubusercontent.com/assets/138029/24700257/7dee0138-19ee-11e7-9130-a0310eaf008a.png">



