### PR TITLE
PP-1867: Add a jenkinsfile to make everything better

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,48 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent any
+
+  options {
+    ansiColor('xterm')
+    timestamps()
+  }
+
+  libraries {
+    lib("pay-jenkins-library@master")
+  }
+
+  stages {
+    stage('Docker Build') {
+      steps {
+        script {
+          buildApp{
+            app = "frontend"
+          }
+        }
+      }
+    }
+    stage('Test') {
+      steps {
+        runEndToEnd("frontend")
+      }
+    }
+    stage('Docker Tag') {
+      steps {
+        script {
+          dockerTag {
+            app = "frontend"
+          }
+        }
+      }
+    }
+    stage('Deploy') {
+      when {
+        branch 'master'
+      }
+      steps {
+        deploy("frontend", "test", null, true)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a Jenkinsfile for `pay-frontend`.

Apart from the referenced project name, this is identical to the Jenkinsfile for `pay-selfservice`.

Immediately before merging, the following Jenkins jobs need to be disabled and deleted:
- `trigger-pay-frontend-master`
- `trigger-pay-frontend-pull-request`
- `build-pay-frontend`
- `deploy-frontend`

In addition, `pay-chef` needs to be modified to ensure the above jobs are not recreated.

Once this merged, existing branches will need a Jenkinsfile to get the full CI experience (new branches will inherit the one from `master`, of course).