### PR TITLE
PP-1892 only return user once cancel complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
+    "chai-as-promised": "^6.0.0",
     "chai-string": "^1.1.2",
     "cheerio": "^0.22.0",
     "chokidar-cli": "latest",


### PR DESCRIPTION
We have had reports of a few users who have been returned to referring service with payment in non-terminal state. One reason for this looks likely to be that the return controller in some circumstances cancels payments before handing the user on to the service. However, we were not waiting for that cancel to go through leaving possibility that cancellation would not have completed (either slowness or failure) when referring service queries state of payment.

This PR fixes that by deferring redirect until after cancel call completes. If cancel fails the user is shown an error page and is not returned to service.

I have modified the tests to better test this flow.

