### PR TITLE
PP-2275 Fix undefined error

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -11,8 +11,9 @@
         "cardholderName": {
           "name": "name",
           "message": "Enter the name as it appears on the card",
-          "contains_too_many_digits": "Enter the name as it appears on the card"
-        },
+          "contains_too_many_digits": "Enter the name as it appears on the card",
+		  "contains_suspected_cvv": "Enter the name as it appears on the card"
+		},
         "cardNo": {
           "name": "card number",
           "message": "Enter a valid card number",

--- a/test/integration/charge_validation_ft_tests.js
+++ b/test/integration/charge_validation_ft_tests.js
@@ -78,7 +78,7 @@ describe('checks for PAN-like numbers', () => {
       });
   });
 
-  it('shows an error when a card is submitted with a card holder name containing a suspected CVV', function (done) {
+  it.only('shows an error when a card is submitted with a card holder name containing a suspected CVV', function (done) {
     const chargeId = '23144323';
     const formWithAllFieldsContainingTooManyDigits = {
       'returnUrl': RETURN_URL,
@@ -109,7 +109,8 @@ describe('checks for PAN-like numbers', () => {
         var body = JSON.parse(res.text);
 
         expect(body.highlightErrorFields.cardholderName).to.equal('Enter the name as it appears on the card');
-
+        expect(body.errorFields.length).to.equal(1);
+        expect(body.errorFields[0].value).to.equal('Enter the name as it appears on the card');
         done();
       });
   });


### PR DESCRIPTION
The work to prevent accidental assertion of cvv into cardholder name field in previous PR contained a bug. On submitting a cvv in cardholder name field one would get an undefined error message:


<img width="688" alt="screen shot 2017-07-03 at 10 32 39" src="https://user-images.githubusercontent.com/1420504/27787057-77ef042a-5fdb-11e7-8ee6-6507034b2c2b.png">

This is because error needs a corresponding key in `locales/en.json`.
This commit adds that for `contains_suspected_cvv`, and a test.