### PR TITLE
Remove test dependencies from docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ RUN mkdir -p /app && cp -a /tmp/node_modules /app/
 
 RUN npm install && npm run compile && npm test && npm prune --production
 
+RUN apk del python make g++
+
 CMD bash ./docker-startup.sh


### PR DESCRIPTION
We don't need no python make or g++ in our prod containers, so uninstalling after tests etc.


