### PR TITLE
PP-2000 Use latest 1.2.0 release of the product page

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "winston": "2.2.x",
     "appmetrics": "1.1.2",
     "appmetrics-statsd": "1.0.1",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/1.1.1/pay-product-page-1.1.1.tgz"
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/1.2.0/pay-product-page-1.2.0.tgz"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
Release 1.2.0 of the product page changes the ‘Who’s using GOV.UK Pay’ section’s first sentence from:

“Central government organisations currently using GOV.UK Pay are:”

… to:

“GOV.UK Pay is working with:”