### PR TITLE
PP-2144 upgrade staticify@0.0.6 to resolve vulnerability in ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "readdir": "0.0.x",
     "rfc822-validate": "1.0.x",
     "serve-favicon": "2.4.3",
-    "staticify": "0.0.x",
+    "staticify": "0.0.7",
     "string": "3.3.x",
     "throng": "4.0.x",
     "uk-postcode": "0.1.x",


### PR DESCRIPTION
## WHAT
See https://github.com/errorception/staticify/pull/2.
They have accepted the fix into the upstream so this is me pulling down their new version 0.0.7 to fix the alert reported by Snyk against frontend.

## HOW 
Version upgrade

