### PR TITLE
PP-2222 Used standardjs linting auto fix, and manually edited linting…

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,9 @@
-var path = require('path');
-module.exports = function(grunt){
+var path = require('path')
+module.exports = function (grunt) {
   var sass = {
     dev: {
       options: {
-        style: "expanded",
+        style: 'expanded',
         sourcemap: true,
         includePaths: [
           'govuk_modules/govuk_template/assets/stylesheets',
@@ -13,20 +13,20 @@ module.exports = function(grunt){
       },
       files: [{
         expand: true,
-        cwd: "app/assets/sass",
-        src: ["*.scss"],
-        dest: "public/stylesheets/",
-        ext: ".css"
+        cwd: 'app/assets/sass',
+        src: ['*.scss'],
+        dest: 'public/stylesheets/',
+        ext: '.css'
       }]
     }
-  };
+  }
 
   var copy = {
     assets: {
       files: [{
         expand: true,
         cwd: 'app/assets/images/',
-        src: ['**','**/*'],
+        src: ['**', '**/*'],
         dest: 'public/images/'
       }]
     },
@@ -37,22 +37,22 @@ module.exports = function(grunt){
         src: '**',
         dest: 'govuk_modules/govuk_frontend_toolkit/'
       },
-        {
-          expand: true,
-          cwd: 'node_modules/govuk_template_mustache/',
-          src: '**',
-          dest: 'govuk_modules/govuk_template/'
-        }]
+      {
+        expand: true,
+        cwd: 'node_modules/govuk_template_mustache/',
+        src: '**',
+        dest: 'govuk_modules/govuk_template/'
+      }]
     },
     payProductPage: {
       files: [{
         expand: true,
         cwd: 'node_modules/pay-product-page',
         src: ['**', '!package.json'],
-        dest: 'public',
+        dest: 'public'
       }]
     }
-  };
+  }
 
   var replace = {
     fixSass: {
@@ -63,24 +63,24 @@ module.exports = function(grunt){
         to: 'filter:unquote("chroma$1");'
       }]
     }
-  };
+  }
 
   var watch = {
-    assets:{
+    assets: {
       files: ['app/assets/**/*'],
       tasks: ['generate-assets'],
       options: {
-        spawn: false,
+        spawn: false
       }
     },
-    forBrowsifier:{
-      files: ['app/*','app/**/*'],
+    forBrowsifier: {
+      files: ['app/*', 'app/**/*'],
       tasks: ['generate-assets'],
       options: {
         spawn: false
       }
     }
-  };
+  }
 
   var nodeMon = {
     dev: {
@@ -88,19 +88,19 @@ module.exports = function(grunt){
       options: {
         ext: 'js',
         ignore: ['node_modules/**', 'app/assets/**', 'public/**'],
-        args: ["-i=true"]
+        args: ['-i=true']
       }
     }
-  };
+  }
 
   var concurrent = {
     target: {
-    tasks: ['watch', 'nodemon'],
+      tasks: ['watch', 'nodemon'],
       options: {
         logConcurrentOutput: true
       }
     }
-  };
+  }
 
   var mochaTest = {
     test: {
@@ -119,60 +119,42 @@ module.exports = function(grunt){
         'test/integration/*.js'
       ]
     }
-  };
-
-  var jshint = {
-    main: {
-      files: {
-        src: [
-          'app/**/*.js',
-          '!app/assets/**/*.js',
-          '!app/utils/custom_certificate.js'
-
-        ]
-      } ,
-      options: {
-        jshintrc: './.jshintrc'
-      }
-    }
-  };
-
+  }
 
   var env = {
     test: {
-    src: "config/test-env.json"
+      src: 'config/test-env.json'
     }
-  };
+  }
 
   var browserify = {
-    "public/javascripts/browsered.js": ['app/browsered.js'],
+    'public/javascripts/browsered.js': ['app/browsered.js'],
     options: {
-      browserifyOptions: { standalone: "module" }
+      browserifyOptions: { standalone: 'module' }
     }
-  };
+  }
 
-
-  var concat =  {
+  var concat = {
     options: {
-      separator: ';',
+      separator: ';'
     },
     dist: {
-      src: ['public/javascripts/browsered.js','app/assets/javascripts/base/*.js',
-      'app/assets/javascripts/modules/*.js'],
-      dest: 'public/javascripts/application.js',
-    },
-  };
+      src: ['public/javascripts/browsered.js', 'app/assets/javascripts/base/*.js',
+        'app/assets/javascripts/modules/*.js'],
+      dest: 'public/javascripts/application.js'
+    }
+  }
 
   var rewrite = {
-    "application.css": {
+    'application.css': {
       src: 'public/stylesheets/application.css',
-      editor: function(contents, filePath) {
-        var staticify = require("staticify")(path.join(__dirname, "public"));
+      editor: function (contents) {
+        var staticify = require('staticify')(path.join(__dirname, 'public'))
 
         return staticify.replacePaths(contents)
       }
     }
-  };
+  }
 
   var compress = {
     main: {
@@ -187,8 +169,7 @@ module.exports = function(grunt){
         {expand: true, src: ['public/stylesheets/*.css'], ext: '.css.gz'}
       ]
     }
-  };
-
+  }
 
   grunt.initConfig({
     // Clean
@@ -208,18 +189,15 @@ module.exports = function(grunt){
     env: env,
     browserify: browserify,
     concat: concat,
-    jshint: jshint,
     rewrite: rewrite,
     compress: compress
   });
-
 
   [
     'grunt-contrib-copy',
     'grunt-contrib-compress',
     'grunt-contrib-watch',
     'grunt-contrib-clean',
-    'grunt-contrib-jshint',
     'grunt-sass',
     'grunt-nodemon',
     'grunt-text-replace',
@@ -231,20 +209,19 @@ module.exports = function(grunt){
     'grunt-rewrite'
 
   ].forEach(function (task) {
-    grunt.loadNpmTasks(task);
-  });
-
+    grunt.loadNpmTasks(task)
+  })
 
   grunt.registerTask(
     'convert_template',
     'Converts the govuk_template to use mustache inheritance',
     function () {
-      var script = require(__dirname + '/lib/template-conversion.js');
+      var script = require(path.join(__dirname, '/lib/template-conversion.js'))
 
-      script.convert();
-      grunt.log.writeln('govuk_template converted');
+      script.convert()
+      grunt.log.writeln('govuk_template converted')
     }
-  );
+  )
 
   grunt.registerTask('generate-assets', [
     'clean',
@@ -256,16 +233,12 @@ module.exports = function(grunt){
     'concat',
     'rewrite',
     'compress'
-  ]);
+  ])
 
-  grunt.registerTask('test', ['env:test', 'mochaTest']);
-  grunt.registerTask('lint', ['jshint']);
-
+  grunt.registerTask('test', ['env:test', 'mochaTest'])
 
   grunt.registerTask('default', [
     'generate-assets',
     'concurrent:target'
-  ]);
-
-
-};
+  ])
+}

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,1 +1,1 @@
-module.exports.chargeValidation = require('./utils/charge_validation');
+module.exports.chargeValidation = require('./utils/charge_validation')

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -1,335 +1,330 @@
-/*jslint node: true */
-"use strict";
-require('array.prototype.find');
-var logger = require('winston');
-var logging = require('../utils/logging.js');
-var baseClient = require('../utils/base_client');
+'use strict'
+require('array.prototype.find')
+var logger = require('winston')
+var logging = require('../utils/logging.js')
+var baseClient = require('../utils/base_client')
 
-var _ = require('lodash');
-var views = require('../utils/views.js');
-var normalise = require('../services/normalise_charge.js');
-var chargeValidator = require('../utils/charge_validation_backend.js');
-var i18n = require('i18n');
-var Charge = require('../models/charge.js');
-var Card  = require('../models/card.js');
-var State = require('../models/state.js');
-var paths = require('../paths.js');
-var CHARGE_VIEW = 'charge';
-var CONFIRM_VIEW = 'confirm';
-var AUTH_WAITING_VIEW = 'auth_waiting';
-var AUTH_3DS_REQUIRED_VIEW = 'auth_3ds_required';
-var AUTH_3DS_REQUIRED_OUT_VIEW = 'auth_3ds_required_out';
-var AUTH_3DS_REQUIRED_IN_VIEW = 'auth_3ds_required_in';
-var CAPTURE_WAITING_VIEW = 'capture_waiting';
-var preserveProperties = ['cardholderName','addressLine1', 'addressLine2', 'addressCity', 'addressPostcode', 'addressCountry'];
-var countries = require("../services/countries.js");
-var CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER;
-var {withAnalyticsError, withAnalytics} = require('../utils/analytics.js');
+var _ = require('lodash')
+var views = require('../utils/views.js')
+var normalise = require('../services/normalise_charge.js')
+var chargeValidator = require('../utils/charge_validation_backend.js')
+var i18n = require('i18n')
+var Charge = require('../models/charge.js')
+var Card = require('../models/card.js')
+var State = require('../models/state.js')
+var paths = require('../paths.js')
+var CHARGE_VIEW = 'charge'
+var CONFIRM_VIEW = 'confirm'
+var AUTH_WAITING_VIEW = 'auth_waiting'
+var AUTH_3DS_REQUIRED_VIEW = 'auth_3ds_required'
+var AUTH_3DS_REQUIRED_OUT_VIEW = 'auth_3ds_required_out'
+var AUTH_3DS_REQUIRED_IN_VIEW = 'auth_3ds_required_in'
+var CAPTURE_WAITING_VIEW = 'capture_waiting'
+var preserveProperties = ['cardholderName', 'addressLine1', 'addressLine2', 'addressCity', 'addressPostcode', 'addressCountry']
+var countries = require('../services/countries.js')
+var CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
+var {withAnalyticsError, withAnalytics} = require('../utils/analytics.js')
 
-
-var appendChargeForNewView = function(charge, req, chargeId){
-  var cardModel             = Card(charge.gatewayAccount.cardTypes);
-  var translation           = i18n.__("chargeController.withdrawalText");
-  charge.withdrawalText     = translation[cardModel.withdrawalTypes.join("_")];
-  charge.allowedCards       = cardModel.allowed;
-  charge.cardsAsStrings     = JSON.stringify(cardModel.allowed);
-  charge.post_card_action   = routeFor('create', chargeId);
-  charge.id                 = chargeId;
-  charge.post_cancel_action = routeFor('cancel', chargeId);
-};
+var appendChargeForNewView = function (charge, req, chargeId) {
+  var cardModel = Card(charge.gatewayAccount.cardTypes)
+  var translation = i18n.__('chargeController.withdrawalText')
+  charge.withdrawalText = translation[cardModel.withdrawalTypes.join('_')]
+  charge.allowedCards = cardModel.allowed
+  charge.cardsAsStrings = JSON.stringify(cardModel.allowed)
+  charge.post_card_action = routeFor('create', chargeId)
+  charge.id = chargeId
+  charge.post_cancel_action = routeFor('cancel', chargeId)
+}
 
 var routeFor = (resource, chargeId) => {
-  return paths.generateRoute(`card.${resource}`, {chargeId: chargeId });
-};
+  return paths.generateRoute(`card.${resource}`, {chargeId: chargeId})
+}
 
 var redirect = (res) => {
   return {
     toAuth3dsRequired: (chargeId) => res.redirect(303, routeFor('auth3dsRequired', chargeId)),
     toAuthWaiting: (chargeId) => res.redirect(303, routeFor('authWaiting', chargeId)),
-    toConfirm: (chargeId) =>  res.redirect(303, routeFor('confirm', chargeId)),
-    toNew: (chargeId) =>  res.redirect(303, routeFor('new', chargeId)),
-    toReturn: (chargeId) =>  res.redirect(303, routeFor('return', chargeId))
-  };
-};
+    toConfirm: (chargeId) => res.redirect(303, routeFor('confirm', chargeId)),
+    toNew: (chargeId) => res.redirect(303, routeFor('new', chargeId)),
+    toReturn: (chargeId) => res.redirect(303, routeFor('return', chargeId))
+  }
+}
 
 module.exports = {
   new: function (req, res) {
-    var _views = views.create(),
-      charge     = normalise.charge(req.chargeData, req.chargeId);
-    appendChargeForNewView(charge, req, charge.id);
+    var _views = views.create()
+    var charge = normalise.charge(req.chargeData, req.chargeId)
+    appendChargeForNewView(charge, req, charge.id)
 
     var init = function () {
-      charge.countries = countries.retrieveCountries();
+      charge.countries = countries.retrieveCountries()
       if (charge.status === State.ENTERING_CARD_DETAILS) {
-        return _views.display(res, CHARGE_VIEW, withAnalytics(charge, charge));
+        return _views.display(res, CHARGE_VIEW, withAnalytics(charge, charge))
       }
-      var chargeModel = Charge(req.headers[CORRELATION_HEADER]);
+      var chargeModel = Charge(req.headers[CORRELATION_HEADER])
       chargeModel.updateToEnterDetails(charge.id)
         .then(function () {
-          _views.display(res, CHARGE_VIEW, withAnalytics(charge, charge));
+          _views.display(res, CHARGE_VIEW, withAnalytics(charge, charge))
         }, function () {
-          _views.display(res, "NOT_FOUND", withAnalyticsError());
-        });
-    };
-    init();
+          _views.display(res, 'NOT_FOUND', withAnalyticsError())
+        })
+    }
+    init()
   },
 
   create: function (req, res) {
-    var charge    = normalise.charge(req.chargeData, req.chargeId);
-    var _views    = views.create();
+    var charge = normalise.charge(req.chargeData, req.chargeId)
+    var _views = views.create()
 
-    var cardModel = Card(req.chargeData.gateway_account.card_types);
-    var submitted = charge.status === State.AUTH_READY;
-    var authUrl   = normalise.authUrl(charge);
+    var cardModel = Card(req.chargeData.gateway_account.card_types)
+    var submitted = charge.status === State.AUTH_READY
+    var authUrl = normalise.authUrl(charge)
 
     var validator = chargeValidator(
-      i18n.__("chargeController.fieldErrors"),
+      i18n.__('chargeController.fieldErrors'),
       logger,
       cardModel
-    );
+    )
 
-    normalise.addressLines(req.body);
-    normalise.whitespace(req.body);
+    normalise.addressLines(req.body)
+    normalise.whitespace(req.body)
 
     if (submitted) {
-      return redirect(res).toAuthWaiting(req.chargeId);
+      return redirect(res).toAuthWaiting(req.chargeId)
     }
 
-    var awaitingAuth = function() {
-        logging.failedChargePost(409,authUrl);
-        redirect(res).toAuthWaiting(req.chargeId);
-      },
+    var awaitingAuth = function () {
+      logging.failedChargePost(409, authUrl)
+      redirect(res).toAuthWaiting(req.chargeId)
+    }
 
-      successfulAuth = function() {
-        redirect(res).toConfirm(req.chargeId);
-      },
+    var successfulAuth = function () {
+      redirect(res).toConfirm(req.chargeId)
+    }
 
-      authResolver = function(status) {
-        switch (status) {
-          case(State.AUTH_3DS_REQUIRED):
-            redirect(res).toAuth3dsRequired(req.chargeId);
-            break;
-          default:
-            successfulAuth();
-        }
-      },
+    var authResolver = function (status) {
+      switch (status) {
+        case (State.AUTH_3DS_REQUIRED):
+          redirect(res).toAuth3dsRequired(req.chargeId)
+          break
+        default:
+          successfulAuth()
+      }
+    }
 
-      connectorFailure = function() {
-        logging.failedChargePost(409,authUrl);
-        _views.display(res, 'SYSTEM_ERROR', withAnalytics(
+    var connectorFailure = function () {
+      logging.failedChargePost(409, authUrl)
+      _views.display(res, 'SYSTEM_ERROR', withAnalytics(
           charge,
-          {returnUrl: routeFor('return', charge.id)}));
-      },
+          {returnUrl: routeFor('return', charge.id)}))
+    }
 
-      unknownFailure = function() {
-        redirect(res).toNew(req.chargeId);
-      },
+    var unknownFailure = function () {
+      redirect(res).toNew(req.chargeId)
+    }
 
-      connectorNonResponsive = function (err) {
-        logging.failedChargePostException(err);
-        _views.display(res, "ERROR", withAnalytics(charge));
-      },
+    var connectorNonResponsive = function (err) {
+      logging.failedChargePostException(err)
+      _views.display(res, 'ERROR', withAnalytics(charge))
+    }
 
-      hasValidationError = function(validation){
-        charge.countries = countries.retrieveCountries();
-        appendChargeForNewView(charge, req, charge.id);
-        _.merge(validation, withAnalytics(charge, charge), _.pick(req.body, preserveProperties));
+    var hasValidationError = function (validation) {
+      charge.countries = countries.retrieveCountries()
+      appendChargeForNewView(charge, req, charge.id)
+      _.merge(validation, withAnalytics(charge, charge), _.pick(req.body, preserveProperties))
 
-        return _views.display(res, CHARGE_VIEW, validation);
-      },
+      return _views.display(res, CHARGE_VIEW, validation)
+    }
 
-      responses = {
-        202: awaitingAuth,
-        409: awaitingAuth,
-        200: authResolver,
-        500: connectorFailure
-      };
+    var responses = {
+      202: awaitingAuth,
+      409: awaitingAuth,
+      200: authResolver,
+      500: connectorFailure
+    }
 
-    function postAuth(authUrl, req, cardBrand) {
-      var startTime = new Date();
-      var correlationId = req.headers[CORRELATION_HEADER] || '';
-
+    function postAuth (authUrl, req, cardBrand) {
+      var startTime = new Date()
+      var correlationId = req.headers[CORRELATION_HEADER] || ''
 
       baseClient.post(authUrl, { data: normalise.apiPayload(req, cardBrand), correlationId: correlationId },
         function (data, json) {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId ,'POST', authUrl, new Date() - startTime);
-          var response = responses[json.statusCode];
-          if (!response) return unknownFailure();
-          response(_.get(data, 'status'));
-        }).on('error', connectorNonResponsive);
+          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', authUrl, new Date() - startTime)
+          var response = responses[json.statusCode]
+          if (!response) return unknownFailure()
+          response(_.get(data, 'status'))
+        }).on('error', connectorNonResponsive)
     }
-    validator.verify(req).then(function(data){
+    validator.verify(req).then(function (data) {
+      if (data.validation.hasError) return hasValidationError(data.validation)
 
-      if (data.validation.hasError) return hasValidationError(data.validation);
+      var cardBrand = data.cardBrand
 
-      var cardBrand = data.cardBrand;
-
-      logging.authChargePost(authUrl);
-      var chargeModel = Charge(req.headers[CORRELATION_HEADER]);
-      chargeModel.patch(req.chargeId, "replace", "email", req.body.email)
+      logging.authChargePost(authUrl)
+      var chargeModel = Charge(req.headers[CORRELATION_HEADER])
+      chargeModel.patch(req.chargeId, 'replace', 'email', req.body.email)
         .then(function () {
-            postAuth(authUrl, req, cardBrand);
-          }, function(err) {
-            logging.failedChargePatch(err);
-            _views.display(res, "ERROR", withAnalyticsError());
-          }
-        );
-    }, unknownFailure);
+          postAuth(authUrl, req, cardBrand)
+        }, function (err) {
+          logging.failedChargePatch(err)
+          _views.display(res, 'ERROR', withAnalyticsError())
+        }
+        )
+    }, unknownFailure)
   },
 
-  checkCard: function(req, res) {
-
-    var cardModel = Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER]);
+  checkCard: function (req, res) {
+    var cardModel = Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER])
     cardModel.checkCard(normalise.creditCard(req.body.cardNo))
       .then(
-        ()=>      { res.json({"accepted": true}); },
-        (data)=>  { res.json({"accepted": false, "message": data }); }
-      );
+        () => { res.json({'accepted': true}) },
+        (data) => { res.json({'accepted': false, 'message': data}) }
+      )
   },
 
   authWaiting: function (req, res) {
-    var charge = normalise.charge(req.chargeData, req.chargeId);
-    switch(charge.status){
-      case(State.AUTH_READY):
-      case(State.AUTH_3DS_READY):
-        var _views = views.create({});
-        _views.display(res, AUTH_WAITING_VIEW, withAnalytics(charge));
-        break;
-      case(State.AUTH_3DS_REQUIRED):
-        redirect(res).toAuth3dsRequired(req.chargeId);
-        break;
+    var charge = normalise.charge(req.chargeData, req.chargeId)
+    switch (charge.status) {
+      case (State.AUTH_READY):
+      case (State.AUTH_3DS_READY):
+        var _views = views.create({})
+        _views.display(res, AUTH_WAITING_VIEW, withAnalytics(charge))
+        break
+      case (State.AUTH_3DS_REQUIRED):
+        redirect(res).toAuth3dsRequired(req.chargeId)
+        break
       default:
-        redirect(res).toConfirm(req.chargeId);
+        redirect(res).toConfirm(req.chargeId)
     }
   },
-  auth3dsHandler(req, res) {
-    var charge = normalise.charge(req.chargeData, req.chargeId);
-    var startTime = new Date();
-    var correlationId = req.headers[CORRELATION_HEADER] || '';
-    var _views = views.create();
+  auth3dsHandler (req, res) {
+    var charge = normalise.charge(req.chargeData, req.chargeId)
+    var startTime = new Date()
+    var correlationId = req.headers[CORRELATION_HEADER] || ''
+    var _views = views.create()
     var templateData = {
       pa_response: _.get(req, 'body.PaRes')
-    };
-    var connector3dsUrl = paths.generateRoute('connectorCharge.threeDs', {chargeId: charge.id});
+    }
+    var connector3dsUrl = paths.generateRoute('connectorCharge.threeDs', {chargeId: charge.id})
 
     baseClient.post(connector3dsUrl, { data: templateData, correlationId: correlationId },
       function (data, json) {
-        logger.info('[%s] - %s to %s ended - total time %dms', correlationId ,'POST', connector3dsUrl, new Date() - startTime);
-        switch(json.statusCode){
+        logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', connector3dsUrl, new Date() - startTime)
+        switch (json.statusCode) {
           case 200:
           case 400:
-            redirect(res).toConfirm(charge.id);
-            break;
+            redirect(res).toConfirm(charge.id)
+            break
           case 202:
           case 409:
-            redirect(res).toAuthWaiting(charge.id);
-            break;
+            redirect(res).toAuthWaiting(charge.id)
+            break
           case 500:
-            _views.display(res, "SYSTEM_ERROR", withAnalytics(charge));
-            break;
+            _views.display(res, 'SYSTEM_ERROR', withAnalytics(charge))
+            break
           default:
-            _views.display(res, "ERROR", withAnalytics(charge));
+            _views.display(res, 'ERROR', withAnalytics(charge))
         }
-      }).on('error', function() {
-      _views.display(res, "ERROR", withAnalytics(charge));
-    });
+      }).on('error', function () {
+        _views.display(res, 'ERROR', withAnalytics(charge))
+      })
   },
   auth3dsRequired: function (req, res) {
-    var charge = normalise.charge(req.chargeData, req.chargeId);
-    var _views = views.create();
-    _views.display(res, AUTH_3DS_REQUIRED_VIEW, withAnalytics(charge));
+    var charge = normalise.charge(req.chargeData, req.chargeId)
+    var _views = views.create()
+    _views.display(res, AUTH_3DS_REQUIRED_VIEW, withAnalytics(charge))
   },
 
   auth3dsRequiredOut: function (req, res) {
-    var charge = normalise.charge(req.chargeData, req.chargeId);
+    var charge = normalise.charge(req.chargeData, req.chargeId)
     var templateData = {
       issuerUrl: _.get(charge, 'auth3dsData.issuerUrl'),
       paRequest: _.get(charge, 'auth3dsData.paRequest'),
       termUrl: paths.generateRoute('external.card.auth3dsRequiredIn', {chargeId: charge.id})
-    };
-    var _views = views.create();
-    _views.display(res, AUTH_3DS_REQUIRED_OUT_VIEW, templateData);
+    }
+    var _views = views.create()
+    _views.display(res, AUTH_3DS_REQUIRED_OUT_VIEW, templateData)
   },
 
   auth3dsRequiredIn: function (req, res) {
-    var charge = normalise.charge(req.chargeData, req.chargeId);
+    var charge = normalise.charge(req.chargeData, req.chargeId)
     var templateData = {
       threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
       paResponse: _.get(req, 'body.PaRes')
-    };
-    var _views = views.create();
-    _views.display(res, AUTH_3DS_REQUIRED_IN_VIEW, templateData);
+    }
+    var _views = views.create()
+    _views.display(res, AUTH_3DS_REQUIRED_IN_VIEW, templateData)
   },
   confirm: function (req, res) {
-    var charge = normalise.charge(req.chargeData, req.chargeId),
-      confirmPath = routeFor('confirm', charge.id),
-      _views = views.create();
+    var charge = normalise.charge(req.chargeData, req.chargeId)
+    var confirmPath = routeFor('confirm', charge.id)
+    var _views = views.create()
     var init = function () {
       _views.display(res, CONFIRM_VIEW, withAnalytics(charge, {
-          hitPage: routeFor('new', charge.id) + "/success",
-          charge: charge,
-          confirmPath: confirmPath,
-          gatewayAccount: {serviceName: charge.gatewayAccount.serviceName},
-          post_cancel_action: routeFor("cancel", charge.id)
-        },
-        confirmPath));
-    };
-    init();
+        hitPage: routeFor('new', charge.id) + '/success',
+        charge: charge,
+        confirmPath: confirmPath,
+        gatewayAccount: {serviceName: charge.gatewayAccount.serviceName},
+        post_cancel_action: routeFor('cancel', charge.id)
+      },
+        confirmPath))
+    }
+    init()
   },
 
   capture: function (req, res) {
-    var charge = normalise.charge(req.chargeData, req.chargeId);
-    var _views = views.create();
+    var charge = normalise.charge(req.chargeData, req.chargeId)
+    var _views = views.create()
 
     var init = function () {
-        var chargeModel = Charge(req.headers[CORRELATION_HEADER]);
-        chargeModel.capture(req.chargeId).then(function () {
-          redirect(res).toReturn(req.chargeId);
-        }, captureFail);
-      },
+      var chargeModel = Charge(req.headers[CORRELATION_HEADER])
+      chargeModel.capture(req.chargeId).then(function () {
+        redirect(res).toReturn(req.chargeId)
+      }, captureFail)
+    }
 
-      captureFail = function (err) {
-        if (err.message === 'CAPTURE_FAILED') return _views.display(res, 'CAPTURE_FAILURE', withAnalytics(charge));
-        _views.display(res, 'SYSTEM_ERROR', withAnalytics(
+    var captureFail = function (err) {
+      if (err.message === 'CAPTURE_FAILED') return _views.display(res, 'CAPTURE_FAILURE', withAnalytics(charge))
+      _views.display(res, 'SYSTEM_ERROR', withAnalytics(
           charge,
           {returnUrl: routeFor('return', charge.id)}
-        ));
-      };
-    init();
+        ))
+    }
+    init()
   },
 
   captureWaiting: function (req, res) {
-    var charge = normalise.charge(req.chargeData, req.chargeId);
-    var _views = views.create();
+    var charge = normalise.charge(req.chargeData, req.chargeId)
+    var _views = views.create()
 
     if (charge.status === State.CAPTURE_READY) {
-      _views.display(res, CAPTURE_WAITING_VIEW, withAnalytics(charge));
+      _views.display(res, CAPTURE_WAITING_VIEW, withAnalytics(charge))
     } else {
       _views.display(res, 'CAPTURE_SUBMITTED', withAnalytics(
         charge,
         {returnUrl: routeFor('return', charge.id)}
-      ));
+      ))
     }
   },
 
   cancel: function (req, res) {
-    var charge = normalise.charge(req.chargeData, req.chargeId);
+    var charge = normalise.charge(req.chargeData, req.chargeId)
 
-    var _views = views.create(),
-      cancelFail = function () {
-        _views.display(res, 'SYSTEM_ERROR', withAnalytics(
+    var _views = views.create()
+    var cancelFail = function () {
+      _views.display(res, 'SYSTEM_ERROR', withAnalytics(
           charge,
           {returnUrl: routeFor('return', charge.id)}
-        ));
-      };
+        ))
+    }
 
-    var chargeModel = Charge(req.headers[CORRELATION_HEADER]);
+    var chargeModel = Charge(req.headers[CORRELATION_HEADER])
     chargeModel.cancel(req.chargeId)
       .then(function () {
         return _views.display(res, 'USER_CANCELLED', withAnalytics(
           charge,
           {returnUrl: routeFor('return', charge.id)}
-        ));
-      }, cancelFail);
+        ))
+      }, cancelFail)
   }
-};
+}

--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -1,10 +1,10 @@
-var Charge = require('../models/charge.js'),
-  StateModel = require('../models/state.js'),
-  views = require('../utils/views.js'),
-  CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER,
-  withAnalyticsError = require('../utils/analytics.js').withAnalyticsError;
+var Charge = require('../models/charge.js')
+var StateModel = require('../models/state.js')
+var views = require('../utils/views.js')
+var CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
+var withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 
-var logger = require('winston');
+var logger = require('winston')
 
 let CANCELABLE_STATES = [
   StateModel.CREATED,
@@ -14,26 +14,25 @@ let CANCELABLE_STATES = [
   StateModel.CAPTURE_READY,
   StateModel.AUTH_3DS_REQUIRED,
   StateModel.AUTH_3DS_READY
-];
+]
 
 module.exports.return = function (req, res) {
-  'use strict';
+  'use strict'
 
-  let correlationId = req.headers[CORRELATION_HEADER] || '';
-  let _views = views.create({});
-  let doRedirect = () => res.redirect(req.chargeData.return_url);
-  let chargeModel = Charge(correlationId);
+  let correlationId = req.headers[CORRELATION_HEADER] || ''
+  let _views = views.create({})
+  let doRedirect = () => res.redirect(req.chargeData.return_url)
+  let chargeModel = Charge(correlationId)
 
   if (CANCELABLE_STATES.includes(req.chargeData.status)) {
-     return chargeModel.cancel(req.chargeId)
+    return chargeModel.cancel(req.chargeId)
       .then(() => logger.warn('Return controller cancelled payment', {'chargeId': req.chargeId}))
       .then(doRedirect)
       .catch(() => {
-        logger.error('Return controller failed to cancel payment', {'chargeId': req.chargeId});
-        _views.display(res, 'SYSTEM_ERROR', withAnalyticsError());
-      });
-
+        logger.error('Return controller failed to cancel payment', {'chargeId': req.chargeId})
+        _views.display(res, 'SYSTEM_ERROR', withAnalyticsError())
+      })
   } else {
-    return doRedirect();
+    return doRedirect()
   }
-};
+}

--- a/app/controllers/secure_controller.js
+++ b/app/controllers/secure_controller.js
@@ -1,45 +1,45 @@
-var paths = require('../paths.js'),
-  Token = require('../models/token.js'),
-  Charge = require('../models/charge.js'),
-  views = require('../utils/views.js'),
-  session = require('../utils/session.js'),
-  cookie = require('../utils/cookies'),
-  csrf = require('csrf'),
-  CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER,
-    withAnalyticsError = require('../utils/analytics.js').withAnalyticsError,
-  stateService = require('../services/state_service.js');
+var paths = require('../paths.js')
+var Token = require('../models/token.js')
+var Charge = require('../models/charge.js')
+var views = require('../utils/views.js')
+var session = require('../utils/session.js')
+var cookie = require('../utils/cookies')
+var csrf = require('csrf')
+var CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
+var withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
+var stateService = require('../services/state_service.js')
 
 module.exports.new = function (req, res) {
-  'use strict';
+  'use strict'
 
-  var chargeTokenId = req.params.chargeTokenId || req.body.chargeTokenId,
-      correlationId = req.headers[CORRELATION_HEADER] || '',
+  var chargeTokenId = req.params.chargeTokenId || req.body.chargeTokenId
+  var correlationId = req.headers[CORRELATION_HEADER] || ''
 
-    init = function () {
-      var charge  = Charge(correlationId);
-      charge.findByToken(chargeTokenId)
-        .then(chargeRetrieved, apiFail);
-    },
+  var init = function () {
+    var charge = Charge(correlationId)
+    charge.findByToken(chargeTokenId)
+        .then(chargeRetrieved, apiFail)
+  }
 
-    chargeRetrieved = function (chargeData) {
-      var token = Token(correlationId);
-      token.destroy(chargeTokenId)
-          .then(apiSuccess(chargeData),apiFail);
-    },
+  var chargeRetrieved = function (chargeData) {
+    var token = Token(correlationId)
+    token.destroy(chargeTokenId)
+          .then(apiSuccess(chargeData), apiFail)
+  }
 
-    apiSuccess = function (chargeData) {
-      var chargeId = chargeData.externalId;
+  var apiSuccess = function (chargeData) {
+    var chargeId = chargeData.externalId
 
-      cookie.setSessionVariable(req, session.createChargeIdSessionKey(chargeId), {
-        csrfSecret: csrf().secretSync()
-      });
+    cookie.setSessionVariable(req, session.createChargeIdSessionKey(chargeId), {
+      csrfSecret: csrf().secretSync()
+    })
 
-      var actionName = stateService.resolveActionName(chargeData.status,'get');
-      res.redirect(303, paths.generateRoute(actionName, {chargeId: chargeId}));
-    },
+    var actionName = stateService.resolveActionName(chargeData.status, 'get')
+    res.redirect(303, paths.generateRoute(actionName, {chargeId: chargeId}))
+  }
 
-    apiFail = function () {
-      views.create().display(res, 'SYSTEM_ERROR', withAnalyticsError());
-    };
-  init();
-};
+  var apiFail = function () {
+    views.create().display(res, 'SYSTEM_ERROR', withAnalyticsError())
+  }
+  init()
+}

--- a/app/controllers/static_controller.js
+++ b/app/controllers/static_controller.js
@@ -1,21 +1,20 @@
-/*jslint node: true */
-"use strict";
-var views = require('../utils/views.js');
-var logger= require('winston');
-var withAnalyticsError = require('../utils/analytics.js').withAnalyticsError;
+/* jslint node: true */
+'use strict'
+var views = require('../utils/views.js')
+var logger = require('winston')
+var withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 
 module.exports = {
-  privacy: function(req,res){
-    res.render('static/privacy');
+  privacy: function (req, res) {
+    res.render('static/privacy')
   },
-  humans: function(req,res){
-    var _views = views.create();
-    _views.display(res, "HUMANS", withAnalyticsError());
-
+  humans: function (req, res) {
+    var _views = views.create()
+    _views.display(res, 'HUMANS', withAnalyticsError())
   },
-  naxsi_error: function(req,res){
-    logger.error('NAXSI ERROR:- ' + req.headers["x-naxsi_sig"]);
-    var _views = views.create();
-    _views.display(res, "NAXSI_SYSTEM_ERROR", withAnalyticsError());
+  naxsi_error: function (req, res) {
+    logger.error('NAXSI ERROR:- ' + req.headers['x-naxsi_sig'])
+    var _views = views.create()
+    _views.display(res, 'NAXSI_SYSTEM_ERROR', withAnalyticsError())
   }
-};
+}

--- a/app/middleware/action_name.js
+++ b/app/middleware/action_name.js
@@ -1,10 +1,11 @@
-var paths      = require(__dirname + '/../paths.js');
-var flatPaths  = require(__dirname + '/../utils/flattened_paths.js')(paths);
+var path = require('path')
+var paths = require(path.join(__dirname, '/../paths.js'))
+var flatPaths = require(path.join(__dirname, '/../utils/flattened_paths.js'))(paths)
 
-module.exports = function(req, res, next){
-  "use strict";
-  
-  var method = Object.keys(req.route.methods)[0];
-  req.actionName = flatPaths[req.route.path + "_" + method];
-  next();
-};
+module.exports = function (req, res, next) {
+  'use strict'
+
+  var method = Object.keys(req.route.methods)[0]
+  req.actionName = flatPaths[req.route.path + '_' + method]
+  next()
+}

--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -1,82 +1,77 @@
-var csrf = require('csrf'),
-  session = require('../utils/session.js'),
-  views = require('../utils/views.js'),
-  chargeParam = require('../services/charge_param_retriever.js'),
-  logger = require('winston'),
-  _views = views.create();
+var csrf = require('csrf')
+var session = require('../utils/session.js')
+var views = require('../utils/views.js')
+var chargeParam = require('../services/charge_param_retriever.js')
+var logger = require('winston')
+var _views = views.create()
 
 var csrfTokenGeneration = function (req, res, next) {
-  "use strict";
-
-  var chargeId = chargeParam.retrieve(req),
-    chargeSession = session.retrieve(req, chargeId);
+  'use strict'
+  var chargeId = chargeParam.retrieve(req)
+  var chargeSession = session.retrieve(req, chargeId)
 
   var init = function () {
-      appendCsrf();
-      next();
-    },
+    appendCsrf()
+    next()
+  }
 
-    appendCsrf = function () {
-      res.locals.csrf = csrf().create(chargeSession.csrfSecret);
-    };
+  var appendCsrf = function () {
+    res.locals.csrf = csrf().create(chargeSession.csrfSecret)
+  }
 
-  init();
-};
+  init()
+}
 
 var csrfCheck = function (req, res, next) {
-  "use strict";
+  'use strict'
 
-  var chargeId = chargeParam.retrieve(req),
-    chargeSession = session.retrieve(req, chargeId),
-    csrfToken = req.body.csrfToken;
+  var chargeId = chargeParam.retrieve(req)
+  var chargeSession = session.retrieve(req, chargeId)
+  var csrfToken = req.body.csrfToken
 
   var init = function () {
-      if (!sessionAvailable()) return showNoSession();
-      if (!csrfValid()) return showCsrfInvalid();
-      next();
-    },
+    if (!sessionAvailable()) return showNoSession()
+    if (!csrfValid()) return showCsrfInvalid()
+    next()
+  }
 
-    sessionAvailable = function () {
-      return chargeSession && chargeSession.csrfSecret;
-    },
+  var sessionAvailable = function () {
+    return chargeSession && chargeSession.csrfSecret
+  }
 
-    showNoSession = function () {
-      _views.display(res, 'UNAUTHORISED');
-      return logger.error('CSRF secret is not defined');
-    },
+  var showNoSession = function () {
+    _views.display(res, 'UNAUTHORISED')
+    return logger.error('CSRF secret is not defined')
+  }
 
-    csrfValid = function () {
-      if (!(req.route.methods.post || req.route.methods.put)) return true;
-      if (!chargeSession.csrfTokens) chargeSession.csrfTokens = [];
+  var csrfValid = function () {
+    if (!(req.route.methods.post || req.route.methods.put)) return true
+    if (!chargeSession.csrfTokens) chargeSession.csrfTokens = []
 
-      if (csrfUsed()) {
-        logger.error('CSRF token was already used');
-        return false;
-      }
-      var verify = csrf().verify(chargeSession.csrfSecret, csrfToken);
-      if (verify === false) return false;
+    if (csrfUsed()) {
+      logger.error('CSRF token was already used')
+      return false
+    }
+    var verify = csrf().verify(chargeSession.csrfSecret, csrfToken)
+    if (verify === false) return false
 
-      chargeSession.csrfTokens.push(csrfToken);
-      return true;
-    },
+    chargeSession.csrfTokens.push(csrfToken)
+    return true
+  }
 
-    csrfUsed = function () {
-      return chargeSession.csrfTokens.indexOf(csrfToken) !== -1;
-    },
+  var csrfUsed = function () {
+    return chargeSession.csrfTokens.indexOf(csrfToken) !== -1
+  }
 
-    showCsrfInvalid = function () {
-      _views.display(res, 'SYSTEM_ERROR');
-      return logger.error('CSRF is invalid');
-    };
+  var showCsrfInvalid = function () {
+    _views.display(res, 'SYSTEM_ERROR')
+    return logger.error('CSRF is invalid')
+  }
 
-  init();
-};
-
+  init()
+}
 
 module.exports = {
   csrfCheck: csrfCheck,
   csrfTokenGeneration: csrfTokenGeneration
-};
-
-
-
+}

--- a/app/middleware/retrieve_charge.js
+++ b/app/middleware/retrieve_charge.js
@@ -1,26 +1,25 @@
-const views = require('../utils/views.js');
-const Charge = require('../models/charge.js');
-const chargeParam = require('../services/charge_param_retriever.js');
-const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER;
-const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError;
+const views = require('../utils/views.js')
+const Charge = require('../models/charge.js')
+const chargeParam = require('../services/charge_param_retriever.js')
+const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
+const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 
-module.exports = function(req, res, next){
-  "use strict";
-  const _views = views.create();
-  const chargeId = chargeParam.retrieve(req);
+module.exports = function (req, res, next) {
+  'use strict'
+  const _views = views.create()
+  const chargeId = chargeParam.retrieve(req)
 
   if (!chargeId) {
-    _views.display(res,"UNAUTHORISED", withAnalyticsError());
+    _views.display(res, 'UNAUTHORISED', withAnalyticsError())
   } else {
-    req.chargeId = chargeId;
+    req.chargeId = chargeId
     Charge(req.headers[CORRELATION_HEADER]).find(chargeId)
       .then(data => {
-        req.chargeData = data;
-        next();
+        req.chargeData = data
+        next()
       })
       .catch(() => {
-        _views.display(res,"SYSTEM_ERROR", withAnalyticsError());
-      });
+        _views.display(res, 'SYSTEM_ERROR', withAnalyticsError())
+      })
   }
-
-};
+}

--- a/app/middleware/state_enforcer.js
+++ b/app/middleware/state_enforcer.js
@@ -1,54 +1,53 @@
-var views         = require('../utils/views.js');
-var _views        = views.create({});
-var _             = require('lodash');
-var stateService  = require('../services/state_service.js');
-var paths         = require('../paths.js');
+var views = require('../utils/views.js')
+var _views = views.create({})
+var _ = require('lodash')
+var stateService = require('../services/state_service.js')
+var paths = require('../paths.js')
 
-var withAnalyticsError = require('../utils/analytics.js').withAnalyticsError;
-module.exports = function(req,res,next){
-  'use strict';
+var withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
+module.exports = function (req, res, next) {
+  'use strict'
 
-  function getGoogleAnalytics() {
-    var gatewayAccount = _.get(req, 'chargeData.gateway_account');
+  function getGoogleAnalytics () {
+    var gatewayAccount = _.get(req, 'chargeData.gateway_account')
     if (gatewayAccount) {
       return {
-        //The state enforcer will append the correct analytics page to the base charge path
+        // The state enforcer will append the correct analytics page to the base charge path
         'path': paths.generateRoute(`card.new`, {chargeId: req.chargeId}),
         'analyticsId': gatewayAccount.analytics_id,
         'type': gatewayAccount.type,
         'paymentProvider': gatewayAccount.payment_provider
-      };
+      }
     }
-    return withAnalyticsError().analytics;
+    return withAnalyticsError().analytics
   }
 
-  var correctStates = stateService.resolveStates(req.actionName);
-  var currentState      = req.chargeData.status,
-  locals            = {
+  var correctStates = stateService.resolveStates(req.actionName)
+  var currentState = req.chargeData.status
+  var locals = {
     chargeId: req.chargeId,
     returnUrl: paths.generateRoute('card.return', {chargeId: req.chargeId}),
     analytics: getGoogleAnalytics()
-  };
+  }
 
-  var init = function(){
+  var init = function () {
+    if (!stateCorrect()) return
+    next()
+  }
 
-    if (!stateCorrect()) return;
-    next();
-  };
-
-  var stateCorrect = function(){
-    var chargeOK = ischargeSessionOK();
+  var stateCorrect = function () {
+    var chargeOK = ischargeSessionOK()
     if (!chargeOK) {
-      var stateName = currentState.toUpperCase().replace(/\s/g, "_");
-      _views.display(res, stateName, locals);
-      return false;
+      var stateName = currentState.toUpperCase().replace(/\s/g, '_')
+      _views.display(res, stateName, locals)
+      return false
     }
-    return true;
-  },
+    return true
+  }
 
-  ischargeSessionOK = function(){
-    return _.includes(correctStates,currentState);
-  };
+  var ischargeSessionOK = function () {
+    return _.includes(correctStates, currentState)
+  }
 
-  return init();
-};
+  return init()
+}

--- a/app/models/card.js
+++ b/app/models/card.js
@@ -1,76 +1,77 @@
-/*jslint node: true */
-"use strict";
-var _           = require('lodash');
+/* jslint node: true */
+'use strict'
+var _ = require('lodash')
 
-var q           = require('q');
-var changeCase  = require('change-case');
-var cardIdClient = require('../utils/cardid_client');
-var logger  = require('winston');
+var q = require('q')
+var changeCase = require('change-case')
+var cardIdClient = require('../utils/cardid_client')
+var logger = require('winston')
 
-var checkCard = function(cardNo,allowed, correlationId) {
-  var defer = q.defer();
+var checkCard = function (cardNo, allowed, correlationId) {
+  var defer = q.defer()
 
-  var startTime = new Date();
-  var data = {"cardNumber": parseInt(cardNo) };
+  var startTime = new Date()
+  var data = {'cardNumber': parseInt(cardNo)}
 
-  cardIdClient.post({data: data, correlationId: correlationId}, function(data, response) {
-      logger.info(`[${correlationId}]  - %s to %s ended - total time %dms`, 'POST', cardIdClient.CARD_URL, new Date() - startTime);
+  cardIdClient.post({data: data, correlationId: correlationId}, function (data, response) {
+    logger.info(`[${correlationId}]  - %s to %s ended - total time %dms`, 'POST', cardIdClient.CARD_URL, new Date() - startTime)
 
-      if (response.statusCode === 404) {
-        return defer.reject("Your card is not supported");
-      }
+    if (response.statusCode === 404) {
+      return defer.reject('Your card is not supported')
+    }
       // if the server is down, or returns non 500, just continue
-      if (response.statusCode !== 200) {
-        return defer.resolve(); }
+    if (response.statusCode !== 200) {
+      return defer.resolve()
+    }
 
-      var cardBrand = changeCase.paramCase(data.brand);
-      var cardType = normaliseCardType(data.type);
+    var cardBrand = changeCase.paramCase(data.brand)
+    var cardType = normaliseCardType(data.type)
 
-      logger.debug(`[${correlationId}] Checking card brand - `, {'cardBrand': cardBrand, 'cardType': cardType});
+    logger.debug(`[${correlationId}] Checking card brand - `, {'cardBrand': cardBrand, 'cardType': cardType})
 
-      var brandExists = _.filter(allowed, {brand: cardBrand}).length > 0;
-      if (!brandExists) defer.reject(changeCase.titleCase(cardBrand) + " is not supported");
+    var brandExists = _.filter(allowed, {brand: cardBrand}).length > 0
+    if (!brandExists) defer.reject(changeCase.titleCase(cardBrand) + ' is not supported')
 
-      var cardObject = _.find(allowed, {brand: cardBrand, type: cardType});
+    var cardObject = _.find(allowed, {brand: cardBrand, type: cardType})
 
-      if (!cardObject) {
-        switch (cardType) {
-          case "DEBIT":
-            return defer.reject(changeCase.titleCase(cardBrand) + " debit cards are not supported");
-          case "CREDIT":
-            return defer.reject(changeCase.titleCase(cardBrand) + " credit cards are not supported");
-        }
+    if (!cardObject) {
+      switch (cardType) {
+        case 'DEBIT':
+          return defer.reject(changeCase.titleCase(cardBrand) + ' debit cards are not supported')
+        case 'CREDIT':
+          return defer.reject(changeCase.titleCase(cardBrand) + ' credit cards are not supported')
       }
-      return defer.resolve(cardBrand);
-    }).on('error',function(error){
-      logger.error(`[${correlationId}] ERROR CALLING CARDID AT ${cardIdClient.CARD_URL}`, error);
-      logger.info(`[${correlationId}] - %s to %s ended - total time %dms`, 'POST', cardIdClient.cardUrl, new Date() - startTime);
-      defer.resolve();
-    });
-    return defer.promise;
-};
+    }
+    return defer.resolve(cardBrand)
+  }).on('error', function (error) {
+    logger.error(`[${correlationId}] ERROR CALLING CARDID AT ${cardIdClient.CARD_URL}`, error)
+    logger.info(`[${correlationId}] - %s to %s ended - total time %dms`, 'POST', cardIdClient.cardUrl, new Date() - startTime)
+    defer.resolve()
+  })
+  return defer.promise
+}
 
-var normaliseCardType = function(cardType) {
+var normaliseCardType = function (cardType) {
   switch (cardType) {
-    case "D":
-      return "DEBIT";
-    case "C":
-      return "CREDIT";
+    case 'D':
+      return 'DEBIT'
+    case 'C':
+      return 'CREDIT'
   }
-  return undefined;
-};
+  return undefined
+}
 
-module.exports = function(allowedCards, correlationId){
-  var withdrawalTypes = [],
-  allowed             = _.clone(allowedCards);
-  correlationId = correlationId || '';
+module.exports = function (allowedCards, correlationId) {
+  var withdrawalTypes = []
+  var allowed = _.clone(allowedCards)
+  correlationId = correlationId || ''
 
-  if (_.filter(allowedCards,{debit: true}).length !== 0) withdrawalTypes.push('debit');
-  if (_.filter(allowedCards,{credit: true}).length !== 0) withdrawalTypes.push('credit');
+  if (_.filter(allowedCards, {debit: true}).length !== 0) withdrawalTypes.push('debit')
+  if (_.filter(allowedCards, {credit: true}).length !== 0) withdrawalTypes.push('credit')
 
   return {
     withdrawalTypes: withdrawalTypes,
     allowed: _.clone(allowed),
-    checkCard: (cardNo)=> { return checkCard(cardNo, allowed, correlationId); }
-  };
-};
+    checkCard: (cardNo) => { return checkCard(cardNo, allowed, correlationId) }
+  }
+}

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -1,27 +1,27 @@
-var logger  = require('winston');
-var q       = require('q');
+var logger = require('winston')
+var q = require('q')
 
-var baseClient = require('../utils/base_client');
-var paths   = require('../paths.js');
-var State   = require('./state.js');
+var baseClient = require('../utils/base_client')
+var paths = require('../paths.js')
+var State = require('./state.js')
 
-module.exports = function(correlationId) {
-  'use strict';
+module.exports = function (correlationId) {
+  'use strict'
 
-  correlationId = correlationId || '';
+  correlationId = correlationId || ''
 
-  var connectorurl = function(resource,params){
-    return paths.generateRoute(`connectorCharge.${resource}`,params);
-  },
+  var connectorurl = function (resource, params) {
+    return paths.generateRoute(`connectorCharge.${resource}`, params)
+  }
 
-  updateToEnterDetails = function(chargeId) {
-    return updateStatus(chargeId, State.ENTERING_CARD_DETAILS);
-  },
+  var updateToEnterDetails = function (chargeId) {
+    return updateStatus(chargeId, State.ENTERING_CARD_DETAILS)
+  }
 
-  updateStatus = function(chargeId, status){
-    var url = connectorurl('updateStatus',{chargeId: chargeId}),
-    data = {new_status: status},
-    defer   = q.defer();
+  var updateStatus = function (chargeId, status) {
+    var url = connectorurl('updateStatus', {chargeId: chargeId})
+    var data = {new_status: status}
+    var defer = q.defer()
 
     logger.debug('[%s] Calling connector to update charge status -', correlationId, {
       service: 'connector',
@@ -29,214 +29,213 @@ module.exports = function(correlationId) {
       chargeId: chargeId,
       newStatus: status,
       url: url
-    });
+    })
 
-    var startTime = new Date();
+    var startTime = new Date()
 
     baseClient.put(url, { data: data, correlationId: correlationId }, function (data, response) {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PUT', url, new Date() - startTime);
-      updateComplete(chargeId, data, response, defer);
-
-    }).on('error',function(err){
-      logger.info('[] - %s to %s ended - total time %dms', 'PUT', url, new Date() - startTime);
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PUT', url, new Date() - startTime)
+      updateComplete(chargeId, data, response, defer)
+    }).on('error', function (err) {
+      logger.info('[] - %s to %s ended - total time %dms', 'PUT', url, new Date() - startTime)
       logger.error('Calling connector to update charge status threw exception -', {
         service: 'connector',
         method: 'PUT',
         chargeId: chargeId,
         url: url,
         error: err
-      });
-      clientUnavailable(err, defer);
-    });
+      })
+      clientUnavailable(err, defer)
+    })
 
-    return defer.promise;
-  },
+    return defer.promise
+  }
 
-  find = function(chargeId){
-    var defer = q.defer();
-    var url = connectorurl('show',{chargeId: chargeId});
+  var find = function (chargeId) {
+    var defer = q.defer()
+    var url = connectorurl('show', {chargeId: chargeId})
 
     logger.debug('[%s] Calling connector to get charge -', correlationId, {
       service: 'connector',
       method: 'GET',
       chargeId: chargeId,
       url: url
-    });
+    })
 
-    var startTime = new Date();
-    baseClient.get(url, {correlationId: correlationId}, function(data, response){
+    var startTime = new Date()
+    baseClient.get(url, {correlationId: correlationId}, function (data, response) {
       if (response.statusCode !== 200) {
-        logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime);
+        logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
         logger.warn('[%s] Calling connector to get charge failed -', correlationId, {
           service: 'connector',
           method: 'GET',
           chargeId: chargeId,
           url: url,
           status: response.statusCode
-        });
-        return defer.reject(new Error('GET_FAILED'));
+        })
+        return defer.reject(new Error('GET_FAILED'))
       }
-      defer.resolve(data);
-    }).on('error',function(err){
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime);
+      defer.resolve(data)
+    }).on('error', function (err) {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
       logger.error('[%s] Calling connector to get charge threw exception -', correlationId, {
         service: 'connector',
         method: 'GET',
         chargeId: chargeId,
         url: url,
         error: err
-      });
-      clientUnavailable(err, defer);
-    });
-    return defer.promise;
-  },
+      })
+      clientUnavailable(err, defer)
+    })
+    return defer.promise
+  }
 
-  capture = function(chargeId){
-    var url = connectorurl('capture',{chargeId: chargeId}),
-    defer   = q.defer();
+  var capture = function (chargeId) {
+    var url = connectorurl('capture', {chargeId: chargeId})
+    var defer = q.defer()
 
     logger.debug('[%s] Calling connector to do capture -', correlationId, {
       service: 'connector',
       method: 'POST',
       chargeId: chargeId,
       url: url
-    });
-
-    var startTime = new Date();
-    baseClient.post(url, { correlationId: correlationId }, function(data, response) {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime);
-      captureComplete(data, response, defer);
     })
-    .on('error',function(err) {
-      logger.info('[%s] - %s to %s ended - total time %dms', 'POST', correlationId, url, new Date() - startTime);
+
+    var startTime = new Date()
+    baseClient.post(url, { correlationId: correlationId }, function (data, response) {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
+      captureComplete(data, response, defer)
+    })
+    .on('error', function (err) {
+      logger.info('[%s] - %s to %s ended - total time %dms', 'POST', correlationId, url, new Date() - startTime)
       logger.error('[%s] Calling connector to do capture failed -', correlationId, {
-        service:'connector',
-        method:'POST',
+        service: 'connector',
+        method: 'POST',
         chargeId: chargeId,
         url: url,
-        error:err
-      });
-      captureFail(err, defer);
-    });
+        error: err
+      })
+      captureFail(err, defer)
+    })
 
-    return defer.promise;
-  },
+    return defer.promise
+  }
 
-  cancel = function(chargeId){
-    var url = connectorurl('cancel',{chargeId: chargeId}),
-      defer   = q.defer();
+  var cancel = function (chargeId) {
+    var url = connectorurl('cancel', {chargeId: chargeId})
+    var defer = q.defer()
 
     logger.debug('[%s] Calling connector to cancel a charge -', correlationId, {
       service: 'connector',
       method: 'POST',
       chargeId: chargeId,
       url: url
-    });
+    })
 
-    var startTime = new Date();
-    baseClient.post(url, { correlationId: correlationId }, function(data, response) {
-        logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime);
-        cancelComplete(data, response, defer);
-      })
-      .on('error',function(err){
-        logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime);
+    var startTime = new Date()
+    baseClient.post(url, { correlationId: correlationId }, function (data, response) {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
+      cancelComplete(data, response, defer)
+    })
+      .on('error', function (err) {
+        logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
         logger.error('[%s] Calling connector cancel a charge threw exception -', correlationId, {
-          service:'connector',
-          method:'POST',
+          service: 'connector',
+          method: 'POST',
           url: url,
           error: err
-        });
-        cancelFail(err, defer);
-      });
+        })
+        cancelFail(err, defer)
+      })
 
-    return defer.promise;
-  },
+    return defer.promise
+  }
 
-  cancelComplete = function(data, response, defer) {
-    var code = response.statusCode;
-    if (code === 204) return defer.resolve();
+  var cancelComplete = function (data, response, defer) {
+    var code = response.statusCode
+    if (code === 204) return defer.resolve()
     logger.error('[%s] Calling connector cancel a charge failed -', correlationId, {
-      service:'connector',
-      method:'POST',
+      service: 'connector',
+      method: 'POST',
       status: code
-    });
-    if (code === 400) return defer.reject(new Error('CANCEL_FAILED'));
-    return defer.reject(new Error('POST_FAILED'));
-  },
+    })
+    if (code === 400) return defer.reject(new Error('CANCEL_FAILED'))
+    return defer.reject(new Error('POST_FAILED'))
+  }
 
-  cancelFail = function(err, defer){
-    clientUnavailable(err, defer);
-  },
+  var cancelFail = function (err, defer) {
+    clientUnavailable(err, defer)
+  }
 
-  findByToken = function(tokenId){
-    var defer = q.defer();
+  var findByToken = function (tokenId) {
+    var defer = q.defer()
     logger.debug('[%s] Calling connector to find a charge by token -', correlationId, {
       service: 'connector',
       method: 'GET'
-    });
+    })
 
-    var startTime = new Date();
-    var findByUrl = connectorurl('findByToken',{chargeTokenId: tokenId});
+    var startTime = new Date()
+    var findByUrl = connectorurl('findByToken', {chargeTokenId: tokenId})
 
-    baseClient.get(findByUrl, {correlationId: correlationId}, function(data, response) {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', findByUrl, new Date() - startTime);
+    baseClient.get(findByUrl, {correlationId: correlationId}, function (data, response) {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', findByUrl, new Date() - startTime)
       if (response.statusCode !== 200) {
         logger.warn('[%s] Calling connector to find a charge by token failed -', correlationId, {
           service: 'connector',
           method: 'GET',
           status: response.statusCode
-        });
-        defer.reject(new Error('GET_FAILED'));
-        return;
+        })
+        defer.reject(new Error('GET_FAILED'))
+        return
       }
 
-      defer.resolve(data);
-    }).on('error', function(err){
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', findByUrl, new Date() - startTime);
+      defer.resolve(data)
+    }).on('error', function (err) {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', findByUrl, new Date() - startTime)
       logger.error('[%s] Calling connector to find a charge by token threw exception -', correlationId, {
-        service:'connector',
-        method:'GET',
-        error:err
-      });
-      clientUnavailable(err, defer);
-    });
-    return defer.promise;
-  },
+        service: 'connector',
+        method: 'GET',
+        error: err
+      })
+      clientUnavailable(err, defer)
+    })
+    return defer.promise
+  }
 
-  captureComplete = function(data, response, defer) {
-    var code = response.statusCode;
-    if (code === 204) return defer.resolve();
-    if (code === 400) return defer.reject(new Error('CAPTURE_FAILED'));
-    return defer.reject(new Error('POST_FAILED'));
-  },
+  var captureComplete = function (data, response, defer) {
+    var code = response.statusCode
+    if (code === 204) return defer.resolve()
+    if (code === 400) return defer.reject(new Error('CAPTURE_FAILED'))
+    return defer.reject(new Error('POST_FAILED'))
+  }
 
-  captureFail = function(err, defer){
-    clientUnavailable(err, defer);
-  },
+  var captureFail = function (err, defer) {
+    clientUnavailable(err, defer)
+  }
 
-  updateComplete = function(chargeId, data, response, defer){
+  var updateComplete = function (chargeId, data, response, defer) {
     if (response.statusCode !== 204) {
       logger.error('[%s] Calling connector to update charge status failed -', correlationId, {
         chargeId: chargeId,
         status: response.statusCode
-      });
-      defer.reject(new Error('UPDATE_FAILED'));
-      return;
+      })
+      defer.reject(new Error('UPDATE_FAILED'))
+      return
     }
 
-    defer.resolve({success: "OK"});
-  },
+    defer.resolve({success: 'OK'})
+  }
 
-  patch = function(chargeId, op, path, value) {
-    var defer   = q.defer();
+  var patch = function (chargeId, op, path, value) {
+    var defer = q.defer()
 
-    var startTime = new Date();
-    var chargesUrl = process.env.CONNECTOR_HOST + "/v1/frontend/charges/";
+    var startTime = new Date()
+    var chargesUrl = process.env.CONNECTOR_HOST + '/v1/frontend/charges/'
 
     logger.debug('[%s] Calling connector to patch charge -', correlationId, {
       service: 'connector',
       method: 'PATCH'
-    });
+    })
 
     var params = {
       data: {
@@ -245,32 +244,32 @@ module.exports = function(correlationId) {
         value: value
       },
       correlationId: correlationId
-    };
+    }
 
     baseClient.patch(chargesUrl + chargeId, params, function (data, response) {
-         logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', chargesUrl, new Date() - startTime);
-        var code = response.statusCode;
-        if (code === 200) {
-          defer.resolve();
-        } else {
-          defer.reject();
-        }
-      }).on('error', function(err){
-        logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', chargesUrl, new Date() - startTime);
-        logger.error('[%s] Calling connector to patch a charge threw exception -', correlationId, {
-          service:'connector',
-          method:'PATCH',
-          error:err
-        });
-        defer.reject();
-      });
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', chargesUrl, new Date() - startTime)
+      var code = response.statusCode
+      if (code === 200) {
+        defer.resolve()
+      } else {
+        defer.reject()
+      }
+    }).on('error', function (err) {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', chargesUrl, new Date() - startTime)
+      logger.error('[%s] Calling connector to patch a charge threw exception -', correlationId, {
+        service: 'connector',
+        method: 'PATCH',
+        error: err
+      })
+      defer.reject()
+    })
 
-      return defer.promise;
-  },
+    return defer.promise
+  }
 
-  clientUnavailable = function(error, defer) {
-    defer.reject(new Error('CLIENT_UNAVAILABLE'),error);
-  };
+  var clientUnavailable = function (error, defer) {
+    defer.reject(new Error('CLIENT_UNAVAILABLE'), error)
+  }
 
   return {
     updateStatus: updateStatus,
@@ -280,5 +279,5 @@ module.exports = function(correlationId) {
     findByToken: findByToken,
     cancel: cancel,
     patch: patch
-  };
-};
+  }
+}

--- a/app/models/state.js
+++ b/app/models/state.js
@@ -8,6 +8,4 @@ module.exports = {
   CAPTURE_SUBMITTED: 'CAPTURE SUBMITTED',
   CREATED: 'CREATED',
   CANCELLED: 'CANCELLED'
-};
-
-
+}

--- a/app/models/token.js
+++ b/app/models/token.js
@@ -1,60 +1,60 @@
-var baseClient = require('../utils/base_client');
+var baseClient = require('../utils/base_client')
 
-var q       = require('q');
-var logger  = require('winston');
-var paths   = require('../paths.js');
+var q = require('q')
+var logger = require('winston')
+var paths = require('../paths.js')
 
-module.exports = function(correlationId) {
-  'use strict';
+module.exports = function (correlationId) {
+  'use strict'
 
-  correlationId = correlationId || "";
+  correlationId = correlationId || ''
 
-  var createUrl = function(resource,params){
-        return paths.generateRoute(`connectorCharge.${resource}`,params);
-      },
+  var createUrl = function (resource, params) {
+    return paths.generateRoute(`connectorCharge.${resource}`, params)
+  }
 
-  destroy = function(tokenId){
-    var defer = q.defer();
+  var destroy = function (tokenId) {
+    var defer = q.defer()
     logger.debug('[%s] Calling connector to delete a token -', correlationId, {
       service: 'connector',
       method: 'DELETE',
       url: createUrl('token', {chargeTokenId: '{tokenId}'})
-    });
+    })
 
-    var startTime = new Date();
-    var deleteUrl = createUrl('token', {chargeTokenId: tokenId});
+    var startTime = new Date()
+    var deleteUrl = createUrl('token', {chargeTokenId: tokenId})
 
-    baseClient.delete(deleteUrl, { correlationId: correlationId }, function(data, response){
+    baseClient.delete(deleteUrl, { correlationId: correlationId }, function (data, response) {
       logger.info('[%s] - %s to %s ended - total time %dms', 'DELETE',
-        correlationId, deleteUrl, new Date() - startTime);
+        correlationId, deleteUrl, new Date() - startTime)
 
       if (response.statusCode !== 204) {
         logger.warn('Calling connector to delete a token failed -', {
           service: 'connector',
           method: 'DELETE',
           url: createUrl('token', {chargeTokenId: '{tokenId}'})
-        });
-        return defer.reject(new Error('DELETE_FAILED'));
+        })
+        return defer.reject(new Error('DELETE_FAILED'))
       }
-      defer.resolve(data);
-    }).on('error',function(err){
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'DELETE', deleteUrl, new Date() - startTime);
+      defer.resolve(data)
+    }).on('error', function (err) {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'DELETE', deleteUrl, new Date() - startTime)
       logger.error('[%s] Calling connector to delete a token threw exception -', correlationId, {
         service: 'connector',
         method: 'DELETE',
         url: createUrl('token', {chargeTokenId: '{tokenId}'}),
         error: err
-      });
-      clientUnavailable(err, defer);
-    });
-    return defer.promise;
-  },
+      })
+      clientUnavailable(err, defer)
+    })
+    return defer.promise
+  }
 
-  clientUnavailable = function(error, defer) {
-    defer.reject(new Error('CLIENT_UNAVAILABLE'), error);
-  };
+  var clientUnavailable = function (error, defer) {
+    defer.reject(new Error('CLIENT_UNAVAILABLE'), error)
+  }
 
   return {
     destroy: destroy
-  };
-};
+  }
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -1,12 +1,13 @@
-var _ = require('lodash');
-var generateRoute = require(__dirname + '/utils/generate_route.js');
+var _ = require('lodash')
+var path = require('path')
+var generateRoute = require(path.join(__dirname, '/utils/generate_route.js'))
 
-if (process.env.CONNECTOR_HOST === undefined) throw new Error('CONNECTOR_HOST environment variable is not defined');
+if (process.env.CONNECTOR_HOST === undefined) throw new Error('CONNECTOR_HOST environment variable is not defined')
 // please structure each route as follows
 // name: {
 //    path: "/foo"
 //    action: get
-//}
+// }
 // the action while not used directly here is used so we can match to the named
 // routes when we have duplicate paths on different actions
 
@@ -63,70 +64,70 @@ var paths = {
     return: {
       path: '/return/:chargeId',
       action: 'get'
-    },
+    }
   },
   secure: {
     get: {
-      path: "/secure/:chargeTokenId",
+      path: '/secure/:chargeTokenId',
       action: 'get'
     },
     post: {
-      path: "/secure/",
+      path: '/secure/',
       action: 'post'
     }
   },
   static: {
     privacy: {
-      path:"/privacy",
+      path: '/privacy',
       action: 'get'
     },
 
     naxsi_error: {
-      path:"/request-denied",
+      path: '/request-denied',
       action: 'get',
-      message: "An invalid character was entered, please try again"
+      message: 'An invalid character was entered, please try again'
     },
 
     humans: {
-      path:"/humans.txt",
+      path: '/humans.txt',
       action: 'get'
     }
   },
   connectorCharge: {
     show: {
-      path: process.env.CONNECTOR_HOST + "/v1/frontend/charges/:chargeId",
+      path: process.env.CONNECTOR_HOST + '/v1/frontend/charges/:chargeId',
       action: 'get'
     },
     updateStatus: {
-      path: process.env.CONNECTOR_HOST + "/v1/frontend/charges/:chargeId/status",
+      path: process.env.CONNECTOR_HOST + '/v1/frontend/charges/:chargeId/status',
       action: 'put'
     },
     capture: {
-      path: process.env.CONNECTOR_HOST + "/v1/frontend/charges/:chargeId/capture",
+      path: process.env.CONNECTOR_HOST + '/v1/frontend/charges/:chargeId/capture',
       action: 'put'
     },
     cancel: {
-      path: process.env.CONNECTOR_HOST + "/v1/frontend/charges/:chargeId/cancel",
+      path: process.env.CONNECTOR_HOST + '/v1/frontend/charges/:chargeId/cancel',
       action: 'post'
     },
     findByToken: {
-      path: process.env.CONNECTOR_HOST + "/v1/frontend/tokens/:chargeTokenId/charge",
+      path: process.env.CONNECTOR_HOST + '/v1/frontend/tokens/:chargeTokenId/charge',
       action: 'get'
     },
     token: {
-      path: process.env.CONNECTOR_HOST + "/v1/frontend/tokens/:chargeTokenId",
+      path: process.env.CONNECTOR_HOST + '/v1/frontend/tokens/:chargeTokenId',
       action: 'delete'
     },
     allCards: {
-      path: process.env.CONNECTOR_HOST + "/v1/api/card-types",
+      path: process.env.CONNECTOR_HOST + '/v1/api/card-types',
       action: 'get'
     },
     threeDs: {
-      path: process.env.CONNECTOR_HOST + "/v1/frontend/charges/:chargeId/3ds",
+      path: process.env.CONNECTOR_HOST + '/v1/frontend/charges/:chargeId/3ds',
       action: 'post'
-    },
+    }
   }
-};
+}
 
 var extendedPaths = _.extend({}, paths, {
   external: {
@@ -137,8 +138,6 @@ var extendedPaths = _.extend({}, paths, {
       }
     }
   }
-});
+})
 
-module.exports = _.extend({}, extendedPaths, {generateRoute: generateRoute(extendedPaths)});
-
-
+module.exports = _.extend({}, extendedPaths, {generateRoute: generateRoute(extendedPaths)})

--- a/app/router.js
+++ b/app/router.js
@@ -1,66 +1,63 @@
-var i18n = require('i18n');
+var i18n = require('i18n')
+var path = require('path')
 
-var charge = require('./controllers/charge_controller.js');
-var secure = require('./controllers/secure_controller.js');
-var statik = require('./controllers/static_controller.js');
-var returnCont = require('./controllers/return_controller.js');
+var charge = require('./controllers/charge_controller.js')
+var secure = require('./controllers/secure_controller.js')
+var statik = require('./controllers/static_controller.js')
+var returnCont = require('./controllers/return_controller.js')
 
-var paths = require(__dirname + '/paths.js');
-var {csrfCheck, csrfTokenGeneration} = require(__dirname + '/middleware/csrf.js');
-var actionName = require(__dirname + '/middleware/action_name.js');
-var stateEnforcer = require(__dirname + '/middleware/state_enforcer.js');
-var retrieveCharge = require(__dirname + '/middleware/retrieve_charge.js');
+var paths = require(path.join(__dirname, '/paths.js'))
+var {csrfCheck, csrfTokenGeneration} = require(path.join(__dirname, '/middleware/csrf.js'))
+var actionName = require(path.join(__dirname, '/middleware/action_name.js'))
+var stateEnforcer = require(path.join(__dirname, '/middleware/state_enforcer.js'))
+var retrieveCharge = require(path.join(__dirname, '/middleware/retrieve_charge.js'))
 
-
-module.exports.paths = paths;
+module.exports.paths = paths
 
 module.exports.bind = function (app) {
-  'use strict';
+  'use strict'
 
   app.get('/healthcheck', function (req, res) {
-    var data = {'ping': {'healthy': true}};
-    res.writeHead(200, {"Content-Type": "application/json"});
-    res.end(JSON.stringify(data));
-  });
+    var data = {'ping': {'healthy': true}}
+    res.writeHead(200, {'Content-Type': 'application/json'})
+    res.end(JSON.stringify(data))
+  })
 
   // charges
-  var card = paths.card;
+  var card = paths.card
 
   var middlewareStack = [
     function (req, res, next) {
-      i18n.setLocale('en');
-      next();
+      i18n.setLocale('en')
+      next()
     },
     csrfCheck,
     csrfTokenGeneration,
     actionName,
     retrieveCharge,
     stateEnforcer
-  ];
+  ]
 
-  app.get(card.new.path, middlewareStack, charge.new);
-  app.get(card.authWaiting.path, middlewareStack, charge.authWaiting);
-  app.get(card.auth3dsRequired.path, middlewareStack, charge.auth3dsRequired);
-  app.get(card.auth3dsRequiredOut.path, middlewareStack, charge.auth3dsRequiredOut);
-  app.post(card.auth3dsRequiredIn.path, [csrfTokenGeneration, retrieveCharge], charge.auth3dsRequiredIn);
-  app.post(card.auth3dsHandler.path, middlewareStack, charge.auth3dsHandler);
-  app.get(card.captureWaiting.path, middlewareStack, charge.captureWaiting);
-  app.post(card.create.path, middlewareStack, charge.create);
-  app.get(card.confirm.path, middlewareStack, charge.confirm);
-  app.post(card.capture.path, middlewareStack, charge.capture);
-  app.post(card.cancel.path, middlewareStack, charge.cancel);
-  app.post(card.checkCard.path, retrieveCharge, charge.checkCard);
-  app.get(card.return.path, retrieveCharge, returnCont.return);
-
+  app.get(card.new.path, middlewareStack, charge.new)
+  app.get(card.authWaiting.path, middlewareStack, charge.authWaiting)
+  app.get(card.auth3dsRequired.path, middlewareStack, charge.auth3dsRequired)
+  app.get(card.auth3dsRequiredOut.path, middlewareStack, charge.auth3dsRequiredOut)
+  app.post(card.auth3dsRequiredIn.path, [csrfTokenGeneration, retrieveCharge], charge.auth3dsRequiredIn)
+  app.post(card.auth3dsHandler.path, middlewareStack, charge.auth3dsHandler)
+  app.get(card.captureWaiting.path, middlewareStack, charge.captureWaiting)
+  app.post(card.create.path, middlewareStack, charge.create)
+  app.get(card.confirm.path, middlewareStack, charge.confirm)
+  app.post(card.capture.path, middlewareStack, charge.capture)
+  app.post(card.cancel.path, middlewareStack, charge.cancel)
+  app.post(card.checkCard.path, retrieveCharge, charge.checkCard)
+  app.get(card.return.path, retrieveCharge, returnCont.return)
 
   // secure controller
-  app.get(paths.secure.get.path, secure.new);
-  app.post(paths.secure.post.path, secure.new);
+  app.get(paths.secure.get.path, secure.new)
+  app.post(paths.secure.post.path, secure.new)
 
   // static controller
-  app.get(paths.static.privacy.path, statik.privacy);
-  app.get(paths.static.humans.path, statik.humans);
-  app.all(paths.static.naxsi_error.path, statik.naxsi_error);
-
-
-};
+  app.get(paths.static.privacy.path, statik.privacy)
+  app.get(paths.static.humans.path, statik.humans)
+  app.all(paths.static.naxsi_error.path, statik.naxsi_error)
+}

--- a/app/services/charge_param_retriever.js
+++ b/app/services/charge_param_retriever.js
@@ -1,43 +1,42 @@
-var logger = require('winston');
-var cookie = require('../utils/cookies');
+var logger = require('winston')
+var cookie = require('../utils/cookies')
 
-module.exports = function(){
-  "use strict";
+module.exports = (function () {
+  'use strict'
 
-  var retrieve = function(req) {
-    var chargeId = getChargeParam(req);
+  var retrieve = function (req) {
+    var chargeId = getChargeParam(req)
 
     if (!chargeId) {
       logger.error('ChargeId was not found in request -', {
         chargeId: 'undefined'
-      });
-      return false;
+      })
+      return false
     }
 
     if (!getChargeFromSession(req, chargeId)) {
       logger.error('ChargeId was not found on the session -', {
         chargeId: chargeId
-      });
-      return false;
+      })
+      return false
     }
-    return chargeId;
-  },
+    return chargeId
+  }
 
-  getChargeParam = function(req) {
-    return (req.params.chargeId) ? req.params.chargeId : req.body.chargeId;
-  },
+  var getChargeParam = function (req) {
+    return (req.params.chargeId) ? req.params.chargeId : req.body.chargeId
+  }
 
-  getChargeFromSession = function(req,chargeId) {
-    if (!cookie.getSessionCookieName()) return;
-    return cookie.getSessionVariable(req, createChargeIdSessionKey(chargeId));
-  },
+  var getChargeFromSession = function (req, chargeId) {
+    if (!cookie.getSessionCookieName()) return
+    return cookie.getSessionVariable(req, createChargeIdSessionKey(chargeId))
+  }
 
-  createChargeIdSessionKey = function(chargeId) {
-    return 'ch_' + chargeId;
-  };
+  var createChargeIdSessionKey = function (chargeId) {
+    return 'ch_' + chargeId
+  }
 
   return {
     retrieve: retrieve
-  };
-
-}();
+  }
+}())

--- a/app/services/countries.js
+++ b/app/services/countries.js
@@ -1,55 +1,51 @@
-/*jslint node: true */
-"use strict";
-var fs = require('fs');
-var _ = require('lodash');
+'use strict'
+var fs = require('fs')
+var _ = require('lodash')
+var path = require('path')
 
-var countries = {};
+var countries = {}
 
-countries = JSON.parse(fs.readFileSync(__dirname + '/../data/countries.json', 'utf8'));
+countries = JSON.parse(fs.readFileSync(path.join(__dirname, '/../data/countries.json'), 'utf8'))
 // Load additional country data from JSON file
-var extensions = JSON.parse(fs.readFileSync(__dirname + '/../data/country-record-extension.json', 'utf8'));
-
+var extensions = JSON.parse(fs.readFileSync(path.join(__dirname, '/../data/country-record-extension.json'), 'utf8'))
 
 // Merge the additional data into the register data
-_.each(countries,function(countryList, i){
-    var country = countries[i].entry;
-    if (country.country === "GB") country.selected = true;
+_.each(countries, function (countryList, i) {
+  var country = countries[i].entry
+  if (country.country === 'GB') country.selected = true
 
-    //delete east germany etc
-    if (country["end-date"]) {
-        delete countries[i];
-        return;
+    // delete east germany etc
+  if (country['end-date']) {
+    delete countries[i]
+    return
+  }
+
+  for (var j = 0; j < extensions.length; j++) {
+    if (country.country === extensions[j].country) {
+      country.aliases = extensions[j].aliases
+      country.weighting = extensions[j].weighting
     }
+  }
+})
 
-    for (var j = 0; j < extensions.length; j++) {
-        if (country.country === extensions[j].country) {
-            country.aliases = extensions[j].aliases;
-            country.weighting = extensions[j].weighting;
-        }
-    }
-});
+countries = _.compact(countries)
+countries = _.sortBy(countries, function (country) {
+  country.entry.name.toLowerCase()
+}).reverse()
 
+var retrieveCountries = function () {
+  return _.clone(countries)
+}
 
-countries  = _.compact(countries);
-countries  = _.sortBy(countries,function(country){
-    country.entry.name.toLowerCase();
-}).reverse();
+var translateAlpha2 = function (alhpa2Code) {
+  var country = _.filter(countries, function (country) {
+    return country.entry.country === alhpa2Code
+  })[0]
+  return country.entry.name
+}
 
-
-var retrieveCountries = function(){
-    return _.clone(countries);
-};
-
-
-var translateAlpha2 = function(alhpa2Code){
-    var country = _.filter(countries,function(country){
-        return country.entry.country === alhpa2Code;
-    })[0];
-    return country.entry.name;
-};
-
-module.exports = 
-    {
-        retrieveCountries: retrieveCountries,
-        translateAlpha2: translateAlpha2
-    };
+module.exports =
+{
+  retrieveCountries: retrieveCountries,
+  translateAlpha2: translateAlpha2
+}

--- a/app/services/environment.js
+++ b/app/services/environment.js
@@ -1,11 +1,9 @@
-/* jshint strict: false */
-
 module.exports = {
-	/**
-	 * Number of node workers in cluster
-	 * @return {Number} 
-	 */
-	getWorkerCount: function () {
-		return process.env.NODE_WORKER_COUNT || 1;
-	}
-};
+    /**
+     * Number of node workers in cluster
+     * @return {Number}
+     */
+  getWorkerCount: function () {
+    return process.env.NODE_WORKER_COUNT || 1
+  }
+}

--- a/app/services/normalise_cards.js
+++ b/app/services/normalise_cards.js
@@ -1,27 +1,25 @@
-/*jslint node: true */
-"use strict";
-var _ = require('lodash');
-module.exports = function(apiCards){
-  var normalised = _.reduce(apiCards, function(result, value) {
-    var entry = _.find(result, function(card) {
-      return card.brand === value.brand;
-    });
+/* jslint node: true */
+'use strict'
+var _ = require('lodash')
+module.exports = function (apiCards) {
+  var normalised = _.reduce(apiCards, function (result, value) {
+    var entry = _.find(result, function (card) {
+      return card.brand === value.brand
+    })
 
     if (!entry) {
       var normalisedCard = {
         brand: value.brand,
-        debit: value.type === "DEBIT",
-        credit: value.type === "CREDIT"
-      };
-      result.push(normalisedCard);
-      return result;
+        debit: value.type === 'DEBIT',
+        credit: value.type === 'CREDIT'
+      }
+      result.push(normalisedCard)
+      return result
     }
 
-    entry[value.type.toLowerCase()] = true;
-    return result;
-  }, []);
+    entry[value.type.toLowerCase()] = true
+    return result
+  }, [])
 
-  return  normalised;
-};
-
-
+  return normalised
+}

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -1,12 +1,12 @@
-var countries = require("../services/countries");
-var humps = require("humps");
-var normaliseCards = require('../services/normalise_cards.js');
-var _ = require('lodash');
+var countries = require('../services/countries')
+var humps = require('humps')
+var normaliseCards = require('../services/normalise_cards.js')
+var _ = require('lodash')
 
-module.exports = function() {
-  "use strict";
+module.exports = (function () {
+  'use strict'
 
-  var _charge = function(charge,chargeId) {
+  var _charge = function (charge, chargeId) {
     var chargeObj = {
       id: chargeId,
       amount: penceToPounds(charge.amount),
@@ -16,99 +16,99 @@ module.exports = function() {
       status: charge.status,
       email: charge.email,
       gatewayAccount: _normaliseGatewayAccountDetails(charge.gateway_account)
-    };
+    }
     if (charge.auth_3ds_data) {
-       chargeObj.auth3dsData = _normaliseAuth3dsData(charge.auth_3ds_data);
+      chargeObj.auth3dsData = _normaliseAuth3dsData(charge.auth_3ds_data)
     }
     if (charge.card_details) {
-       chargeObj.cardDetails = _normaliseConfirmationDetails(charge.card_details);
+      chargeObj.cardDetails = _normaliseConfirmationDetails(charge.card_details)
     }
-    return chargeObj;
-  },
+    return chargeObj
+  }
 
-  penceToPounds = function(pence) {
-    return (parseInt(pence) / 100).toFixed(2);
-  },
+  var penceToPounds = function (pence) {
+    return (parseInt(pence) / 100).toFixed(2)
+  }
 
-  addressForApi = function(body) {
+  var addressForApi = function (body) {
     return {
       line1: body.addressLine1,
       line2: body.addressLine2,
       city: body.addressCity,
       postcode: body.addressPostcode,
       country: body.addressCountry
-    };
-  },
-  // body is passed by reference
-  addressLines = function(body) {
-    if (!body.addressLine1 && body.addressLine2) {
-        body.addressLine1 = body.addressLine2;
-        delete body.addressLine2;
     }
-  },
-  whitespace = function(body){
+  }
+  // body is passed by reference
+  var addressLines = function (body) {
+    if (!body.addressLine1 && body.addressLine2) {
+      body.addressLine1 = body.addressLine2
+      delete body.addressLine2
+    }
+  }
+  var whitespace = function (body) {
     var toIgnore = [
       'submitCardDetails',
       'csrfToken',
       'chargeId'
-    ];
+    ]
 
-    _.forIn(body, function(value, key) {
+    _.forIn(body, function (value, key) {
       if (!_.includes(toIgnore, key)) {
-        body[key] = value.trim();
+        body[key] = value.trim()
       }
-    });
-  },
+    })
+  }
 
-  _normaliseConfirmationDetails = function(cardDetails){
-    cardDetails.cardNumber = '************' + cardDetails.last_digits_card_number;
-    delete cardDetails.last_digits_card_number;
-    var normalisedDetails = humps.camelizeKeys(cardDetails);
-    normalisedDetails.billingAddress = _normaliseAddress(cardDetails.billing_address);
-    return normalisedDetails;
-  },
+  var _normaliseConfirmationDetails = function (cardDetails) {
+    cardDetails.cardNumber = '************' + cardDetails.last_digits_card_number
+    delete cardDetails.last_digits_card_number
+    var normalisedDetails = humps.camelizeKeys(cardDetails)
+    normalisedDetails.billingAddress = _normaliseAddress(cardDetails.billing_address)
+    return normalisedDetails
+  }
 
-  _normaliseAddress = function(address) {
+  var _normaliseAddress = function (address) {
     return [address.line1,
       address.line2,
       address.city,
       address.postcode,
-      countries.translateAlpha2(address.country)].filter(function(str){return str;}).join(", ");
-  },
+      countries.translateAlpha2(address.country)].filter(function (str) { return str }).join(', ')
+  }
 
-  _normaliseGatewayAccountDetails = function (accountDetails) {
-    var gatewayAccountDetails = humps.camelizeKeys(accountDetails);
-    gatewayAccountDetails.cardTypes = normaliseCards(gatewayAccountDetails.cardTypes);
-    return gatewayAccountDetails;
-  },
+  var _normaliseGatewayAccountDetails = function (accountDetails) {
+    var gatewayAccountDetails = humps.camelizeKeys(accountDetails)
+    gatewayAccountDetails.cardTypes = normaliseCards(gatewayAccountDetails.cardTypes)
+    return gatewayAccountDetails
+  }
 
-  _normaliseAuth3dsData = function(auth3dsData) {
+  var _normaliseAuth3dsData = function (auth3dsData) {
     return {
       paRequest: auth3dsData.paRequest,
       issuerUrl: auth3dsData.issuerUrl
-    };
-  },
+    }
+  }
 
   // an empty string is equal to false in soft equality used by filter
-  addressForView = function(body) {
+  var addressForView = function (body) {
     return [body.addressLine1,
-        body.addressLine2,
-        body.addressCity,
-        body.addressPostcode,
-        countries.translateAlpha2(body.addressCountry)].filter(function(str){return str;}).join(", ");
-  },
+      body.addressLine2,
+      body.addressCity,
+      body.addressPostcode,
+      countries.translateAlpha2(body.addressCountry)].filter(function (str) { return str }).join(', ')
+  }
 
-  creditCard = function(creditCardNo) {
-    creditCardNo = (creditCardNo) ? creditCardNo : "";
-    return creditCardNo.replace(/\D/g,'');
-  },
+  var creditCard = function (creditCardNo) {
+    creditCardNo = (creditCardNo) || ''
+    return creditCardNo.replace(/\D/g, '')
+  }
 
-  expiryDate = function(month, year){
-    month = (month.length === 1) ? "0" + month : month;
-    return month.slice(-2) + "/" + year.slice(-2);
-  },
+  var expiryDate = function (month, year) {
+    month = (month.length === 1) ? '0' + month : month
+    return month.slice(-2) + '/' + year.slice(-2)
+  }
 
-  apiPayload = function(req, cardBrand){
+  var apiPayload = function (req, cardBrand) {
     return {
       'card_number': creditCard(req.body.cardNo),
       'cvc': req.body.cvc,
@@ -116,20 +116,20 @@ module.exports = function() {
       'expiry_date': expiryDate(req.body.expiryMonth, req.body.expiryYear),
       'cardholder_name': req.body.cardholderName,
       'address': addressForApi(req.body),
-      'accept_header': req.header("accept"),
-      'user_agent_header': req.header("user-agent")
-    };
-  },
+      'accept_header': req.header('accept'),
+      'user_agent_header': req.header('user-agent')
+    }
+  }
 
-  authUrl = function(charge){
-    var authLink = charge.links.find((link) => {return link.rel === 'cardAuth';});
-    return authLink.href;
-  },
+  var authUrl = function (charge) {
+    var authLink = charge.links.find((link) => { return link.rel === 'cardAuth' })
+    return authLink.href
+  }
 
-  chargeUrl = function(charge){
-    var selfLink = charge.links.find((link) => {return link.rel === 'self';});
-    return selfLink.href;
-  };
+  var chargeUrl = function (charge) {
+    var selfLink = charge.links.find((link) => { return link.rel === 'self' })
+    return selfLink.href
+  }
 
   return {
     charge: _charge,
@@ -142,8 +142,5 @@ module.exports = function() {
     apiPayload: apiPayload,
     authUrl: authUrl,
     chargeUrl: chargeUrl
-  };
-}();
-
-
-
+  }
+}())

--- a/app/services/state_service.js
+++ b/app/services/state_service.js
@@ -1,51 +1,49 @@
-var _ = require('lodash'),
-State = require('../models/state.js'),
-paths = require('../paths.js');
+var _ = require('lodash')
+var State = require('../models/state.js')
+var paths = require('../paths.js')
 
-module.exports = function () {
-  'use strict';
+module.exports = (function () {
+  'use strict'
 
   // The logic will always resolve to the first successful match.
   // Changing the order of the states might have side-effects
   var STATES = {
-    "card.new": [State.ENTERING_CARD_DETAILS, State.CREATED],
-    "card.confirm": [State.AUTH_SUCCESS],
-    "card.auth3dsRequired": [State.AUTH_3DS_REQUIRED],
-    "card.auth3dsRequiredIn": [State.AUTH_3DS_REQUIRED],
-    "card.auth3dsHandler": [State.AUTH_3DS_REQUIRED],
-    "card.auth3dsRequiredOut": [State.AUTH_3DS_REQUIRED],
-    "card.authWaiting": [State.AUTH_READY, State.AUTH_3DS_REQUIRED, State.AUTH_3DS_READY, State.AUTH_SUCCESS],
-    "card.create": [State.AUTH_READY, State.ENTERING_CARD_DETAILS],
-    "card.capture": [State.AUTH_SUCCESS],
-    "card.captureWaiting": [State.CAPTURE_READY, State.CAPTURE_SUBMITTED],
-    "card.cancel": [State.ENTERING_CARD_DETAILS, State.AUTH_SUCCESS]
-  };
+    'card.new': [State.ENTERING_CARD_DETAILS, State.CREATED],
+    'card.confirm': [State.AUTH_SUCCESS],
+    'card.auth3dsRequired': [State.AUTH_3DS_REQUIRED],
+    'card.auth3dsRequiredIn': [State.AUTH_3DS_REQUIRED],
+    'card.auth3dsHandler': [State.AUTH_3DS_REQUIRED],
+    'card.auth3dsRequiredOut': [State.AUTH_3DS_REQUIRED],
+    'card.authWaiting': [State.AUTH_READY, State.AUTH_3DS_REQUIRED, State.AUTH_3DS_READY, State.AUTH_SUCCESS],
+    'card.create': [State.AUTH_READY, State.ENTERING_CARD_DETAILS],
+    'card.capture': [State.AUTH_SUCCESS],
+    'card.captureWaiting': [State.CAPTURE_READY, State.CAPTURE_SUBMITTED],
+    'card.cancel': [State.ENTERING_CARD_DETAILS, State.AUTH_SUCCESS]
+  }
 
   var resolveStates = function (actionName) {
-    var states = STATES[actionName];
-    if (!states) throw new Error('Cannot find correct states for action');
-    return states;
-  };
+    var states = STATES[actionName]
+    if (!states) throw new Error('Cannot find correct states for action')
+    return states
+  }
 
   var resolveActionName = function (state, verb) {
+    var possibleActionNames = _.reduce(STATES, function (result, value, key) {
+      var hasState = _.includes(value, state)
+      if (hasState) result.push(key)
+      return result
+    }, [])
 
-    var possibleActionNames = _.reduce(STATES, function(result, value, key) {
-      var hasState = _.includes(value, state);
-      if (hasState) result.push(key);
-      return result;
-    }, []);
+    var validActionNames = _.filter(possibleActionNames, function (actionName) {
+      return _.result(paths, actionName).action === verb
+    })
 
-    var validActionNames = _.filter(possibleActionNames, function(actionName) {
-      return _.result(paths,actionName).action === verb;
-    });
+    if (validActionNames.length < 1) throw new Error(`No actionName found for state: ${state} and verb: ${verb}`)
 
-    if (validActionNames.length < 1) throw new Error(`No actionName found for state: ${state} and verb: ${verb}`);
-
-    return validActionNames[0];
-  };
+    return validActionNames[0]
+  }
   return {
     resolveStates: resolveStates,
     resolveActionName: resolveActionName
-  };
-}();
-
+  }
+}())

--- a/app/utils/analytics.js
+++ b/app/utils/analytics.js
@@ -1,33 +1,32 @@
-var _ = require('lodash');
-var paths = require('../paths.js');
+var _ = require('lodash')
+var paths = require('../paths.js')
 
 const ANALYTICS_ERROR = {
   analytics: {
-    analyticsId: "Service unavailable",
-    type: "Service unavailable",
-    paymentProvider: "Service unavailable"
+    analyticsId: 'Service unavailable',
+    type: 'Service unavailable',
+    paymentProvider: 'Service unavailable'
   }
-};
+}
 
-module.exports = function () {
-  'use strict';
+module.exports = (function () {
+  'use strict'
 
-  var withAnalytics = function(charge, param) {
-      return _.merge(
-        {
-          analytics: {
-            path: paths.generateRoute(`card.new`, {chargeId: charge.id }),
-            analyticsId: charge.gatewayAccount.analyticsId,
-            type: charge.gatewayAccount.type,
-            paymentProvider: charge.gatewayAccount.paymentProvider
-          }}, param);
-    },
-    withError = function() {
-      return _.clone(ANALYTICS_ERROR);
-    };
+  var withAnalytics = function (charge, param) {
+    return _.merge(
+      {
+        analytics: {
+          path: paths.generateRoute(`card.new`, {chargeId: charge.id}),
+          analyticsId: charge.gatewayAccount.analyticsId,
+          type: charge.gatewayAccount.type,
+          paymentProvider: charge.gatewayAccount.paymentProvider
+        }}, param)
+  }
+  var withError = function () {
+    return _.clone(ANALYTICS_ERROR)
+  }
   return {
     withAnalyticsError: withError,
     withAnalytics: withAnalytics
-  };
-}();
-
+  }
+}())

--- a/app/utils/base_client.js
+++ b/app/utils/base_client.js
@@ -1,26 +1,26 @@
-const urlParse = require('url');
-const https = require('https');
+const urlParse = require('url')
+const https = require('https')
+const path = require('path')
+const logger = require('winston')
 
-const logger = require('winston');
-
-const customCertificate = require(__dirname + '/custom_certificate');
-const CORRELATION_HEADER_NAME = require(__dirname + '/correlation_header').CORRELATION_HEADER;
+const customCertificate = require(path.join(__dirname, '/custom_certificate'))
+const CORRELATION_HEADER_NAME = require(path.join(__dirname, '/correlation_header')).CORRELATION_HEADER
 
 var agentOptions = {
   keepAlive: true,
   maxSockets: process.env.MAX_SOCKETS || 100
-};
+}
 
-if (process.env.DISABLE_INTERNAL_HTTPS !== "true") {
-  agentOptions.ca = customCertificate.getCertOptions();
+if (process.env.DISABLE_INTERNAL_HTTPS !== 'true') {
+  agentOptions.ca = customCertificate.getCertOptions()
 } else {
-  logger.warn('DISABLE_INTERNAL_HTTPS is set.');
+  logger.warn('DISABLE_INTERNAL_HTTPS is set.')
 }
 
 /**
  * @type {https.Agent}
  */
-const agent = new https.Agent(agentOptions);
+const agent = new https.Agent(agentOptions)
 
 /**
  *
@@ -33,12 +33,12 @@ const agent = new https.Agent(agentOptions);
  *
  * @private
  */
-var _request = function request(methodName, url, args, callback) {
-  const parsedUrl = urlParse.parse(url);
-  let headers = {};
+var _request = function request (methodName, url, args, callback) {
+  const parsedUrl = urlParse.parse(url)
+  let headers = {}
 
-  headers["Content-Type"] = "application/json";
-  headers[CORRELATION_HEADER_NAME] = args.correlationId;
+  headers['Content-Type'] = 'application/json'
+  headers[CORRELATION_HEADER_NAME] = args.correlationId
 
   const httpsOptions = {
     hostname: parsedUrl.hostname,
@@ -47,43 +47,42 @@ var _request = function request(methodName, url, args, callback) {
     method: methodName,
     agent: agent,
     headers: headers
-  };
+  }
 
   let req = https.request(httpsOptions, (res) => {
-    let data = '';
+    let data = ''
     res.on('data', (chunk) => {
-      data += chunk;
-    });
+      data += chunk
+    })
 
     res.on('end', () => {
       try {
-        data = JSON.parse(data);
-      } catch(e) {
-        //if response exists but is not parsable, log it and carry on
+        data = JSON.parse(data)
+      } catch (e) {
+        // if response exists but is not parsable, log it and carry on
         if (data) {
-          logger.info('Response from %s in unexpected format: %s', url, data);
+          logger.info('Response from %s in unexpected format: %s', url, data)
         }
-        data = null;
+        data = null
       }
-      callback(data, {statusCode: res.statusCode});
-    });
-  });
+      callback(data, {statusCode: res.statusCode})
+    })
+  })
 
   if (args.data) {
-    req.write(JSON.stringify(args.data));
+    req.write(JSON.stringify(args.data))
   }
 
   req.on('response', (response) => {
     response.on('readable', () => {
-      response.read();
-    });
-  });
+      response.read()
+    })
+  })
 
-  req.end();
+  req.end()
 
-  return req;
-};
-
+  return req
+}
 
 /*
  * @module baseClient
@@ -97,8 +96,8 @@ module.exports = {
    *
    * @returns {OutgoingMessage}
    */
-  get: function(url, args, callback) {
-    return _request('GET', url, args, callback);
+  get: function (url, args, callback) {
+    return _request('GET', url, args, callback)
   },
 
   /**
@@ -109,8 +108,8 @@ module.exports = {
    *
    * @returns {OutgoingMessage}
    */
-  post : function (url, args, callback) {
-    return _request('POST', url, args, callback);
+  post: function (url, args, callback) {
+    return _request('POST', url, args, callback)
   },
 
   /**
@@ -121,8 +120,8 @@ module.exports = {
    *
    * @returns {OutgoingMessage}
    */
-  put: function(url, args, callback) {
-    return _request('PUT', url, args, callback);
+  put: function (url, args, callback) {
+    return _request('PUT', url, args, callback)
   },
 
   /**
@@ -133,8 +132,8 @@ module.exports = {
    *
    * @returns {OutgoingMessage}
    */
-  patch: function(url, args, callback) {
-    return _request('PATCH', url, args, callback);
+  patch: function (url, args, callback) {
+    return _request('PATCH', url, args, callback)
   },
 
   /**
@@ -145,7 +144,7 @@ module.exports = {
    *
    * @returns {OutgoingMessage}
    */
-  delete: function(url, args, callback) {
-    return _request('DELETE', url, args, callback);
+  delete: function (url, args, callback) {
+    return _request('DELETE', url, args, callback)
   }
-};
+}

--- a/app/utils/cardid_client.js
+++ b/app/utils/cardid_client.js
@@ -1,6 +1,6 @@
-var baseClient = require("./base_client");
+var baseClient = require('./base_client')
 
-var cardUrl = process.env.CARDID_HOST + "/v1/api/card";
+var cardUrl = process.env.CARDID_HOST + '/v1/api/card'
 
 /*
  * @module cardIdClient
@@ -13,9 +13,9 @@ module.exports = {
    *
    * @returns {NodeRestClient}
    */
-  post: function(args, callBack) {
-    return baseClient.post(cardUrl, args, callBack);
+  post: function (args, callBack) {
+    return baseClient.post(cardUrl, args, callBack)
   },
 
   CARD_URL: cardUrl
-};
+}

--- a/app/utils/charge_utils.js
+++ b/app/utils/charge_utils.js
@@ -1,9 +1,9 @@
 module.exports = {
-    hashOutCardNumber: function (cardNumber) {
-        'use strict';
+  hashOutCardNumber: function (cardNumber) {
+    'use strict'
 
-        var hashedSize = cardNumber.length - 4;
-        var lastFour = cardNumber.substring(hashedSize);
-        return new Array(hashedSize + 1).join('*') + lastFour;
-    }
-};
+    var hashedSize = cardNumber.length - 4
+    var lastFour = cardNumber.substring(hashedSize)
+    return new Array(hashedSize + 1).join('*') + lastFour
+  }
+}

--- a/app/utils/charge_validation.js
+++ b/app/utils/charge_validation.js
@@ -1,101 +1,98 @@
-
-var chargeValidationFields = require('./charge_validation_fields');
-var changeCase  = require('change-case');
-var customError  = {
-  expiryYear:  {
+var chargeValidationFields = require('./charge_validation_fields')
+var changeCase = require('change-case')
+var customError = {
+  expiryYear: {
     skip: true
   },
-  expiryMonth:  {
-    cssKey: "expiry-date"
+  expiryMonth: {
+    cssKey: 'expiry-date'
   }
-};
+}
 
+module.exports = function (translations, logger, Card) {
+  'use strict'
+  var validations = chargeValidationFields(Card)
+  var fieldValidations = validations.fieldValidations
+  var requiredFields = validations.requiredFormFields
+  var optionalFields = validations.optionalFormFields
 
-module.exports = function(translations, logger, Card) {
-  'use strict';
-  var validations     = chargeValidationFields(Card);
-  var fieldValidations= validations.fieldValidations;
-  var requiredFields  = validations.requiredFormFields;
-  var optionalFields  = validations.optionalFormFields;
-
-  var creditCardType  = validations.creditCardType;
-  var verify = function(body) {
+  var creditCardType = validations.creditCardType
+  var verify = function (body) {
     var checkResult = {
       hasError: false,
       errorFields: [],
       highlightErrorFields: {}
-    },
+    }
 
-    init = function(){
-
-      var field;
-      for(var i=0; i < requiredFields.length; i++) {
-        field = requiredFields[i];
-        checkRequiredFormField(field, body[field]);
+    var init = function () {
+      var field
+      for (var i = 0; i < requiredFields.length; i++) {
+        field = requiredFields[i]
+        checkRequiredFormField(field, body[field])
       }
 
-      for(var j=0; j < optionalFields.length; j++) {
-        field = optionalFields[j];
-        if(body[field]) checkOptionalFormField(field, body[field]);
+      for (var j = 0; j < optionalFields.length; j++) {
+        field = optionalFields[j]
+        if (body[field]) checkOptionalFormField(field, body[field])
       }
 
-      if (checkResult.errorFields.length > 0) checkResult.hasError = true;
-      return checkResult;
-    },
+      if (checkResult.errorFields.length > 0) checkResult.hasError = true
+      return checkResult
+    }
 
-    checkRequiredFormField = function(name, value) {
-      var customValidation = checkFieldValidation(name, value);
-      if (value && customValidation === true) return;
-      var translation   = translations.fields[name],
-      highlightMessage  = translation.message,
-      problem           = !value ?  missing(name) : translation[customValidation];
+    var checkRequiredFormField = function (name, value) {
+      var customValidation = checkFieldValidation(name, value)
+      if (value && customValidation === true) return
+      var translation = translations.fields[name]
+      var highlightMessage = translation.message
+      var problem = !value ? missing(name) : translation[customValidation]
 
-      pushToErrorFields(name, problem);
-      pushToHighlightField(name, highlightMessage);
-    },
+      pushToErrorFields(name, problem)
+      pushToHighlightField(name, highlightMessage)
+    }
 
-    checkOptionalFormField = function(name, value) {
-      var customValidation = checkFieldValidation(name, value);
-      if (value && customValidation === true) return;
-      var translation   = translations.fields[name],
-        highlightMessage  = translation.message,
-        problem           = translation[customValidation];
+    var checkOptionalFormField = function (name, value) {
+      var customValidation = checkFieldValidation(name, value)
+      if (value && customValidation === true) return
+      var translation = translations.fields[name]
+      var highlightMessage = translation.message
+      var problem = translation[customValidation]
 
-      pushToErrorFields(name, problem);
-      pushToHighlightField(name, highlightMessage);
-    },
+      pushToErrorFields(name, problem)
+      pushToHighlightField(name, highlightMessage)
+    }
 
-    checkFieldValidation = function(name, value) {
-      return (fieldValidations[name]) ? fieldValidations[name].bind(fieldValidations)(value,body) : true;
-    },
+    var checkFieldValidation = function (name, value) {
+      return (fieldValidations[name]) ? fieldValidations[name].bind(fieldValidations)(value, body) : true
+    }
 
-    missing = function(name){
-      var translation = translations.fields[name];
-      return "Enter a valid " + translation.name;
-    },
+    var missing = function (name) {
+      var translation = translations.fields[name]
+      return 'Enter a valid ' + translation.name
+    }
 
-    pushToErrorFields = function(fieldName, problem) {
-      var custom = customError[fieldName];
-      var cssKey = changeCase.paramCase(fieldName);
+    var pushToErrorFields = function (fieldName, problem) {
+      var custom = customError[fieldName]
+      var cssKey = changeCase.paramCase(fieldName)
       if (custom) {
-        if (custom.skip) return;
-        if (custom.cssKey) cssKey = custom.cssKey;
+        if (custom.skip) return
+        if (custom.cssKey) cssKey = custom.cssKey
       }
 
       checkResult.errorFields.push({
         cssKey: cssKey,
         key: fieldName,
         value: problem
-      });
-    },
+      })
+    }
 
-    pushToHighlightField = function(fieldName, highlightMessage) {
-      var fields = checkResult.highlightErrorFields;
-      fields[fieldName] = highlightMessage;
-    };
+    var pushToHighlightField = function (fieldName, highlightMessage) {
+      var fields = checkResult.highlightErrorFields
+      fields[fieldName] = highlightMessage
+    }
 
-    return init();
-  };
+    return init()
+  }
 
   return {
     verify: verify,
@@ -104,6 +101,5 @@ module.exports = function(translations, logger, Card) {
     creditCardType: creditCardType,
     allowedCards: Card.allowed,
     cardNo: fieldValidations.cardNo
-  };
-
-};
+  }
+}

--- a/app/utils/charge_validation_backend.js
+++ b/app/utils/charge_validation_backend.js
@@ -1,50 +1,48 @@
-/*jslint node: true */
-"use strict";
+/* jslint node: true */
+'use strict'
 
-var chargeValidator = require('./charge_validation.js');
-var q               = require('q');
-var _               = require('lodash');
-var normalise       = require('../services/normalise_charge.js');
+var chargeValidator = require('./charge_validation.js')
+var q = require('q')
+var _ = require('lodash')
+var normalise = require('../services/normalise_charge.js')
 
-module.exports = function(translations, logger, cardModel) {
+module.exports = function (translations, logger, cardModel) {
   var validator = chargeValidator(
     translations,
     logger,
     cardModel
-  );
+  )
 
-  var verify = function(req) {
+  var verify = function (req) {
+    var logger = require('winston')
+    var defer = q.defer()
+    var validation = validator.verify(req.body)
+    cardModel.checkCard(normalise.creditCard(req.body.cardNo)).then(function (cardBrand) {
+      logger.debug('Card supported - ', {'cardBrand': cardBrand})
+      defer.resolve({validation: validation, cardBrand: cardBrand})
+    }, function (err) {
+      logger.error('Card not supported - ', {'err': err})
+      addCardnotSupportedError(validation, err)
+      defer.resolve({validation: validation})
+    })
 
-    var logger = require('winston');
-    var defer = q.defer();
-    var validation = validator.verify(req.body);
-    cardModel.checkCard(normalise.creditCard(req.body.cardNo)).then(function(cardBrand){
-      logger.debug("Card supported - ", {'cardBrand': cardBrand});
-      defer.resolve({validation: validation, cardBrand: cardBrand});
-    },function(err){
-      logger.error("Card not supported - ", {'err': err});
-      addCardnotSupportedError(validation, err);
-      defer.resolve({validation: validation});
-    });
+    return defer.promise
+  }
 
-    return defer.promise;
-  },
-
-  addCardnotSupportedError = function(validation,cardErrors){
-    validation.hasError  = true;
+  var addCardnotSupportedError = function (validation, cardErrors) {
+    validation.hasError = true
     _.remove(validation.errorFields, (errorField) => {
-      return errorField.cssKey === "card-no";
-    });
+      return errorField.cssKey === 'card-no'
+    })
     validation.errorFields.unshift({
-      "cssKey":"card-no",
-      "key":"cardNo",
-      "value": cardErrors
-    });
-    validation.highlightErrorFields.cardNo = cardErrors;
-  };
+      'cssKey': 'card-no',
+      'key': 'cardNo',
+      'value': cardErrors
+    })
+    validation.highlightErrorFields.cardNo = cardErrors
+  }
 
   return {
-    verify: verify,
-  };
-
-};
+    verify: verify
+  }
+}

--- a/app/utils/charge_validation_fields.js
+++ b/app/utils/charge_validation_fields.js
@@ -1,63 +1,63 @@
-var luhn = require('./luhn');
-var ukPostcode = require("uk-postcode");
-var creditCardType = require('credit-card-type');
-var rfc822Validator = require('rfc822-validate');
-var emailTools = require('./email_tools');
-var EMAIL_MAX_LENGTH = 254;
+var luhn = require('./luhn')
+var ukPostcode = require('uk-postcode')
+var creditCardType = require('credit-card-type')
+var rfc822Validator = require('rfc822-validate')
+var emailTools = require('./email_tools')
+var EMAIL_MAX_LENGTH = 254
 
-module.exports = function(Card){
-  "use strict";
+module.exports = function (Card) {
+  'use strict'
   var requiredFormFields = [
-    "cardNo",
-    "expiryMonth",
-    "expiryYear",
-    "cardholderName",
-    "cvc",
-    "addressLine1",
-    "addressCity",
-    "addressPostcode",
-    "email",
-    "addressCountry"
-  ];
+    'cardNo',
+    'expiryMonth',
+    'expiryYear',
+    'cardholderName',
+    'cvc',
+    'addressLine1',
+    'addressCity',
+    'addressPostcode',
+    'email',
+    'addressCountry'
+  ]
 
   var optionalFormFields = [
     'addressLine2'
-  ];
+  ]
 
-  var validateEmail = function(email) {
-    var validEmail = rfc822Validator(email),
-      domain;
+  var validateEmail = function (email) {
+    var validEmail = rfc822Validator(email)
+    var domain
 
     if (!validEmail) {
-      return "message";
+      return 'message'
     } else {
-      domain = emailTools(email).domain;
+      domain = emailTools(email).domain
       if (domain && domain.indexOf('.') === -1) {
-        return "message";
+        return 'message'
       }
-      return true;
-    }
-  };
-
-  function containsSuspectedCVV(input) {
-    if (typeof input === 'number' || typeof input === 'string') {
-      return /^\s*\d{3,4}\s*$/.test(String(input));
-    } else {
-      return false;
+      return true
     }
   }
 
-  function containsSuspectedPAN(input) {
+  function containsSuspectedCVV (input) {
     if (typeof input === 'number' || typeof input === 'string') {
-      var matchedDigits = String(input).match(/(\d)/g);
-      return (matchedDigits !== null) && (matchedDigits.length > 11) ;
+      return /^\s*\d{3,4}\s*$/.test(String(input))
     } else {
-      return false;
+      return false
     }
   }
 
-  function isValidPostcode(postcode, countryCode) {
-    return !(countryCode === "GB" && !ukPostcode.fromString(postcode).isComplete());
+  function containsSuspectedPAN (input) {
+    if (typeof input === 'number' || typeof input === 'string') {
+      var matchedDigits = String(input).match(/(\d)/g)
+      return (matchedDigits !== null) && (matchedDigits.length > 11)
+    } else {
+      return false
+    }
+  }
+
+  function isValidPostcode (postcode, countryCode) {
+    return !(countryCode === 'GB' && !ukPostcode.fromString(postcode).isComplete())
   }
 
   /*
@@ -69,92 +69,89 @@ module.exports = function(Card){
    */
 
   var fieldValidations = {
-    cardNo:  function(cardNo) {
-      if (!cardNo) return "message"; // default message
-      cardNo        = cardNo.replace(/\D/g,'');
-      var cardType  = creditCardType(cardNo);
-      var valid     = luhn.validate(cardNo);
-      if (!cardNo ||  cardNo.length < 12 || cardNo.length > 19) return 'number_incorrect_length';
-      if (!valid) return "luhn_invalid";
-      if(!cardType[0]) return "card_not_supported";
+    cardNo: function (cardNo) {
+      if (!cardNo) return 'message' // default message
+      cardNo = cardNo.replace(/\D/g, '')
+      var cardType = creditCardType(cardNo)
+      var valid = luhn.validate(cardNo)
+      if (!cardNo || cardNo.length < 12 || cardNo.length > 19) return 'number_incorrect_length'
+      if (!valid) return 'luhn_invalid'
+      if (!cardType[0]) return 'card_not_supported'
       for (var i = 0; i < this.allowedCards.length; i++) {
-        if (this.allowedCards[i].brand === cardType[0].type) return true;
+        if (this.allowedCards[i].brand === cardType[0].type) return true
       }
-      return "card_not_supported";
+      return 'card_not_supported'
     },
 
-
-    expiryMonth:  function(expiryMonth, allFields) {
-      var expiryYear = allFields.expiryYear;
-      if (expiryMonth === undefined || expiryMonth === "") return "message";
-      if (expiryYear  === undefined || expiryYear === "") return "message";
-
-
+    expiryMonth: function (expiryMonth, allFields) {
+      var expiryYear = allFields.expiryYear
+      if (expiryMonth === undefined || expiryMonth === '') return 'message'
+      if (expiryYear === undefined || expiryYear === '') return 'message'
 
       // month is zero indexed
-      expiryMonth = expiryMonth -1;
-      var isValidMonth = /^\d+$/.test(expiryMonth) && expiryMonth >= 0 && expiryMonth <= 11;
-      if (!isValidMonth) return "invalid_month";
+      expiryMonth = expiryMonth - 1
+      var isValidMonth = /^\d+$/.test(expiryMonth) && expiryMonth >= 0 && expiryMonth <= 11
+      if (!isValidMonth) return 'invalid_month'
       // validations are grouped for expiry month and year,
       // this is why both validations are happening in expiry month
       // can;t be renamed as it all runs off meta programming further up the stack
-      var isValidYear = (String(allFields.expiryYear).length === 2 || String(allFields.expiryYear).length === 4);
-      if (!isValidYear) return "invalid_year";
+      var isValidYear = (String(allFields.expiryYear).length === 2 || String(allFields.expiryYear).length === 4)
+      if (!isValidYear) return 'invalid_year'
 
-      var cardDate = allFields.expiryYear;
-      if (String(allFields.expiryYear).length === 2) cardDate = "20" + cardDate;
-      cardDate = new Date(cardDate,expiryMonth);
+      var cardDate = allFields.expiryYear
+      if (String(allFields.expiryYear).length === 2) cardDate = '20' + cardDate
+      cardDate = new Date(cardDate, expiryMonth)
 
-      var currentDate = new Date();
-      if (currentDate.getFullYear() > cardDate.getFullYear()) return "in_the_past";
+      var currentDate = new Date()
+      if (currentDate.getFullYear() > cardDate.getFullYear()) return 'in_the_past'
       if (currentDate.getFullYear() === cardDate.getFullYear() &&
-        currentDate.getMonth() > cardDate.getMonth()) return "in_the_past";
+        currentDate.getMonth() > cardDate.getMonth()) return 'in_the_past'
 
-      return true;
+      return true
     },
 
-    cvc: function(code) {
-      if(code === undefined) return "invalid_length";
-      code = code.replace(/\D/g,'');
+    cvc: function (code) {
+      if (code === undefined) return 'invalid_length'
+      code = code.replace(/\D/g, '')
       if (code.length === 3 || code.length === 4) {
-        return true;
+        return true
       }
-      return "invalid_length";
+      return 'invalid_length'
     },
 
-    addressPostcode: function(addressPostcode, allFields){
-      if (!isValidPostcode(addressPostcode, allFields.addressCountry)) return 'message';
-      if (containsSuspectedPAN(addressPostcode)) return 'contains_too_many_digits';
-      return true;
+    addressPostcode: function (addressPostcode, allFields) {
+      if (!isValidPostcode(addressPostcode, allFields.addressCountry)) return 'message'
+      if (containsSuspectedPAN(addressPostcode)) return 'contains_too_many_digits'
+      return true
     },
 
-    email: function(email){
-      if (email && email.length > EMAIL_MAX_LENGTH) return "invalid_length";
-      if (containsSuspectedPAN(email)) return 'contains_too_many_digits';
-      return validateEmail(email);
+    email: function (email) {
+      if (email && email.length > EMAIL_MAX_LENGTH) return 'invalid_length'
+      if (containsSuspectedPAN(email)) return 'contains_too_many_digits'
+      return validateEmail(email)
     },
 
-    cardholderName: function(name) {
-      if (containsSuspectedPAN(name)) return 'contains_too_many_digits';
-      if (containsSuspectedCVV(name)) return 'contains_suspected_cvv';
-      return true;
+    cardholderName: function (name) {
+      if (containsSuspectedPAN(name)) return 'contains_too_many_digits'
+      if (containsSuspectedCVV(name)) return 'contains_suspected_cvv'
+      return true
     },
 
-    addressLine1: function(addressLine) {
-      return !containsSuspectedPAN(addressLine) || 'contains_too_many_digits';
+    addressLine1: function (addressLine) {
+      return !containsSuspectedPAN(addressLine) || 'contains_too_many_digits'
     },
 
-    addressLine2: function(addressLine) {
-      return !containsSuspectedPAN(addressLine) || 'contains_too_many_digits';
+    addressLine2: function (addressLine) {
+      return !containsSuspectedPAN(addressLine) || 'contains_too_many_digits'
     },
 
-    addressCity: function(townCity) {
-      return !containsSuspectedPAN(townCity) || 'contains_too_many_digits';
+    addressCity: function (townCity) {
+      return !containsSuspectedPAN(townCity) || 'contains_too_many_digits'
     },
 
     creditCardType: creditCardType,
     allowedCards: Card.allowed
-  };
+  }
 
   return {
     creditCardType: creditCardType,
@@ -162,6 +159,5 @@ module.exports = function(Card){
     requiredFormFields: requiredFormFields,
     fieldValidations: fieldValidations,
     optionalFormFields: optionalFormFields
-  };
-
-};
+  }
+}

--- a/app/utils/cookies.js
+++ b/app/utils/cookies.js
@@ -1,8 +1,8 @@
-const clientSessions = require("client-sessions");
+const clientSessions = require('client-sessions')
 
-const SESSION_COOKIE_NAME_1 = 'frontend_state';
-const SESSION_COOKIE_NAME_2 = 'frontend_state_2';
-const KEY_MIN_LENGTH = 10;
+const SESSION_COOKIE_NAME_1 = 'frontend_state'
+const SESSION_COOKIE_NAME_2 = 'frontend_state_2'
+const KEY_MIN_LENGTH = 10
 
 /**
  * @private
@@ -12,9 +12,9 @@ const KEY_MIN_LENGTH = 10;
  * @param {*} value
  * @param {string} cookieName
  */
-function setValueOnCookie(req, key, value, cookieName) {
-  if(typeof req[cookieName] === 'object') {
-    req[cookieName][key] = value;
+function setValueOnCookie (req, key, value, cookieName) {
+  if (typeof req[cookieName] === 'object') {
+    req[cookieName][key] = value
   }
 }
 
@@ -24,8 +24,8 @@ function setValueOnCookie(req, key, value, cookieName) {
  * @param {string} key
  * @returns {boolean}
  */
-function isValidKey(key) {
-  return !!key && typeof key === 'string' && key.length > KEY_MIN_LENGTH;
+function isValidKey (key) {
+  return !!key && typeof key === 'string' && key.length > KEY_MIN_LENGTH
 }
 
 /**
@@ -37,7 +37,7 @@ function isValidKey(key) {
  *
  * @returns {object}
  * */
-function namedCookie(name, key) {
+function namedCookie (name, key) {
   return {
     cookieName: name,
     proxy: true,
@@ -45,9 +45,9 @@ function namedCookie(name, key) {
     cookie: {
       maxAge: parseInt(process.env.COOKIE_MAX_AGE),
       httpOnly: true,
-      secureProxy: (process.env.SECURE_COOKIE_OFF !== "true") // default is true, only false if the env variable present
+      secureProxy: (process.env.SECURE_COOKIE_OFF !== 'true') // default is true, only false if the env variable present
     }
-  };
+  }
 }
 
 /**
@@ -57,24 +57,24 @@ function namedCookie(name, key) {
  *
  * @param {Express.App} app
  */
-function configureSessionCookie(app) {
-  let key1 = process.env.SESSION_ENCRYPTION_KEY;
-  let key2 = process.env.SESSION_ENCRYPTION_KEY_2;
+function configureSessionCookie (app) {
+  let key1 = process.env.SESSION_ENCRYPTION_KEY
+  let key2 = process.env.SESSION_ENCRYPTION_KEY_2
 
   if (!isValidKey(key1) && !isValidKey(key2)) {
-    throw new Error('cookie encryption key is not set');
+    throw new Error('cookie encryption key is not set')
   }
 
   if (process.env.COOKIE_MAX_AGE === undefined) {
-    throw new Error('cookie max age is not set');
+    throw new Error('cookie max age is not set')
   }
 
   if (isValidKey(key1)) {
-    app.use(clientSessions(namedCookie(SESSION_COOKIE_NAME_1, key1)));
+    app.use(clientSessions(namedCookie(SESSION_COOKIE_NAME_1, key1)))
   }
 
   if (isValidKey(key2)) {
-    app.use(clientSessions(namedCookie(SESSION_COOKIE_NAME_2, key2)));
+    app.use(clientSessions(namedCookie(SESSION_COOKIE_NAME_2, key2)))
   }
 }
 
@@ -85,13 +85,13 @@ function configureSessionCookie(app) {
  *
  * @returns {string}
  */
-function getSessionCookieName() {
+function getSessionCookieName () {
   if (isValidKey(process.env.SESSION_ENCRYPTION_KEY)) {
-    return SESSION_COOKIE_NAME_1;
+    return SESSION_COOKIE_NAME_1
   }
 
   if (isValidKey(process.env.SESSION_ENCRYPTION_KEY_2)) {
-    return SESSION_COOKIE_NAME_2;
+    return SESSION_COOKIE_NAME_2
   }
 }
 
@@ -103,13 +103,13 @@ function getSessionCookieName() {
  * @param {string} key
  * @param {*} value
  */
-function setSessionVariable(req, key, value) {
-  if (!!process.env.SESSION_ENCRYPTION_KEY) {
-    setValueOnCookie(req, key, value, SESSION_COOKIE_NAME_1);
+function setSessionVariable (req, key, value) {
+  if (process.env.SESSION_ENCRYPTION_KEY) {
+    setValueOnCookie(req, key, value, SESSION_COOKIE_NAME_1)
   }
 
-  if (!!process.env.SESSION_ENCRYPTION_KEY_2) {
-    setValueOnCookie(req, key, value, SESSION_COOKIE_NAME_2);
+  if (process.env.SESSION_ENCRYPTION_KEY_2) {
+    setValueOnCookie(req, key, value, SESSION_COOKIE_NAME_2)
   }
 }
 
@@ -120,10 +120,10 @@ function setSessionVariable(req, key, value) {
  * @param {string} key
  * @returns {*}
  */
-function getSessionVariable(req, key) {
-  let session = req[getSessionCookieName()];
+function getSessionVariable (req, key) {
+  let session = req[getSessionCookieName()]
 
-  return session && session[key];
+  return session && session[key]
 }
 
 module.exports = {
@@ -132,4 +132,4 @@ module.exports = {
   setSessionVariable: setSessionVariable,
   getSessionVariable: getSessionVariable,
   namedCookie: namedCookie
-};
+}

--- a/app/utils/correlation_header.js
+++ b/app/utils/correlation_header.js
@@ -1,4 +1,1 @@
-module.exports.CORRELATION_HEADER  = 'x-request-id';
-
-
-
+module.exports.CORRELATION_HEADER = 'x-request-id'

--- a/app/utils/custom_certificate.js
+++ b/app/utils/custom_certificate.js
@@ -1,34 +1,33 @@
-var path = require('path');
-var fs   = require('fs');
+var path = require('path')
+var fs = require('fs')
 
-var logger = require('winston');
+var logger = require('winston')
 
 module.exports = {
   getCertOptions: function () {
-    var certsPath = process.env.CERTS_PATH || __dirname + '/../../certs';
+    var certsPath = process.env.CERTS_PATH || path.join(__dirname, '/../../certs')
 
     try {
       if (!fs.lstatSync(certsPath).isDirectory()) {
         logger.error('Provided CERTS_PATH is not a directory', {
           certsPath: certsPath
-        });
-        return;
+        })
+        return
       }
-    }
-    catch (e) {
+    } catch (e) {
       logger.error('Provided CERTS_PATH could not be read', {
         certsPath: certsPath
-      });
-      return;
+      })
+      return
     }
 
-    var ca = [];
-    var certs = fs.readdirSync(certsPath).forEach(
-      (certPath) => ca.push(
+    var ca = []
+    fs.readdirSync(certsPath).forEach(
+      certPath => ca.push(
         fs.readFileSync(path.join(certsPath, certPath))
       )
-    );
+    )
 
-    return ca;
+    return ca
   }
-};
+}

--- a/app/utils/email_tools.js
+++ b/app/utils/email_tools.js
@@ -2,39 +2,39 @@
    We use rfc822-validate in our email validation
    so this follows that standard. */
 
-var emailTools = function(email) {
-  "use strict";
+var emailTools = function (email) {
+  'use strict'
 
-  var init = function() {
-    var sQtext = '[^\\x0d\\x22\\x5c\\x80-\\xff]';
-    var sDtext = '[^\\x0d\\x5b-\\x5d\\x80-\\xff]';
-    var sAtom = '[^\\x00-\\x20\\x22\\x28\\x29\\x2c\\x2e\\x3a-\\x3c\\x3e\\x40\\x5b-\\x5d\\x7f-\\xff]+';
-    var sQuotedPair = '\\x5c[\\x00-\\x7f]';
-    var sDomainLiteral = '\\x5b(' + sDtext + '|' + sQuotedPair + ')*\\x5d';
-    var sQuotedString = '\\x22(' + sQtext + '|' + sQuotedPair + ')*\\x22';
-    var sDomain_ref = sAtom;
-    var sSubDomain = '(' + sDomain_ref + '|' + sDomainLiteral + ')';
-    var sWord = '(' + sAtom + '|' + sQuotedString + ')';
-    var sDomain = sSubDomain + '(\\x2e' + sSubDomain + ')*';
-    var sLocalPart = sWord + '(\\x2e' + sWord + ')*';
-    var sAddrSpec = '(' + sLocalPart + ')' + '\\x40' + '(' + sDomain + ')'; // complete RFC822 email address spec
-    var sValidEmail = '^' + sAddrSpec + '$'; // as whole string
+  var init = (function () {
+    var sQtext = '[^\\x0d\\x22\\x5c\\x80-\\xff]'
+    var sDtext = '[^\\x0d\\x5b-\\x5d\\x80-\\xff]'
+    var sAtom = '[^\\x00-\\x20\\x22\\x28\\x29\\x2c\\x2e\\x3a-\\x3c\\x3e\\x40\\x5b-\\x5d\\x7f-\\xff]+'
+    var sQuotedPair = '\\x5c[\\x00-\\x7f]'
+    var sDomainLiteral = '\\x5b(' + sDtext + '|' + sQuotedPair + ')*\\x5d'
+    var sQuotedString = '\\x22(' + sQtext + '|' + sQuotedPair + ')*\\x22'
+    var sDomainRef = sAtom
+    var sSubDomain = '(' + sDomainRef + '|' + sDomainLiteral + ')'
+    var sWord = '(' + sAtom + '|' + sQuotedString + ')'
+    var sDomain = sSubDomain + '(\\x2e' + sSubDomain + ')*'
+    var sLocalPart = sWord + '(\\x2e' + sWord + ')*'
+    var sAddrSpec = '(' + sLocalPart + ')' + '\\x40' + '(' + sDomain + ')' // complete RFC822 email address spec
+    var sValidEmail = '^' + sAddrSpec + '$' // as whole string
 
-    var reValidEmail = new RegExp(sValidEmail);
+    var reValidEmail = new RegExp(sValidEmail)
 
     var f = function (email) {
-      return reValidEmail.exec(email);
-    };
+      return reValidEmail.exec(email)
+    }
 
-    return f;
-  }();
+    return f
+  }())
 
-  var match = init(email);
+  var match = init(email)
 
   return {
     'local-part': (match !== null) ? match[1] : false,
     'domain': (match !== null) ? match[7] : false
-  };
-};
+  }
+}
 
-module.exports = emailTools;
+module.exports = emailTools

--- a/app/utils/flattened_paths.js
+++ b/app/utils/flattened_paths.js
@@ -1,24 +1,24 @@
 // this is to get a one dimensional array of the routes,
 // so we can infer the pathname from the req route path
 
-  module.exports = function(paths){
-  'use strict';
+  module.exports = function (paths) {
+    'use strict'
 
-  var flattenObject = function(paths) {
-    var flattenedPaths = {};
-    for (var controllerName in paths) {
-      if(paths.hasOwnProperty(controllerName)) {
-        var controller = paths[controllerName];
-        if (typeof controller !== 'object') continue;
-        for (var actionName in controller) {
-          if (controller.hasOwnProperty(actionName)) {
-            var action = controller[actionName];
-            flattenedPaths[action.path + "_" + action.action] = `${controllerName}.${actionName}`;
+    var flattenObject = function (paths) {
+      var flattenedPaths = {}
+      for (var controllerName in paths) {
+        if (paths.hasOwnProperty(controllerName)) {
+          var controller = paths[controllerName]
+          if (typeof controller !== 'object') continue
+          for (var actionName in controller) {
+            if (controller.hasOwnProperty(actionName)) {
+              var action = controller[actionName]
+              flattenedPaths[action.path + '_' + action.action] = `${controllerName}.${actionName}`
+            }
           }
         }
       }
+      return flattenedPaths
     }
-    return flattenedPaths;
-  };
-  return flattenObject(paths);
-};
+    return flattenObject(paths)
+  }

--- a/app/utils/generate_route.js
+++ b/app/utils/generate_route.js
@@ -1,36 +1,36 @@
-var _             = require('lodash');
-var querystring   = require('querystring');
+var _ = require('lodash')
+var querystring = require('querystring')
 
-module.exports = function(paths) {
-  'use strict';
+module.exports = function (paths) {
+  'use strict'
 
-  return function(actionName, params) {
-    var route = _.result(paths,actionName).path,
-      copiedParams = _.cloneDeep(params);
+  return function (actionName, params) {
+    var route = _.result(paths, actionName).path
+    var copiedParams = _.cloneDeep(params)
 
-    var init = function(){
-      _.forEach(copiedParams,checkNamedParams);
-      var query = constructQueryString();
-      return route + query;
-    };
+    var init = function () {
+      _.forEach(copiedParams, checkNamedParams)
+      var query = constructQueryString()
+      return route + query
+    }
 
-    var checkNamedParams = function(value,key){
-      var hasNamedParam = route.indexOf(":" + key) !== -1;
-      if (!hasNamedParam) return;
-      replaceAndDeleteNamedParam(key,value);
-    };
+    var checkNamedParams = function (value, key) {
+      var hasNamedParam = route.indexOf(':' + key) !== -1
+      if (!hasNamedParam) return
+      replaceAndDeleteNamedParam(key, value)
+    }
 
-    var replaceAndDeleteNamedParam = function(key,value) {
-      route = route.replace(":" + key,value);
-      delete copiedParams[key];
-    };
+    var replaceAndDeleteNamedParam = function (key, value) {
+      route = route.replace(':' + key, value)
+      delete copiedParams[key]
+    }
 
-    var constructQueryString = function(){
-      var validParams = _.omitBy(copiedParams,_.isEmpty,_.isUndefined);
-      if (Object.keys(validParams).length === 0) return "";
-      return ["?", querystring.stringify(validParams)].join("");
-    };
+    var constructQueryString = function () {
+      var validParams = _.omitBy(copiedParams, _.isEmpty, _.isUndefined)
+      if (Object.keys(validParams).length === 0) return ''
+      return ['?', querystring.stringify(validParams)].join('')
+    }
 
-    return init();
-  };
-};
+    return init()
+  }
+}

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -1,36 +1,36 @@
-/*jslint node: true */
-"use strict";
-var logger = require('winston');
+/* jslint node: true */
+'use strict'
+var logger = require('winston')
 module.exports = {
 
-  authChargePost: function(url){
-    logger.debug("Calling connector to authorize a charge (post card details) -", {
+  authChargePost: function (url) {
+    logger.debug('Calling connector to authorize a charge (post card details) -', {
       service: 'connector',
       method: 'POST',
       url: url
-    });
+    })
   },
-  failedChargePost: function(status,url){
+  failedChargePost: function (status, url) {
     logger.warn('Calling connector to authorize a charge (post card details) failed -', {
       service: 'connector',
       method: 'POST',
       status: status,
       url: url
-    });
+    })
   },
 
-  failedChargePostException: function(err){
+  failedChargePostException: function (err) {
     logger.error('Calling connector to authorize a charge (post card details) threw exception -', {
       service: 'connector',
       method: 'POST',
       error: err
-    });
+    })
   },
-  failedChargePatch: function(err){
+  failedChargePatch: function (err) {
     logger.warn('Calling connector to patch a charge failed -', {
       service: 'connector',
       method: 'POST',
       err: err
-    });
+    })
   }
-};
+}

--- a/app/utils/luhn.js
+++ b/app/utils/luhn.js
@@ -1,49 +1,47 @@
-/* jshint ignore:start */
 // COPIED OVER FROM NODE_LUHN
 // https://github.com/JamesEggers1/node-luhn/issues/12
-"use strict";
-module.exports = (function(){
-    function validate(cardNumber){
-        var trimmed = String(cardNumber).replace(/[\s]/g, "")
-            , length = trimmed.length
-            , odd = false
-            , total = 0
-            , calc
-            , calc2;
+'use strict'
+module.exports = (function () {
+  function validate (cardNumber) {
+    var trimmed = String(cardNumber).replace(/[\s]/g, '')
+    var length = trimmed.length
+    var odd = false
+    var total = 0
+    var calc
+    var calc2
 
-            if (length === 0){
-                return true;
-            }
+    if (length === 0) {
+      return true
+    }
 
-            if (!/^[0-9]+$/.test(trimmed)) {
-                return false;
-            }
+    if (!/^[0-9]+$/.test(trimmed)) {
+      return false
+    }
 
-            for (var i = length; i > 0; i--) {
-                calc = parseInt(trimmed.charAt(i - 1));
-                if (!odd) {
-                    total += calc;
-                } else {
-                    calc2 = calc * 2;
+    for (var i = length; i > 0; i--) {
+      calc = parseInt(trimmed.charAt(i - 1))
+      if (!odd) {
+        total += calc
+      } else {
+        calc2 = calc * 2
 
-                    switch (calc2) {
-                    case 10: calc2 = 1; break;
-                    case 12: calc2 = 3; break;
-                    case 14: calc2 = 5; break;
-                    case 16: calc2 = 7; break;
-                    case 18: calc2 = 9; break;
-                    default: calc2 = calc2;
-                    }
-                    total += calc2;
-                }
-                odd = !odd;
-            }
-
-            return ((total % 10) === 0);
+        switch (calc2) {
+          case 10: calc2 = 1; break
+          case 12: calc2 = 3; break
+          case 14: calc2 = 5; break
+          case 16: calc2 = 7; break
+          case 18: calc2 = 9; break
+          default: calc2 = calc2 // eslint-disable-line
         }
+        total += calc2
+      }
+      odd = !odd
+    }
 
-        return {
-            validate: validate
-        };
-} ());
-/* jshint ignore:end */
+    return ((total % 10) === 0)
+  }
+
+  return {
+    validate: validate
+  }
+}())

--- a/app/utils/metrics.js
+++ b/app/utils/metrics.js
@@ -1,20 +1,19 @@
-/*jslint node: true */
-"use strict";
-var appmetrics = require('appmetrics');
-var metricsHost = process.env.METRICS_HOST || "localhost";
-var metricsPort = process.env.METRICS_PORT || 8125;
-var metricsPrefix = "frontend.";
+/* jslint node: true */
+'use strict'
+var appmetrics = require('appmetrics')
+var metricsHost = process.env.METRICS_HOST || 'localhost'
+var metricsPort = process.env.METRICS_PORT || 8125
+var metricsPrefix = 'frontend.'
 
 function initialiseMonitoring () {
-  appmetrics.configure({'mqtt':'off'});
-  var appmetricsStatsd = require('appmetrics-statsd');
+  appmetrics.configure({'mqtt': 'off'})
+  var appmetricsStatsd = require('appmetrics-statsd')
 
-  return appmetricsStatsd.StatsD(null, metricsHost, metricsPort, metricsPrefix);
+  return appmetricsStatsd.StatsD(null, metricsHost, metricsPort, metricsPrefix)
 }
 
-module.exports = function() {
-
+module.exports = (function () {
   return {
-    metrics: initialiseMonitoring()
-  };
-}();
+    metrics: initialiseMonitoring
+  }
+}())

--- a/app/utils/no_cache.js
+++ b/app/utils/no_cache.js
@@ -1,7 +1,7 @@
-module.exports = function(res){
-  'use strict';
-  
-  res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
-  res.header('Expires', '-1');
-  res.header('Pragma', 'no-cache');
-};
+module.exports = function (res) {
+  'use strict'
+
+  res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate')
+  res.header('Expires', '-1')
+  res.header('Pragma', 'no-cache')
+}

--- a/app/utils/session.js
+++ b/app/utils/session.js
@@ -1,19 +1,16 @@
-var cookie = require('../utils/cookies');
+'use strict'
 
-module.exports = function() {
-  'use strict';
+var cookie = require('../utils/cookies')
 
-  var createChargeIdSessionKey = function(chargeId) {
-    return 'ch_' + chargeId;
-  },
-
-  retrieve = function(req, chargeId) {
-    return cookie.getSessionVariable(req, createChargeIdSessionKey(chargeId));
-  };
-
-
+module.exports = (function () {
+  var createChargeIdSessionKey = function (chargeId) {
+    return 'ch_' + chargeId
+  }
+  var retrieve = function (req, chargeId) {
+    return cookie.getSessionVariable(req, createChargeIdSessionKey(chargeId))
+  }
   return {
     retrieve: retrieve,
     createChargeIdSessionKey: createChargeIdSessionKey
-  };
-}();
+  }
+}())

--- a/app/utils/views.js
+++ b/app/utils/views.js
@@ -1,230 +1,229 @@
-var logger  = require('winston');
-var _       = require('lodash');
+var logger = require('winston')
+var _ = require('lodash')
 
-
-module.exports = function() {
-  'use strict';
+module.exports = (function () {
+  'use strict'
 
   var expired = {
-      view: "errors/incorrect_state/session_expired",
-      analyticsPage: "/session_expired"
-    },
-    systemCancelled = {
-      view: "errors/incorrect_state/system_cancelled",
-      analyticsPage: "/system_cancelled"
-    },
+    view: 'errors/incorrect_state/session_expired',
+    analyticsPage: '/session_expired'
+  }
 
-    userCancelled = {
-      view: "user_cancelled",
-      locals: { status: 'successful' },
-      analyticsPage: "/user_cancelled"
-    },
+  var systemCancelled = {
+    view: 'errors/incorrect_state/system_cancelled',
+    analyticsPage: '/system_cancelled'
+  }
 
-    systemError = {
-      code: 500,
-      view: 'errors/system_error',
-      analyticsPage: "/error"
-    },
+  var userCancelled = {
+    view: 'user_cancelled',
+    locals: { status: 'successful' },
+    analyticsPage: '/user_cancelled'
+  }
 
-    error = {
+  var systemError = {
+    code: 500,
+    view: 'errors/system_error',
+    analyticsPage: '/error'
+  }
+
+  var error = {
+    code: 500,
+    view: 'error',
+    locals: {
+      message: 'There is a problem, please try again later'
+    },
+    analyticsPage: '/error'
+  }
+
+  var _default = {
+    auth_3ds_required: {
+      view: 'auth_3ds_required',
+      analyticsPage: '/3ds_required'
+    },
+    auth_3ds_required_in: {
+      view: 'auth_3ds_required_in',
+      analyticsPage: '/3ds_required'
+    },
+    auth_3ds_required_out: {
+      view: 'auth_3ds_required_out',
+      analyticsPage: '/3ds_required'
+    },
+    auth_waiting: {
+      view: 'auth_waiting',
+      analyticsPage: '/auth_waiting'
+    },
+    confirm: {
+      view: 'confirm',
+      analyticsPage: '/confirm'
+    },
+    charge: {
+      view: 'charge'
+    },
+    capture_waiting: {
+      view: 'capture_waiting',
+      analyticsPage: '/capture_waiting'
+    },
+    NOT_FOUND: {
+      code: 404,
+      view: 'error',
+      locals: {
+        message: 'Page cannot be found'
+      }
+    },
+    ERROR: {
       code: 500,
       view: 'error',
       locals: {
         message: 'There is a problem, please try again later'
-      },
-      analyticsPage: "/error"
-    },
-
-    _default = {
-      auth_3ds_required: {
-        view: "auth_3ds_required",
-        analyticsPage: "/3ds_required"
-      },
-      auth_3ds_required_in: {
-        view: "auth_3ds_required_in",
-        analyticsPage: "/3ds_required"
-      },
-      auth_3ds_required_out: {
-        view: "auth_3ds_required_out",
-        analyticsPage: "/3ds_required"
-      },
-      auth_waiting: {
-        view: "auth_waiting",
-        analyticsPage: "/auth_waiting"
-      },
-      confirm: {
-        view: "confirm",
-        analyticsPage: "/confirm"
-      },
-      charge: {
-        view: "charge"
-      },
-      capture_waiting: {
-        view: "capture_waiting",
-        analyticsPage: "/capture_waiting"
-      },
-      NOT_FOUND: {
-        code: 404,
-        view: 'error',
-        locals: {
-          message: "Page cannot be found"
-        }
-      },
-      ERROR: {
-        code: 500,
-        view: 'error',
-        locals: {
-          message: 'There is a problem, please try again later'
-        }
-      },
-
-      SESSION_INCORRECT: {
-        code: 422,
-        view: "errors/incorrect_state/session_expired",
-        analyticsPage: "/problem"
-      },
-
-      SYSTEM_ERROR: systemError,
-
-      NAXSI_SYSTEM_ERROR: {
-        code: 400,
-        view: 'error',
-        locals: {
-          message: "Please try again later"
-        }
-      },
-
-      HUMANS: {
-        code: 200,
-        view: 'plain_message',
-        locals: {
-          message: "GOV.UK Payments is built by a team at the Government Digital Service in London. If you'd like to join us, see https://gds.blog.gov.uk/jobs"
-        }
-      },
-
-      UNAUTHORISED: {
-        code: 403,
-        view: 'errors/system_error'
-      },
-
-      CAPTURE_SUBMITTED: {
-        view: "errors/charge_confirm_state_completed",
-        locals: {status: 'successful'},
-        analyticsPage: "/success_return"
-      },
-
-      CREATED: error,
-
-      EXPIRED: expired,
-
-      EXPIRE_CANCEL_READY: expired,
-
-      EXPIRE_CANCEL_FAILED: expired,
-
-      SYSTEM_CANCELLED: systemCancelled,
-
-      SYSTEM_CANCEL_READY: systemCancelled,
-
-      SYSTEM_CANCEL_ERROR: systemCancelled,
-
-      USER_CANCELLED: userCancelled,
-
-      USER_CANCEL_READY: userCancelled,
-
-      USER_CANCEL_ERROR: userCancelled,
-
-      CAPTURED: {
-        view: "errors/charge_confirm_state_completed",
-        locals: {status: 'successful'},
-        analyticsPage: "/success_return"
-      },
-
-      CAPTURE_APPROVED: {
-        view: "errors/charge_confirm_state_completed",
-        locals: {status: 'successful'},
-        analyticsPage: "/success_return"
-      },
-
-      CAPTURE_APPROVED_RETRY: {
-        view: "errors/charge_confirm_state_completed",
-        locals: {status: 'successful'},
-        analyticsPage: "/success_return"
-      },
-
-      CAPTURE_ERROR: {
-        view: "errors/incorrect_state/capture_failure",
-        analyticsPage: "/capture_failure"
-      },
-
-      CAPTURE_FAILURE: {
-        view: "errors/incorrect_state/capture_failure",
-        analyticsPage: "/capture_failure"
-      },
-
-      AUTHORISATION_3DS_REQUIRED: {
-        view: "errors/incorrect_state/auth_3ds_required",
-        analyticsPage: "/3ds_required"
-      },
-
-      AUTHORISATION_SUCCESS: {
-        view: "errors/incorrect_state/auth_success",
-        analyticsPage: "/in_progress"
-      },
-
-      AUTHORISATION_REJECTED: {
-        view: "errors/incorrect_state/auth_failure",
-        analyticsPage: "/auth_failure"
-      },
-
-      AUTHORISATION_CANCELLED: {
-        view: "errors/incorrect_state/auth_failure",
-        analyticsPage: "/auth_failure"
-      },
-
-      AUTHORISATION_ERROR: {
-        view: "errors/system_error",
-        analyticsPage: "/error"
-      },
-
-      AUTHORISATION_READY: {
-        view: "errors/incorrect_state/auth_waiting",
-        analyticsPage: "/in_progress"
-      },
-
-      CAPTURE_READY: {
-        view: "errors/incorrect_state/capture_waiting",
-        analyticsPage: "/in_progress"
-      },
-
-      ENTERING_CARD_DETAILS: systemError,
-
-      display: function(res, resName, locals) {
-        var action = _.result(this, resName);
-        var status;
-        locals = locals || {};
-        locals.viewName = resName;
-        if (!action) {
-          logger.error("VIEW " + resName + " NOT FOUND");
-          locals = { viewName: 'error' };
-          action = this.ERROR;
-        }
-        locals = (action.locals) ? _.merge({}, action.locals, locals) : locals;
-
-        if (_.get(locals, 'analytics.path')) {
-          locals.analytics.path = locals.analytics.path + _.get(action, 'analyticsPage', '');
-        }
-        status = (action.code) ? action.code : 200;
-        res.status(status);
-        res.render(action.view,locals);
       }
     },
 
-    create = function(localViews) {
-      return _.merge({},_default,localViews);
-    };
+    SESSION_INCORRECT: {
+      code: 422,
+      view: 'errors/incorrect_state/session_expired',
+      analyticsPage: '/problem'
+    },
+
+    SYSTEM_ERROR: systemError,
+
+    NAXSI_SYSTEM_ERROR: {
+      code: 400,
+      view: 'error',
+      locals: {
+        message: 'Please try again later'
+      }
+    },
+
+    HUMANS: {
+      code: 200,
+      view: 'plain_message',
+      locals: {
+        message: "GOV.UK Payments is built by a team at the Government Digital Service in London. If you'd like to join us, see https://gds.blog.gov.uk/jobs"
+      }
+    },
+
+    UNAUTHORISED: {
+      code: 403,
+      view: 'errors/system_error'
+    },
+
+    CAPTURE_SUBMITTED: {
+      view: 'errors/charge_confirm_state_completed',
+      locals: {status: 'successful'},
+      analyticsPage: '/success_return'
+    },
+
+    CREATED: error,
+
+    EXPIRED: expired,
+
+    EXPIRE_CANCEL_READY: expired,
+
+    EXPIRE_CANCEL_FAILED: expired,
+
+    SYSTEM_CANCELLED: systemCancelled,
+
+    SYSTEM_CANCEL_READY: systemCancelled,
+
+    SYSTEM_CANCEL_ERROR: systemCancelled,
+
+    USER_CANCELLED: userCancelled,
+
+    USER_CANCEL_READY: userCancelled,
+
+    USER_CANCEL_ERROR: userCancelled,
+
+    CAPTURED: {
+      view: 'errors/charge_confirm_state_completed',
+      locals: {status: 'successful'},
+      analyticsPage: '/success_return'
+    },
+
+    CAPTURE_APPROVED: {
+      view: 'errors/charge_confirm_state_completed',
+      locals: {status: 'successful'},
+      analyticsPage: '/success_return'
+    },
+
+    CAPTURE_APPROVED_RETRY: {
+      view: 'errors/charge_confirm_state_completed',
+      locals: {status: 'successful'},
+      analyticsPage: '/success_return'
+    },
+
+    CAPTURE_ERROR: {
+      view: 'errors/incorrect_state/capture_failure',
+      analyticsPage: '/capture_failure'
+    },
+
+    CAPTURE_FAILURE: {
+      view: 'errors/incorrect_state/capture_failure',
+      analyticsPage: '/capture_failure'
+    },
+
+    AUTHORISATION_3DS_REQUIRED: {
+      view: 'errors/incorrect_state/auth_3ds_required',
+      analyticsPage: '/3ds_required'
+    },
+
+    AUTHORISATION_SUCCESS: {
+      view: 'errors/incorrect_state/auth_success',
+      analyticsPage: '/in_progress'
+    },
+
+    AUTHORISATION_REJECTED: {
+      view: 'errors/incorrect_state/auth_failure',
+      analyticsPage: '/auth_failure'
+    },
+
+    AUTHORISATION_CANCELLED: {
+      view: 'errors/incorrect_state/auth_failure',
+      analyticsPage: '/auth_failure'
+    },
+
+    AUTHORISATION_ERROR: {
+      view: 'errors/system_error',
+      analyticsPage: '/error'
+    },
+
+    AUTHORISATION_READY: {
+      view: 'errors/incorrect_state/auth_waiting',
+      analyticsPage: '/in_progress'
+    },
+
+    CAPTURE_READY: {
+      view: 'errors/incorrect_state/capture_waiting',
+      analyticsPage: '/in_progress'
+    },
+
+    ENTERING_CARD_DETAILS: systemError,
+
+    display: function (res, resName, locals) {
+      var action = _.result(this, resName)
+      var status
+      locals = locals || {}
+      locals.viewName = resName
+      if (!action) {
+        logger.error('VIEW ' + resName + ' NOT FOUND')
+        locals = { viewName: 'error' }
+        action = this.ERROR
+      }
+      locals = (action.locals) ? _.merge({}, action.locals, locals) : locals
+
+      if (_.get(locals, 'analytics.path')) {
+        locals.analytics.path = locals.analytics.path + _.get(action, 'analyticsPage', '')
+      }
+      status = (action.code) ? action.code : 200
+      res.status(status)
+      res.render(action.view, locals)
+    }
+  }
+
+  var create = function (localViews) {
+    return _.merge({}, _default, localViews)
+  }
 
   return {
     create: create
-  };
-
-}();
+  }
+}())

--- a/lib/template-config.js
+++ b/lib/template-config.js
@@ -1,17 +1,17 @@
 module.exports = {
-  assetPath: "{{assetPath}}",
-  afterHeader: "{{$afterHeader}}{{/afterHeader}}",
-  bodyClasses: "{{$bodyClasses}}{{/bodyClasses}}",
-  bodyEnd: "{{$bodyEnd}}{{/bodyEnd}}",
-  content: "{{$content}}{{/content}}",
-  cookieMessage: "{{$cookieMessage}}{{/cookieMessage}}",
-  footerSupportLinks: "{{$footerSupportLinks}}{{/footerSupportLinks}}",
-  footerTop: "{{$footerTop}}{{/footerTop}}",
-  head: "{{$head}}{{/head}}",
-  headerClass: "{{$headerClass}}{{/headerClass}}",
-  insideHeader: "{{$insideHeader}}{{/insideHeader}}",
-  homepageUrl: "{{$homepageUrl}}https://www.gov.uk{{/homepageUrl}}",
-  globalHeaderText: "{{$globalHeaderText}}GOV.UK{{/globalHeaderText}}",
-  pageTitle: "{{$pageTitle}}GOV.UK - The best place to find government services and information{{/pageTitle}}",
-  propositionHeader: "{{$propositionHeader}}{{/propositionHeader}}"
-};
+  assetPath: '{{assetPath}}',
+  afterHeader: '{{$afterHeader}}{{/afterHeader}}',
+  bodyClasses: '{{$bodyClasses}}{{/bodyClasses}}',
+  bodyEnd: '{{$bodyEnd}}{{/bodyEnd}}',
+  content: '{{$content}}{{/content}}',
+  cookieMessage: '{{$cookieMessage}}{{/cookieMessage}}',
+  footerSupportLinks: '{{$footerSupportLinks}}{{/footerSupportLinks}}',
+  footerTop: '{{$footerTop}}{{/footerTop}}',
+  head: '{{$head}}{{/head}}',
+  headerClass: '{{$headerClass}}{{/headerClass}}',
+  insideHeader: '{{$insideHeader}}{{/insideHeader}}',
+  homepageUrl: '{{$homepageUrl}}https://www.gov.uk{{/homepageUrl}}',
+  globalHeaderText: '{{$globalHeaderText}}GOV.UK{{/globalHeaderText}}',
+  pageTitle: '{{$pageTitle}}GOV.UK - The best place to find government services and information{{/pageTitle}}',
+  propositionHeader: '{{$propositionHeader}}{{/propositionHeader}}'
+}

--- a/lib/template-conversion.js
+++ b/lib/template-conversion.js
@@ -1,22 +1,15 @@
-var Hogan = require('hogan.js'),
-    fs = require('fs'),
-    path = require('path'),
-    govukDir = path.normalize(__dirname + '/../govuk_modules'),
-    govukConfig = require(__dirname + '/template-config'),
-    compiledTemplate,
-    govukTemplate,
-    handleErr;
-
-handleErr = function (err) {
-  if (err) {
-    throw err;
-  }
-};
+var Hogan = require('hogan.js')
+var fs = require('fs')
+var path = require('path')
+var govukDir = path.normalize(path.join(__dirname, '/../govuk_modules'))
+var govukConfig = require(path.join(__dirname, '/template-config'))
+var compiledTemplate
+var govukTemplate
 
 module.exports = {
-  convert : function () {
-    govukTemplate = fs.readFileSync(govukDir + '/govuk_template/views/layouts/govuk_template.html', { encoding : 'utf-8' });
-    compiledTemplate = Hogan.compile(govukTemplate);
-    fs.writeFileSync(govukDir + '/govuk_template/views/layouts/govuk_template.html', compiledTemplate.render(govukConfig), { encoding : 'utf-8' });
+  convert: function () {
+    govukTemplate = fs.readFileSync(govukDir + '/govuk_template/views/layouts/govuk_template.html', { encoding: 'utf-8' })
+    compiledTemplate = Hogan.compile(govukTemplate)
+    fs.writeFileSync(govukDir + '/govuk_template/views/layouts/govuk_template.html', compiledTemplate.render(govukConfig), { encoding: 'utf-8' })
   }
-};
+}

--- a/lib/template-engine.js
+++ b/lib/template-engine.js
@@ -1,15 +1,14 @@
 /**
 * This file is a version of https://github.com/steveukx/hogan-middleware adapted for our requirements.
 */
-var Hogan = require('hogan.js');
-var ReadDir = require('readdir');
-var Path = require('path');
-var FS = require('fs');
-var argv = require('minimist')(process.argv.slice(2));
-var path = require('path');
-var staticify = require("staticify")(path.join(__dirname, "../public"));
+var path = require('path')
+var hogan = require('hogan.js')
+var readDir = require('readdir')
+var fs = require('fs')
+var argv = require('minimist')(process.argv.slice(2))
+var staticify = require('staticify')(path.join(__dirname, '../public'))
 
-function TemplateEngine() {
+function TemplateEngine () {
 }
 
 /**
@@ -17,7 +16,7 @@ function TemplateEngine() {
  * @type {fs.FSWatcher[]}
  * @ignore
  */
-TemplateEngine._watches = [];
+TemplateEngine._watches = []
 
 /**
  * Called by the express server to get the content for a given template at the templatePath supplied. The templateData
@@ -32,42 +31,41 @@ TemplateEngine._watches = [];
  * @param {Function} next Callback to receive two arguments, an error object and the template result.
  */
 TemplateEngine.__express = function (templatePath, templateData, next) {
-   var templatePaths = [templateData.settings.views, templateData.settings.vendorViews];
-   var templateName;
+  var templatePaths = [templateData.settings.views, templateData.settings.vendorViews]
+  var templateName
 
-   for (var i = 0, j = templatePaths.length; i < j; i++) {
-      if (templatePath.indexOf(templatePaths[i]) === 0) {
-         templateName = TemplateEngine._getTemplateName(templatePaths[i], templatePath);
+  for (var i = 0, j = templatePaths.length; i < j; i++) {
+    if (templatePath.indexOf(templatePaths[i]) === 0) {
+      templateName = TemplateEngine._getTemplateName(templatePaths[i], templatePath)
 
-         break;
-      }
-   }
+      break
+    }
+  }
 
-   if (!templateName) {
-      templateName = Path.basename(templatePath, Path.extname(templatePath));
-   }
+  if (!templateName) {
+    templateName = path.basename(templatePath, path.extname(templatePath))
+  }
 
-   var templates = TemplateEngine._getTemplates(templatePaths);
-   var output = null, error = null;
-   var i18n = FS.readFileSync("./locales/en.json", "utf8");
-   templateData.i18n = JSON.parse(i18n);
-   templateData.i18nAsString = i18n;
-   var app = require(__dirname + '/../server.js').getApp;
-   templateData.jsPath = app.get('settings').getVersionedPath('/javascripts/application.js');
-   templateData.cssPath = app.get('settings').getVersionedPath('/stylesheets/application.css');
-   templateData.iframeCssPath = app.get('settings').getVersionedPath('/stylesheets/iframe.css');
+  var templates = TemplateEngine._getTemplates(templatePaths)
+  var output = null
+  var error = null
+  var i18n = fs.readFileSync('./locales/en.json', 'utf8')
+  templateData.i18n = JSON.parse(i18n)
+  templateData.i18nAsString = i18n
+  var app = require(path.join(__dirname, '/../server.js')).getApp
+  templateData.jsPath = app.get('settings').getVersionedPath('/javascripts/application.js')
+  templateData.cssPath = app.get('settings').getVersionedPath('/stylesheets/application.css')
+  templateData.iframeCssPath = app.get('settings').getVersionedPath('/stylesheets/iframe.css')
 
-   try {
-      output = templates[templateName].render(templateData, templates);
-      output = staticify.replacePaths(output);
-   }
-   catch (e) {
-      error = e;
-   }
-   finally {
-      next(error, output);
-   }
-};
+  try {
+    output = templates[templateName].render(templateData, templates)
+    output = staticify.replacePaths(output)
+  } catch (e) {
+    error = e
+  } finally {
+    next(error, output)
+  }
+}
 
 /**
  * Remove the base path from a template path, and the extension to generate the template name
@@ -78,11 +76,11 @@ TemplateEngine.__express = function (templatePath, templateData, next) {
  * @private
  */
 TemplateEngine._getTemplateName = function (basePath, templatePath) {
-   var relativePath = Path.relative(basePath, templatePath);
-   var templateName = Path.join(Path.dirname(relativePath), Path.basename(templatePath, Path.extname(templatePath)));
+  var relativePath = path.relative(basePath, templatePath)
+  var templateName = path.join(path.dirname(relativePath), path.basename(templatePath, path.extname(templatePath)))
 
-   return templateName;
-};
+  return templateName
+}
 
 /**
 
@@ -99,16 +97,16 @@ TemplateEngine._getTemplateName = function (basePath, templatePath) {
  * @private
  */
 TemplateEngine._storeTemplate = function (basePath) {
-   return function (templatePath) {
-      var templateName = TemplateEngine._getTemplateName(basePath, templatePath);
+  return function (templatePath) {
+    var templateName = TemplateEngine._getTemplateName(basePath, templatePath)
 
-      TemplateEngine.__templates[templateName] = Hogan.compile(FS.readFileSync(templatePath, 'utf-8'));
+    TemplateEngine.__templates[templateName] = hogan.compile(fs.readFileSync(templatePath, 'utf-8'))
 
-      if (argv.verbose){
-         console.log('Stored template', templateName);
-      }
-   };
-};
+    if (argv.verbose) {
+      console.log('Stored template', templateName)
+    }
+  }
+}
 
 /**
  * Gets all templates, when the template path hasn't yet been scanned it will be read synchronously to ensure there are
@@ -117,12 +115,12 @@ TemplateEngine._storeTemplate = function (basePath) {
  * @param {Array} templatePaths
  */
 TemplateEngine._getTemplates = function (templatePaths) {
-   TemplateEngine.__templates = {};
-   for (var i = 0, j = templatePaths.length; i < j; i++) {
-      ReadDir.readSync(templatePaths[i], ['**.html'], ReadDir.ABSOLUTE_PATHS)
-         .forEach(TemplateEngine._storeTemplate(templatePaths[i]), TemplateEngine);
-   }
-   return TemplateEngine.__templates;
-};
+  TemplateEngine.__templates = {}
+  for (var i = 0, j = templatePaths.length; i < j; i++) {
+    readDir.readSync(templatePaths[i], ['**.html'], readDir.ABSOLUTE_PATHS)
+         .forEach(TemplateEngine._storeTemplate(templatePaths[i]), TemplateEngine)
+  }
+  return TemplateEngine.__templates
+}
 
-module.exports = TemplateEngine;
+module.exports = TemplateEngine

--- a/package.json
+++ b/package.json
@@ -7,17 +7,20 @@
   "engines": {
     "node": ">5.6.0"
   },
-  "jshintConfig": {
-    "node": true,
-    "esversion": 6,
-    "globals": {
-      "describe": false,
-      "it": false,
-      "before": false,
-      "beforeEach": false,
-      "after": false,
-      "afterEach": false
-    }
+  "standard": {
+    "globals": [
+      "describe",
+      "context",
+      "before",
+      "beforeEach",
+      "after",
+      "afterEach",
+      "it",
+      "expect"
+    ],
+    "ignore": [
+      "app/assets/**/*.js"
+    ]
   },
   "scripts": {
     "compile": "grunt generate-assets",
@@ -25,8 +28,8 @@
     "start": "node_modules/forever/bin/forever --minUptime 1000 --spinSleepTime 500 start.js",
     "stop": "node_modules/forever/bin/forever stop start.js",
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
-    "test": "grunt lint && npm run grunt-test",
-    "lint": "node ./node_modules/.bin/jshint --verbose ./app/*.js ./test/*.js",
+    "test": "npm run lint && npm run grunt-test",
+    "lint": "standard",
     "grunt-test": "node ./node_modules/.bin/grunt test",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"
@@ -37,7 +40,6 @@
     "browserify": "14.4.x",
     "change-case": "2.3.x",
     "client-sessions": "0.8.x",
-    "cluster": "0.7.x",
     "compression": "1.6.x",
     "credit-card-type": "5.0.x",
     "csrf": "3.0.x",
@@ -86,7 +88,6 @@
     "grunt-contrib-compress": "1.4.x",
     "grunt-contrib-concat": "1.0.x",
     "grunt-contrib-copy": "1.0.x",
-    "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-watch": "1.0.x",
     "grunt-env": "0.4.x",
     "grunt-mocha-test": "^0.13.2",
@@ -96,16 +97,16 @@
     "grunt-rewrite": "1.0.x",
     "grunt-sass": "2.0.x",
     "grunt-text-replace": "0.4.x",
-    "jshint": "latest",
     "mocha": "^3.4.2",
     "mockserver-client": "^1.0.16",
     "mockserver-grunt": "^1.0.41",
     "nock": "^9.0.13",
     "portfinder": "^1.0.13",
-    "superagent": "^3.5.2",
-    "supertest": "^3.0.0",
     "proxyquire": "~1.8.0",
-    "sinon": "~2.3.5"
+    "sinon": "~2.3.5",
+    "standard": "^10.0.2",
+    "superagent": "^3.5.2",
+    "supertest": "^3.0.0"
   },
   "snyk": true
 }

--- a/server.js
+++ b/server.js
@@ -1,105 +1,103 @@
-//Please leave here even though it looks unused - this enables Node.js metrics to be pushed to Hosted Graphite
-require('./app/utils/metrics.js').metrics;
+// Please leave here even though it looks unused - this enables Node.js metrics to be pushed to Hosted Graphite
+require('./app/utils/metrics.js').metrics()
 
-var express           = require('express');
-var path              = require('path');
-var favicon           = require('serve-favicon');
-var router            = require(__dirname + '/app/router.js');
-var bodyParser        = require('body-parser');
-var cookies    = require(__dirname + '/app/utils/cookies.js');
-var logger            = require('winston');
-var loggingMiddleware = require('morgan');
-var noCache           = require(__dirname + '/app/utils/no_cache.js');
-var i18n              = require('i18n');
-var port              = (process.env.PORT || 3000);
-var argv              = require('minimist')(process.argv.slice(2));
-var app               = express();
-var session           = require('./app/utils/session.js');
-var environment       = require('./app/services/environment.js');
-var staticify         = require("staticify")(path.join(__dirname, "public"));
-var compression       = require('compression');
-var oneYear           = 86400000 * 365;
-var publicCaching     = {maxAge: oneYear};
+var path = require('path')
+var express = require('express')
+var favicon = require('serve-favicon')
+var router = require(path.join(__dirname, '/app/router.js'))
+var bodyParser = require('body-parser')
+var cookies = require(path.join(__dirname, '/app/utils/cookies.js'))
+var logger = require('winston')
+var loggingMiddleware = require('morgan')
+var noCache = require(path.join(__dirname, '/app/utils/no_cache.js'))
+var i18n = require('i18n')
+var port = process.env.PORT || 3000
+var argv = require('minimist')(process.argv.slice(2))
+var app = express()
+var session = require('./app/utils/session.js')
+var staticify = require('staticify')(path.join(__dirname, 'public'))
+var compression = require('compression')
+var oneYear = 86400000 * 365
+var publicCaching = {maxAge: oneYear}
 
 i18n.configure({
   locales: ['en'],
-  directory: __dirname + '/locales',
+  directory: path.join(__dirname, '/locales'),
   objectNotation: true,
   defaultLocale: 'en',
   register: global
-});
-app.set('settings', {getVersionedPath: staticify.getVersionedPath});
+})
+app.set('settings', {getVersionedPath: staticify.getVersionedPath})
 logger.stream = {
   write: function (message) {
-    logger.info(message);
+    logger.info(message)
   }
-};
+}
 app.use(/\/((?!images|public|stylesheets|javascripts).)*/, loggingMiddleware(
-      ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" - total time :response-time ms'));
+      ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" - total time :response-time ms'))
 
-app.use(i18n.init);
-app.use(compression());
-app.use(staticify.middleware);
+app.use(i18n.init)
+app.use(compression())
+app.use(staticify.middleware)
 
+app.enable('trust proxy')
+app.disable('x-powered-by')
 
-app.enable('trust proxy');
-app.disable('x-powered-by');
+cookies.configureSessionCookie(app)
 
-cookies.configureSessionCookie(app);
+app.engine('html', require(path.join(__dirname, '/lib/template-engine.js')).__express)
+app.set('view engine', 'html')
+app.set('vendorViews', path.join(__dirname, '/govuk_modules/govuk_template/views/layouts'))
+app.set('views', path.join(__dirname, '/app/views'))
 
-app.engine('html', require(__dirname + '/lib/template-engine.js').__express);
-app.set('view engine', 'html');
-app.set('vendorViews', __dirname + '/govuk_modules/govuk_template/views/layouts');
-app.set('views', __dirname + '/app/views');
+app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({extended: true}))
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended: true}));
+app.use('/javascripts', express.static(path.join(__dirname, '/public/assets/javascripts'), publicCaching))
+app.use('/images', express.static(path.join(__dirname, '/public/images'), publicCaching))
+app.use('/stylesheets', express.static(path.join(__dirname, '/public/assets/stylesheets'), publicCaching))
 
-app.use('/javascripts', express.static(__dirname + '/public/assets/javascripts', publicCaching));
-app.use('/images', express.static(__dirname + '/public/images', publicCaching));
-app.use('/stylesheets', express.static(__dirname + '/public/assets/stylesheets', publicCaching));
+app.use('/public', express.static(path.join(__dirname, '/public'), publicCaching))
+app.use('/public', express.static(path.join(__dirname, '/govuk_modules/govuk_template/assets'), publicCaching))
+app.use('/public', express.static(path.join(__dirname, '/govuk_modules/govuk_frontend_toolkit'), publicCaching))
 
-app.use('/public', express.static(__dirname + '/public', publicCaching));
-app.use('/public', express.static(__dirname + '/govuk_modules/govuk_template/assets', publicCaching));
-app.use('/public', express.static(__dirname + '/govuk_modules/govuk_frontend_toolkit', publicCaching));
-
-app.use(favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images', 'favicon.ico')));
+app.use(favicon(path.join(__dirname, 'govuk_modules', 'govuk_template', 'assets', 'images', 'favicon.ico')))
 app.use(function (req, res, next) {
-  res.locals.assetPath = '/public/';
-  if (typeof process.env.ANALYTICS_TRACKING_ID === "undefined") {
-    logger.warn('Google Analytics Tracking ID [ANALYTICS_TRACKING_ID] is not set');
-    res.locals.analyticsTrackingId = ""; //to not break the app
+  res.locals.assetPath = '/public/'
+  if (typeof process.env.ANALYTICS_TRACKING_ID === 'undefined') {
+    logger.warn('Google Analytics Tracking ID [ANALYTICS_TRACKING_ID] is not set')
+    res.locals.analyticsTrackingId = '' // to not break the app
   } else {
-    res.locals.analyticsTrackingId = process.env.ANALYTICS_TRACKING_ID;
+    res.locals.analyticsTrackingId = process.env.ANALYTICS_TRACKING_ID
   }
   res.locals.session = function () {
-    return session.retrieve(req, req.chargeId);
-  };
-  next();
-});
+    return session.retrieve(req, req.chargeId)
+  }
+  next()
+})
 
 app.use(function (req, res, next) {
-  noCache(res);
-  next();
-});
+  noCache(res)
+  next()
+})
 
-router.bind(app);
+router.bind(app)
 
 /**
  * Starts app
  */
-function start() {
-  app.listen(port);
-  logger.info('Listening on port ' + port);
-  return app;
+function start () {
+  app.listen(port)
+  logger.info('Listening on port ' + port)
+  return app
 }
 
-//immediately invoke start if -i flag set. Allows script to be run by task runner
-if (!!argv.i) {
-  start();
+// immediately invoke start if -i flag set. Allows script to be run by task runner
+if (argv.i) {
+  start()
 }
 
 module.exports = {
   start: start,
   getApp: app
-};
+}

--- a/start.js
+++ b/start.js
@@ -1,15 +1,15 @@
 (function () {
-  'use strict';
+  'use strict'
 
-  var fs = require('fs'),
-    cluster = require('cluster'),
-    logger = require('winston'),
-    throng = require('throng'),
-    server = require('./server'),
-    environment = require('./app/services/environment'),
-    pidFile = __dirname + '/.start.pid',
-    fileOptions = { encoding : 'utf-8' },
-    pid;
+  var path = require('path')
+  var fs = require('fs')
+  var logger = require('winston')
+  var throng = require('throng')
+  var server = require('./server')
+  var environment = require('./app/services/environment')
+  var pidFile = path.join(__dirname, '/.start.pid')
+  var fileOptions = { encoding: 'utf-8' }
+  var pid
 
   /**
    * throng is a wrapper around node cluster
@@ -20,54 +20,54 @@
       workers: environment.getWorkerCount(),
       master: startMaster,
       start: startWorker
-    });
+    })
   }
 
   /**
    * Start master process
    */
-  function startMaster() {
-    logger.info(`Master started. PID: ${ process.pid }`);
+  function startMaster () {
+    logger.info(`Master started. PID: ${process.pid}`)
     process.on('SIGINT', () => {
-      logger.info(`Master exiting`);
+      logger.info(`Master exiting`)
       process.exit()
-    });
+    })
   }
 
   /**
    * Start cluster worker. Log start and exit
-   * @param  {Number} workerId 
+   * @param  {Number} workerId
    */
   function startWorker (workerId) {
-    server.start();
+    server.start()
 
-    logger.info(`Started worker ${ workerId }, PID: ${ process.pid }`);
+    logger.info(`Started worker ${workerId}, PID: ${process.pid}`)
 
     process.on('SIGINT', () => {
-      logger.info(`Worker ${ workerId } exiting...`);
+      logger.info(`Worker ${workerId} exiting...`)
       process.exit()
-    });
+    })
   }
 
   /**
    * Make sure all child processes are cleaned up
    */
   function onInterrupt () {
-    pid = fs.readFileSync(pidFile, fileOptions);
-    fs.unlink(pidFile);
-    process.kill(pid, 'SIGTERM');
-    process.exit();
+    pid = fs.readFileSync(pidFile, fileOptions)
+    fs.unlink(pidFile)
+    process.kill(pid, 'SIGTERM')
+    process.exit()
   }
 
   /**
    * Keep track of processes, and clean up on SIGINT
    */
   function monitor () {
-    fs.writeFileSync(pidFile, process.pid, fileOptions);
-    process.on('SIGINT', onInterrupt);
+    fs.writeFileSync(pidFile, process.pid, fileOptions)
+    process.on('SIGINT', onInterrupt)
   }
 
-  monitor();
+  monitor()
 
-  start();
-}());
+  start()
+}())

--- a/test/analytics_ui_tests.js
+++ b/test/analytics_ui_tests.js
@@ -1,91 +1,91 @@
-var renderTemplate = require(__dirname + '/test_helpers/html_assertions.js').render;
-var should = require('chai').should();
+var path = require('path')
+var renderTemplate = require(path.join(__dirname, '/test_helpers/html_assertions.js')).render
+var should = require('chai').should() // eslint-disable-line
+
 describe('Frontend analytics', function () {
+  var googleAnalyticsScript = '//www.google-analytics.com/analytics.js'
+  var googleAnalyticsCustomDimensions = {
+    'analyticsId': 'testId',
+    'type': 'testType',
+    'paymentProvider': 'paymentProvider'
+  }
 
-    var googleAnalyticsScript = '//www.google-analytics.com/analytics.js';
-    var googleAnalyticsCustomDimensions = {
-        'analyticsId': 'testId',
-        'type': 'testType',
-        'paymentProvider': 'paymentProvider'
-    };
+  var checkGACustomDimensions = function (body) {
+    body.should.containSelector('script').withText("'dimension1':'testId'")
+    body.should.containSelector('script').withText("'dimension2':'testType'")
+    body.should.containSelector('script').withText("'dimension3':'paymentProvider'")
+  }
 
-    var checkGACustomDimensions = function(body) {
-        body.should.containSelector('script').withText("'dimension1':'testId'");
-        body.should.containSelector('script').withText("'dimension2':'testType'");
-        body.should.containSelector('script').withText("'dimension3':'paymentProvider'");
+  it('should be enabled in charge view', function () {
+    var templateData = {
+      'amount': '50.00',
+      'analytics': googleAnalyticsCustomDimensions
+    }
+    var body = renderTemplate('charge', templateData)
+    body.should.containSelector('script').withText(googleAnalyticsScript)
+    checkGACustomDimensions(body)
+  })
+
+  it('should be enabled in confirm view', function () {
+    var templateData = {
+      'cardNumber': '************5100',
+      'expiryDate': '11/99',
+      'amount': '10.00',
+      'description': 'Payment Description',
+      'cardholderName': 'Random dude',
+      'address': '1 street lane, avenue city, AB1 3DF',
+      'serviceName': 'Service 1',
+      'analytics': googleAnalyticsCustomDimensions
     }
 
-    it('should be enabled in charge view', function () {
-        var templateData = {
-            'amount': '50.00',
-            'analytics': googleAnalyticsCustomDimensions
-        };
-        var body = renderTemplate('charge', templateData);
-        body.should.containSelector('script').withText(googleAnalyticsScript);
-        checkGACustomDimensions(body);
-    });
+    var body = renderTemplate('confirm', templateData)
+    body.should.containSelector('script').withText(googleAnalyticsScript)
+    checkGACustomDimensions(body)
+  })
 
-    it('should be enabled in confirm view', function () {
-        var templateData = {
-            'cardNumber': "************5100",
-            'expiryDate': "11/99",
-            'amount': "10.00",
-            'description': "Payment Description",
-            'cardholderName': 'Random dude',
-            'address': '1 street lane, avenue city, AB1 3DF',
-            'serviceName': 'Service 1',
-            'analytics': googleAnalyticsCustomDimensions
-        };
+  it('should be enabled in error view', function () {
+    var msg = 'error processing your payment!'
+    var body = renderTemplate('error', {
+      'message': msg,
+      'analytics': googleAnalyticsCustomDimensions
+    })
+    body.should.containSelector('script').withText(googleAnalyticsScript)
+    checkGACustomDimensions(body)
+  })
 
-        var body = renderTemplate('confirm', templateData);
-        body.should.containSelector('script').withText(googleAnalyticsScript);
-        checkGACustomDimensions(body);
-    });
+  it('should be enabled in error with return url view', function () {
+    var msg = 'error processing your payment!'
+    var returnUrl = 'http://some.return.url'
+    var body = renderTemplate('error_with_return_url', {
+      'message': msg,
+      'return_url': returnUrl,
+      'analytics': googleAnalyticsCustomDimensions
+    })
+    body.should.containSelector('script').withText(googleAnalyticsScript)
+    checkGACustomDimensions(body)
+  })
 
-    it('should be enabled in error view', function() {
-        var msg = 'error processing your payment!';
-        var body = renderTemplate('error', {
-            'message' : msg,
-            'analytics': googleAnalyticsCustomDimensions
-        });
-        body.should.containSelector('script').withText(googleAnalyticsScript);
-        checkGACustomDimensions(body);
-    });
+  it('should be enabled when waiting for auth', function () {
+    var body = renderTemplate('auth_waiting', {
+      'analytics': googleAnalyticsCustomDimensions
+    })
+    body.should.containSelector('script').withText(googleAnalyticsScript)
+    checkGACustomDimensions(body)
+  })
 
-    it('should be enabled in error with return url view', function() {
-        var msg = 'error processing your payment!';
-        var return_url = 'http://some.return.url';
-        var body = renderTemplate('error_with_return_url', {
-            'message' : msg,
-            'return_url': return_url,
-            'analytics': googleAnalyticsCustomDimensions
-        });
-        body.should.containSelector('script').withText(googleAnalyticsScript);
-        checkGACustomDimensions(body);
-    });
+  it('should be enabled when waiting for capture', function () {
+    var body = renderTemplate('capture_waiting', {
+      'analytics': googleAnalyticsCustomDimensions
+    })
+    body.should.containSelector('script').withText(googleAnalyticsScript)
+    checkGACustomDimensions(body)
+  })
 
-    it('should be enabled when waiting for auth', function() {
-        var body = renderTemplate('auth_waiting', {
-            'analytics': googleAnalyticsCustomDimensions
-        });
-        body.should.containSelector('script').withText(googleAnalyticsScript);
-        checkGACustomDimensions(body);
-    });
-
-    it('should be enabled when waiting for capture', function() {
-        var body = renderTemplate('capture_waiting', {
-            'analytics': googleAnalyticsCustomDimensions
-        });
-        body.should.containSelector('script').withText(googleAnalyticsScript);
-        checkGACustomDimensions(body);
-    });
-
-    it('should be enabled when user cancels a payment', function() {
-        var body = renderTemplate('user_cancelled', {
-            'analytics': googleAnalyticsCustomDimensions
-        });
-        body.should.containSelector('script').withText(googleAnalyticsScript);
-        checkGACustomDimensions(body);
-    });
-
-});
+  it('should be enabled when user cancels a payment', function () {
+    var body = renderTemplate('user_cancelled', {
+      'analytics': googleAnalyticsCustomDimensions
+    })
+    body.should.containSelector('script').withText(googleAnalyticsScript)
+    checkGACustomDimensions(body)
+  })
+})

--- a/test/charge_hash_out_tests.js
+++ b/test/charge_hash_out_tests.js
@@ -1,26 +1,27 @@
-hashOutCardNumber = require(__dirname + '/../app/utils/charge_utils.js').hashOutCardNumber;
-var chai = require('chai');
-chai.use(require('chai-string'));
-var should = chai.should();
+var path = require('path')
+var hashOutCardNumber = require(path.join(__dirname, '/../app/utils/charge_utils.js')).hashOutCardNumber
+var chai = require('chai')
+chai.use(require('chai-string'))
+var should = chai.should() // eslint-disable-line
 
-describe('Card number masking', function() {
-  var cardNumbers_12_to_19 = [
-   '12345678AAAA',
-   '123456789AAAA',
-   '1234567890AAAA',
-   '12345678901AAAA',
-   '123456789012AAAA',
-   '1234567890123AAAA',
-   '12345678901234AAAA',
-   '123456789012345AAAA'
-  ];
+describe('Card number masking', function () {
+  var cardNumbers12To19 = [
+    '12345678AAAA',
+    '123456789AAAA',
+    '1234567890AAAA',
+    '12345678901AAAA',
+    '123456789012AAAA',
+    '1234567890123AAAA',
+    '12345678901234AAAA',
+    '123456789012345AAAA'
+  ]
 
-  cardNumbers_12_to_19.forEach(function (key) {
+  cardNumbers12To19.forEach(function (key) {
     it('should only show last 4 digits, regardless of card number length. key=' + key, function () {
-      var hashedNumber = hashOutCardNumber(key);
-      hashedNumber.should.endWith('AAAA');
-      var expectedStarCount = hashedNumber.length - 4;
-      hashedNumber.should.have.entriesCount('*', expectedStarCount);
-    });
-  });
-});
+      var hashedNumber = hashOutCardNumber(key)
+      hashedNumber.should.endWith('AAAA')
+      var expectedStarCount = hashedNumber.length - 4
+      hashedNumber.should.have.entriesCount('*', expectedStarCount)
+    })
+  })
+})

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -1,131 +1,129 @@
-var renderTemplate = require(__dirname + '/test_helpers/html_assertions.js').render;
-var cheerio = require('cheerio');
-var should = require('chai').should();
+var path = require('path')
+var renderTemplate = require(path.join(__dirname, '/test_helpers/html_assertions.js')).render
+var cheerio = require('cheerio')
+var should = require('chai').should() // eslint-disable-line
 
-describe('The charge view', function() {
-
+describe('The charge view', function () {
   it('should render the amount', function () {
     var templateData = {
-      'amount' : '50.00'
-    };
+      'amount': '50.00'
+    }
 
-    var body = renderTemplate('charge', templateData);
-    body.should.containSelector('#amount').withText('£50.00');
-  });
+    var body = renderTemplate('charge', templateData)
+    body.should.containSelector('#amount').withText('£50.00')
+  })
 
   it('should have a submit form.', function () {
-    var postAction = "/post_card_path";
+    var postAction = '/post_card_path'
     var templateData = {
-      'post_card_action' : postAction
-    };
+      'post_card_action': postAction
+    }
 
-    var body = renderTemplate('charge', templateData);
+    var body = renderTemplate('charge', templateData)
 
     body.should.containSelector('form#card-details').withAttributes(
-        {
-          action: postAction,
-          method: "POST",
-          name: "cardDetails"
-        });
-  });
+      {
+        action: postAction,
+        method: 'POST',
+        name: 'cardDetails'
+      })
+  })
 
   it('should have a \'Continue\' button.', function () {
-    var body = renderTemplate('charge', {});
-    body.should.containInputWithIdAndName('submit-card-details', 'submitCardDetails', 'submit');
-  });
+    var body = renderTemplate('charge', {})
+    body.should.containInputWithIdAndName('submit-card-details', 'submitCardDetails', 'submit')
+  })
 
   it('should show all input fields.', function () {
-     var body = renderTemplate('charge', {'id' : '1234'});
-     body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden');
-     body.should.containInputWithIdAndName('card-no', 'cardNo', 'tel').withAttribute('maxlength', '26').withLabel('card-no-lbl', 'Card number');
-     body.should.containInputWithIdAndName('cvc', 'cvc', 'number').withLabel('cvc-lbl', 'Card security code');
-     body.should.containInputWithIdAndName('expiry-month', 'expiryMonth', 'number');
-     body.should.containInputWithIdAndName('expiry-year', 'expiryYear', 'number');
-     body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('maxlength', '200').withLabel('cardholder-name-lbl', 'Name on card');
-     body.should.containInputWithIdAndName('address-line-1', 'addressLine1', 'text').withAttribute('maxlength', '100').withLabel('address-line-1-lbl', 'Building name and/or number and street');
-     body.should.containInputWithIdAndName('address-line-2', 'addressLine2', 'text').withAttribute('maxlength', '100');
-     body.should.containInputWithIdAndName('address-city', 'addressCity', 'text').withAttribute('maxlength', '100').withLabel('address-city-lbl', 'Town or city');
-     body.should.containInputWithIdAndName('address-postcode', 'addressPostcode', 'text').withAttribute('maxlength', '10').withLabel('address-postcode-lbl', 'Postcode');
-     body.should.containInputWithIdAndName('charge-id', 'chargeId', 'hidden').withAttribute('value', '1234');
-  });
+    var body = renderTemplate('charge', {'id': '1234'})
+    body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
+    body.should.containInputWithIdAndName('card-no', 'cardNo', 'tel').withAttribute('maxlength', '26').withLabel('card-no-lbl', 'Card number')
+    body.should.containInputWithIdAndName('cvc', 'cvc', 'number').withLabel('cvc-lbl', 'Card security code')
+    body.should.containInputWithIdAndName('expiry-month', 'expiryMonth', 'number')
+    body.should.containInputWithIdAndName('expiry-year', 'expiryYear', 'number')
+    body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('maxlength', '200').withLabel('cardholder-name-lbl', 'Name on card')
+    body.should.containInputWithIdAndName('address-line-1', 'addressLine1', 'text').withAttribute('maxlength', '100').withLabel('address-line-1-lbl', 'Building name and/or number and street')
+    body.should.containInputWithIdAndName('address-line-2', 'addressLine2', 'text').withAttribute('maxlength', '100')
+    body.should.containInputWithIdAndName('address-city', 'addressCity', 'text').withAttribute('maxlength', '100').withLabel('address-city-lbl', 'Town or city')
+    body.should.containInputWithIdAndName('address-postcode', 'addressPostcode', 'text').withAttribute('maxlength', '10').withLabel('address-postcode-lbl', 'Postcode')
+    body.should.containInputWithIdAndName('charge-id', 'chargeId', 'hidden').withAttribute('value', '1234')
+  })
 
-  it('should populate form data if reserved in response', function(){
+  it('should populate form data if reserved in response', function () {
     var responseData = {
-      'id' : '1234',
-      'cardholderName' : 'J. Vardy',
-      'addressLine1' : '1 High Street',
-      'addressLine2' : 'blah blah',
-      'addressCity' : 'Leicester City',
-      'addressPostcode' : 'CT16 1FB'
-    };
-    var body = renderTemplate('charge', responseData);
+      'id': '1234',
+      'cardholderName': 'J. Vardy',
+      'addressLine1': '1 High Street',
+      'addressLine2': 'blah blah',
+      'addressCity': 'Leicester City',
+      'addressPostcode': 'CT16 1FB'
+    }
+    var body = renderTemplate('charge', responseData)
 
-    body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('value', responseData.cardholderName);
-    body.should.containInputWithIdAndName('address-line-1', 'addressLine1', 'text').withAttribute('value', responseData.addressLine1);
-    body.should.containInputWithIdAndName('address-line-2', 'addressLine2', 'text').withAttribute('value', responseData.addressLine2);
-    body.should.containInputWithIdAndName('address-city', 'addressCity', 'text').withAttribute('value', responseData.addressCity);
-    body.should.containInputWithIdAndName('address-postcode', 'addressPostcode', 'text').withAttribute('value', responseData.addressPostcode);
-
-  });
-});
+    body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('value', responseData.cardholderName)
+    body.should.containInputWithIdAndName('address-line-1', 'addressLine1', 'text').withAttribute('value', responseData.addressLine1)
+    body.should.containInputWithIdAndName('address-line-2', 'addressLine2', 'text').withAttribute('value', responseData.addressLine2)
+    body.should.containInputWithIdAndName('address-city', 'addressCity', 'text').withAttribute('value', responseData.addressCity)
+    body.should.containInputWithIdAndName('address-postcode', 'addressPostcode', 'text').withAttribute('value', responseData.addressPostcode)
+  })
+})
 
 describe('The confirm view', function () {
-
   it('should render cardNumber, expiryDate, amount and cardholder details fields', function () {
     var templateData = {
       charge: {
-        "cardDetails": {
-          'cardNumber': "************5100",
-          'expiryDate': "11/99",
+        'cardDetails': {
+          'cardNumber': '************5100',
+          'expiryDate': '11/99',
           'cardholderName': 'Francisco Blaya-Gonzalvez',
           'billingAddress': '1 street lane, avenue city, AB1 3DF'
         },
-        'amount': "10.00",
-        'description': "Payment Description & <xss attack> assessment"
+        'amount': '10.00',
+        'description': 'Payment Description & <xss attack> assessment'
       }
-    };
+    }
 
-    var body = renderTemplate('confirm', templateData);
-    var $ = cheerio.load(body);
-    $('#payment-description').html().should.equal('Payment Description &amp; &lt;xss attack&gt; assessment');
-    body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden');
-    body.should.containSelector('#card-number').withText('************5100');
-    body.should.containSelector('#expiry-date').withText('11/99');
-    body.should.containSelector('#amount').withText('£10.00');
-    body.should.containSelector('#payment-description').withText('Payment Description');
-    body.should.containSelector('#cardholder-name').withText('Francisco Blaya-Gonzalvez');
-    body.should.containSelector('#address').withText('1 street lane, avenue city, AB1 3DF');
-  });
+    var body = renderTemplate('confirm', templateData)
+    var $ = cheerio.load(body)
+    $('#payment-description').html().should.equal('Payment Description &amp; &lt;xss attack&gt; assessment')
+    body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
+    body.should.containSelector('#card-number').withText('************5100')
+    body.should.containSelector('#expiry-date').withText('11/99')
+    body.should.containSelector('#amount').withText('£10.00')
+    body.should.containSelector('#payment-description').withText('Payment Description')
+    body.should.containSelector('#cardholder-name').withText('Francisco Blaya-Gonzalvez')
+    body.should.containSelector('#address').withText('1 street lane, avenue city, AB1 3DF')
+  })
 
   it('should render a confirm button', function () {
-    var body = renderTemplate('confirm', {confirmPath: '/card_details/123/confirm', 'charge': { id: 1234 }});
+    var body = renderTemplate('confirm', {confirmPath: '/card_details/123/confirm', 'charge': { id: 1234 }})
     body.should.containSelector('form#confirmation').withAttributes(
-        {
-          action: '/card_details/123/confirm',
-          method: "POST"
-        });
-    body.should.containSelector('button#confirm').withText("Confirm");
-    body.should.containInputField('chargeId', 'hidden').withAttribute('value', '1234');
-  });
+      {
+        action: '/card_details/123/confirm',
+        method: 'POST'
+      })
+    body.should.containSelector('button#confirm').withText('Confirm')
+    body.should.containInputField('chargeId', 'hidden').withAttribute('value', '1234')
+  })
 
   it('should have a cancel form.', function () {
-    var postAction = "/post_cancel_path";
+    var postAction = '/post_cancel_path'
     var templateData = {
-      'post_cancel_action' : postAction
-    };
+      'post_cancel_action': postAction
+    }
 
-    var body = renderTemplate('charge', templateData);
+    var body = renderTemplate('charge', templateData)
 
     body.should.containSelector('form#cancel').withAttributes(
       {
         action: postAction,
-        method: "POST",
-        name: "cancel"
-      });
-  });
+        method: 'POST',
+        name: 'cancel'
+      })
+  })
 
   it('should have a \'Cancel\' button.', function () {
-    var body = renderTemplate('charge', {});
-    body.should.containInputWithIdAndName('cancel-payment', 'cancel', 'submit');
-  });
-});
+    var body = renderTemplate('charge', {})
+    body.should.containInputWithIdAndName('cancel-payment', 'cancel', 'submit')
+  })
+})

--- a/test/controllers/charge_controller_test.js
+++ b/test/controllers/charge_controller_test.js
@@ -1,208 +1,200 @@
-require(__dirname + '/../test_helpers/html_assertions.js');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
 var proxyquire = require('proxyquire')
-var sinon = require('sinon');
-var expect = require('chai').expect;
+var sinon = require('sinon')
+var expect = require('chai').expect
 
-var mockCharge = function () {
-
+var mockCharge = (function () {
   var mock = function (shouldSuccess, error) {
     return function () {
       var updateToEnterDetails = function () {
         return {
           then: function (success, fail) {
-            return shouldSuccess ? success() : fail();
+            return shouldSuccess ? success() : fail()
           }
-        };
-      };
+        }
+      }
       var capture = function () {
         return {
           then: function (success, fail) {
-            return shouldSuccess ? success() : fail(error);
+            return shouldSuccess ? success() : fail(error)
           }
-        };
-      };
+        }
+      }
       return {
         updateToEnterDetails: updateToEnterDetails,
         capture: capture
       }
-    };
-  };
+    }
+  }
 
   return {
     mock: mock
   }
+}())
 
-}();
-
-var mockNormalise = function () {
+var mockNormalise = (function () {
   var mock = function (chargeObject) {
     return {
       charge: function (data) {
-        return chargeObject;
+        return chargeObject
       }
     }
-  };
+  }
 
   return {
     withCharge: mock
   }
+}())
 
-}();
-
-var mockSession = function () {
+var mockSession = (function () {
   var retrieve = function () {
     return [{
-      brand: "visa",
+      brand: 'visa',
       debit: true,
       credit: false
-    }];
-  };
+    }]
+  }
 
   return {
     retrieve: retrieve
-  };
-
-}();
+  }
+}())
 
 var requireChargeController = function (mockedCharge, mockedNormalise) {
-  return proxyquire(__dirname + '/../../app/controllers/charge_controller.js', {
+  return proxyquire(path.join(__dirname, '/../../app/controllers/charge_controller.js'), {
     '../models/charge.js': mockedCharge,
     '../services/normalise_charge.js': mockedNormalise,
     '../utils/session.js': mockSession
-  });
-};
+  })
+}
 
 describe('card details endpoint', function () {
-
-  var request, response;
+  var request, response
 
   var aChargeWithStatus = function (status) {
     return {
-      "externalId": "dh6kpbb4k82oiibbe4b9haujjk",
-      "status": status,
-      "gatewayAccount": {
-        "serviceName": "Service Name",
-        "analyticsId": "test-1234",
-        "type": "test",
-        "paymentProvider": "sandbox"
+      'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
+      'status': status,
+      'gatewayAccount': {
+        'serviceName': 'Service Name',
+        'analyticsId': 'test-1234',
+        'type': 'test',
+        'paymentProvider': 'sandbox'
       },
-      "id": "3"
-    };
-  };
+      'id': '3'
+    }
+  }
 
   var aResponseWithStatus = function (status) {
     return {
-      "externalId": "dh6kpbb4k82oiibbe4b9haujjk",
-      "status": status,
-      "gatewayAccount": {
-        "serviceName": "Service Name",
-        "analyticsId": "test-1234",
-        "type": "test",
-        "paymentProvider": "sandbox"
+      'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
+      'status': status,
+      'gatewayAccount': {
+        'serviceName': 'Service Name',
+        'analyticsId': 'test-1234',
+        'type': 'test',
+        'paymentProvider': 'sandbox'
       },
-      "analytics": {
-        "analyticsId": "test-1234",
-        "type": "test",
-        "paymentProvider": "sandbox"
+      'analytics': {
+        'analyticsId': 'test-1234',
+        'type': 'test',
+        'paymentProvider': 'sandbox'
       }
-    };
-  };
+    }
+  }
   before(function () {
-
     request = {
-      query: {debitOnly : false},
+      query: {debitOnly: false},
       frontend_state: {},
       params: {chargeTokenId: 1},
-      headers:{'x-request-id': 'unique-id'}
-    };
+      headers: {'x-request-id': 'unique-id'}
+    }
 
     response = {
       redirect: sinon.spy(),
       render: sinon.spy(),
       status: sinon.spy()
-    };
-  });
+    }
+  })
 
   it('should not call update to enter card details if charge is already in ENTERING CARD DETAILS', function () {
-
-    var mockedNormalisedCharge = aChargeWithStatus('ENTERING CARD DETAILS');
-    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge);
+    var mockedNormalisedCharge = aChargeWithStatus('ENTERING CARD DETAILS')
+    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge)
     // To make sure this test does not proceed to chargeModel.updateToEnterDetails.
     // That is to differentiate from next test.
-    var emptyChargeModel = {};
+    var emptyChargeModel = {}
 
-    var expectedCharge = aResponseWithStatus('ENTERING CARD DETAILS');
-    requireChargeController(emptyChargeModel, mockedNormalise).new(request, response);
-    expect(response.render.calledWithMatch('charge', expectedCharge)).to.be.true;
-  });
+    var expectedCharge = aResponseWithStatus('ENTERING CARD DETAILS')
+    requireChargeController(emptyChargeModel, mockedNormalise).new(request, response)
+    expect(response.render.calledWithMatch('charge', expectedCharge)).to.be.true // eslint-disable-line
+  })
 
   it('should update to enter card details if charge is in CREATED', function () {
+    var charge = mockCharge.mock(true)
 
-    var charge = mockCharge.mock(true);
+    var mockedNormalisedCharge = aChargeWithStatus('CREATED')
+    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge)
 
-    var mockedNormalisedCharge = aChargeWithStatus('CREATED');
-    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge);
-
-    var expectedCharge = aResponseWithStatus('CREATED');
-    requireChargeController(charge, mockedNormalise).new(request, response);
-    expect(response.render.calledWithMatch('charge', expectedCharge)).to.be.true;
-  });
+    var expectedCharge = aResponseWithStatus('CREATED')
+    requireChargeController(charge, mockedNormalise).new(request, response)
+    expect(response.render.calledWithMatch('charge', expectedCharge)).to.be.true // eslint-disable-line
+  })
 
   it('should display NOT FOUND if updateToEnterDetails returns error', function () {
+    var charge = mockCharge.mock(false)
 
-    var charge = mockCharge.mock(false);
+    var mockedNormalisedCharge = aChargeWithStatus('CREATED')
+    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge)
 
-    var mockedNormalisedCharge = aChargeWithStatus('CREATED');
-    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge);
-
-    requireChargeController(charge, mockedNormalise).new(request, response);
-    expect(response.render.calledWith('error', {"message":"Page cannot be found",
-        "viewName":"NOT_FOUND",
-        "analytics" : {
-          "analyticsId": "Service unavailable",
-          "type": "Service unavailable",
-          "paymentProvider": "Service unavailable"
-        }
-    })).to.be.true;
-  });
+    requireChargeController(charge, mockedNormalise).new(request, response)
+    var systemErrorObj = {'message': 'Page cannot be found',
+      'viewName': 'NOT_FOUND',
+      'analytics': {
+        'analyticsId': 'Service unavailable',
+        'type': 'Service unavailable',
+        'paymentProvider': 'Service unavailable'
+      }
+    }
+    expect(response.render.calledWith('error', systemErrorObj)).to.be.true // eslint-disable-line
+  })
 
   it('should display SYSTEM_ERROR if capture returns an error', function () {
+    var charge = mockCharge.mock(false, { message: 'some error' })
 
-    var charge = mockCharge.mock(false, { message: 'some error' });
+    var mockedNormalisedCharge = aChargeWithStatus('CAPTURE_READY')
+    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge)
 
-    var mockedNormalisedCharge = aChargeWithStatus('CAPTURE_READY');
-    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge);
-
-    requireChargeController(charge, mockedNormalise).capture(request, response);
-    expect(response.render.calledWith('errors/system_error', {
-      "viewName": 'SYSTEM_ERROR',
-      "returnUrl": '/return/3',
-      "analytics" : {
-        "analyticsId": 'test-1234',
-        "type": 'test',
-        "paymentProvider": 'sandbox',
-        "path": '/card_details/3/error',
+    requireChargeController(charge, mockedNormalise).capture(request, response)
+    var systemErrorObj = {
+      'viewName': 'SYSTEM_ERROR',
+      'returnUrl': '/return/3',
+      'analytics': {
+        'analyticsId': 'test-1234',
+        'type': 'test',
+        'paymentProvider': 'sandbox',
+        'path': '/card_details/3/error'
       }
-    })).to.be.true;
-  });
+    }
+    expect(response.render.calledWith('errors/system_error', systemErrorObj)).to.be.true // eslint-disable-line
+  })
 
   it('should display CAPTURE_FAILURE if capture returns a capture failed error', function () {
+    var charge = mockCharge.mock(false, { message: 'CAPTURE_FAILED' })
 
-    var charge = mockCharge.mock(false, { message: 'CAPTURE_FAILED' });
+    var mockedNormalisedCharge = aChargeWithStatus('CAPTURE_READY')
+    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge)
 
-    var mockedNormalisedCharge = aChargeWithStatus('CAPTURE_READY');
-    var mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge);
-
-    requireChargeController(charge, mockedNormalise).capture(request, response);
-    expect(response.render.calledWith('errors/incorrect_state/capture_failure', {
-      "viewName": 'CAPTURE_FAILURE',
-      "analytics" : {
-        "analyticsId": 'test-1234',
-        "type": 'test',
-        "paymentProvider": 'sandbox',
-        "path": '/card_details/3/capture_failure'
+    requireChargeController(charge, mockedNormalise).capture(request, response)
+    var systemErrorObj = {
+      'viewName': 'CAPTURE_FAILURE',
+      'analytics': {
+        'analyticsId': 'test-1234',
+        'type': 'test',
+        'paymentProvider': 'sandbox',
+        'path': '/card_details/3/capture_failure'
       }
-    })).to.be.true;
-  });
-
-});
+    }
+    expect(response.render.calledWith('errors/incorrect_state/capture_failure', systemErrorObj)).to.be.true // eslint-disable-line
+  })
+})

--- a/test/controllers/return_controller_test.js
+++ b/test/controllers/return_controller_test.js
@@ -1,95 +1,86 @@
-/*jslint node: true */
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
+var proxyquire = require('proxyquire')
+var chai = require('chai')
+var chaiAsPromised = require('chai-as-promised')
 
-require(__dirname + '/../test_helpers/html_assertions.js');
-var proxyquire = require('proxyquire');
-var chai = require('chai');
-var chaiAsPromised = require('chai-as-promised');
+var assert = require('assert')
+var sinon = require('sinon')
+var nock = require('nock')
+var expect = chai.expect
 
-var should = chai.should();
-var assert = require('assert');
-var q = require('q');
-var sinon = require('sinon');
-var paths = require('../../app/paths.js');
-var nock = require('nock');
-var expect = chai.expect;
-
-chai.use(chaiAsPromised);
-
+chai.use(chaiAsPromised)
 
 let requireReturnController = function () {
   let mocks = {
     'csrf': function () {
       return {
         secretSync: function () {
-          return 'foo';
+          return 'foo'
         }
       }
     }
-  };
+  }
 
-  return proxyquire(__dirname + '/../../app/controllers/return_controller.js', mocks)
-};
+  return proxyquire(path.join(__dirname, '/../../app/controllers/return_controller.js'), mocks)
+}
 
 describe('return controller', function () {
-
-
-  let request, response;
+  let request, response
 
   beforeEach(function () {
     request = {
       chargeId: 'aChargeId',
-      headers:{'x-Request-id': 'unique-id'}
-    };
+      headers: {'x-Request-id': 'unique-id'}
+    }
 
     response = {
       redirect: sinon.spy(),
       render: sinon.spy(),
       status: sinon.spy()
-    };
-  });
+    }
+  })
 
   it('should redirect to the original service for terminal (non-cancelable) states', function () {
     request.chargeData = {
-      status: "CAPTURED",
+      status: 'CAPTURED',
       return_url: 'http://a_return_url.com'
-    };
+    }
 
-    requireReturnController().return(request, response);
-    assert(response.redirect.calledWith('http://a_return_url.com'));
-  });
+    requireReturnController().return(request, response)
+    assert(response.redirect.calledWith('http://a_return_url.com'))
+  })
 
   it('should redirect to the original service for cancelable states', function (done) {
     request.chargeData = {
-      status: "CREATED",
+      status: 'CREATED',
       return_url: 'http://a_return_url.com'
-    };
+    }
 
     nock(process.env.CONNECTOR_HOST)
-      .post("/v1/frontend/charges/aChargeId/cancel")
-      .reply(204);
+      .post('/v1/frontend/charges/aChargeId/cancel')
+      .reply(204)
 
     requireReturnController().return(request, response)
       .should.be.fulfilled.then(() => {
-        assert(response.redirect.calledWith('http://a_return_url.com'));
-    }).should.notify(done);
-
-  });
+        assert(response.redirect.calledWith('http://a_return_url.com'))
+      }).should.notify(done)
+  })
 
   it('should show an error if cancel fails', function (done) {
     request.chargeData = {
-      status: "CREATED",
+      status: 'CREATED',
       return_url: 'http://a_return_url.com'
-    };
+    }
     nock(process.env.CONNECTOR_HOST)
-      .post("/v1/frontend/charges/aChargeId/cancel")
-      .reply(500);
+      .post('/v1/frontend/charges/aChargeId/cancel')
+      .reply(500)
 
     requireReturnController().return(request, response)
       .should.be.fulfilled.then(() => {
-        expect(response.render.called).to.equal(true);
-        expect(response.render.getCall(0).args[0]).to.equal("errors/system_error");
-        expect(response.render.getCall(0).args[1].viewName).to.equal('SYSTEM_ERROR');
-
-    }).should.notify(done);
-  });
-});
+        expect(response.render.called).to.equal(true)
+        expect(response.render.getCall(0).args[0]).to.equal('errors/system_error')
+        expect(response.render.getCall(0).args[1].viewName).to.equal('SYSTEM_ERROR')
+      }).should.notify(done)
+  })
+})

--- a/test/controllers/secure_controller_test.js
+++ b/test/controllers/secure_controller_test.js
@@ -1,156 +1,150 @@
-require(__dirname + '/../test_helpers/html_assertions.js');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
 var proxyquire = require('proxyquire')
-var should = require('chai').should();
-var assert = require('assert');
-var q = require('q');
-var sinon = require('sinon');
-var expect = require('chai').expect;
-var paths = require('../../app/paths.js');
-var cookies = require('../../app/utils/cookies');
+var q = require('q')
+var sinon = require('sinon')
+var expect = require('chai').expect
+var paths = require('../../app/paths.js')
 
-var mockCharge = function () {
+var mockCharge = (function () {
   var mock = function (withSuccess, chargeObject) {
     return function () {
       return {
         findByToken: function () {
           var defer = q.defer();
-          (withSuccess) ? defer.resolve(chargeObject) : defer.reject();
-          return defer.promise;
+          (withSuccess) ? defer.resolve(chargeObject) : defer.reject()
+          return defer.promise
         }
       }
-    };
-  };
+    }
+  }
 
   return {
     withSuccess: function (chargeObject) {
-      return mock(true, chargeObject);
+      return mock(true, chargeObject)
     },
-    withFailure: function() {
-      return mock(false);
+    withFailure: function () {
+      return mock(false)
     }
   }
-}();
+}())
 
-var mockToken = function () {
+var mockToken = (function () {
   var mock = function (withSuccess) {
     return function () {
       return {
         destroy: function () {
           var defer = q.defer();
-          (withSuccess) ? defer.resolve() : defer.reject();
-          return defer.promise;
+          (withSuccess) ? defer.resolve() : defer.reject()
+          return defer.promise
         }
       }
-    };
-  };
+    }
+  }
 
   return {
     withSuccess: function () {
-      return mock(true);
+      return mock(true)
     },
-    withFailure: function() {
-      return mock(false);
+    withFailure: function () {
+      return mock(false)
     }
   }
-}();
+}())
 
 var requireSecureController = function (mockedCharge, mockedToken) {
-  return proxyquire(__dirname + '/../../app/controllers/secure_controller.js', {
+  return proxyquire(path.join(__dirname, '/../../app/controllers/secure_controller.js'), {
     '../models/charge.js': mockedCharge,
     '../models/token.js': mockedToken,
     'csrf': function () {
       return {
         secretSync: function () {
-          return 'foo';
+          return 'foo'
         }
       }
     }
   })
-};
+}
 
 describe('secure controller', function () {
   describe('get method', function () {
-
-    var request, response, chargeObject;
+    var request, response, chargeObject
 
     before(function () {
       request = {
         frontend_state: {},
         params: {chargeTokenId: 1},
-        headers:{'x-Request-id': 'unique-id'}
-      };
+        headers: {'x-Request-id': 'unique-id'}
+      }
 
       response = {
         redirect: sinon.spy(),
         render: sinon.spy(),
         status: sinon.spy()
-      };
+      }
 
       chargeObject = {
-        "externalId": "dh6kpbb4k82oiibbe4b9haujjk",
-        "status": "CREATED",
-        "gatewayAccount": {
-          "service_name": "Service Name",
-          "analytics_id": "bla-1234",
-          "type": "live",
-          "payment_provider": "worldpay"
+        'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
+        'status': 'CREATED',
+        'gatewayAccount': {
+          'service_name': 'Service Name',
+          'analytics_id': 'bla-1234',
+          'type': 'live',
+          'payment_provider': 'worldpay'
         }
-      };
-    });
+      }
+    })
 
     describe('when the token is invalid', function () {
       it('should display the generic error page', function (done) {
-        requireSecureController(mockCharge.withFailure(), mockToken.withSuccess()).new(request, response);
-        setTimeout(function(){
-          expect(response.render.calledWith('errors/system_error',
-              {
-                viewName: 'SYSTEM_ERROR',
-                analytics : {
-                  "analyticsId": "Service unavailable",
-                  "type": "Service unavailable",
-                  "paymentProvider": "Service unavailable"
-                }
-              })).to.be.true;
+        requireSecureController(mockCharge.withFailure(), mockToken.withSuccess()).new(request, response)
+        setTimeout(function () {
+          var systemErrorObj = {
+            viewName: 'SYSTEM_ERROR',
+            analytics: {
+              'analyticsId': 'Service unavailable',
+              'type': 'Service unavailable',
+              'paymentProvider': 'Service unavailable'
+            }
+          }
+          expect(response.render.calledWith('errors/system_error', systemErrorObj)).to.be.true // eslint-disable-line
           done()
-        },0);
-      });
-    });
+        }, 0)
+      })
+    })
 
     describe('when the token is valid', function () {
       describe('and not destroyed successfully', function () {
         it('should display the generic error page', function () {
-          requireSecureController(mockCharge.withSuccess(), mockToken.withFailure()).new(request, response);
-          expect(response.render.calledWith('errors/system_error',
-              {
-                viewName: 'SYSTEM_ERROR',
-                analytics : {
-                  "analyticsId": "Service unavailable",
-                  "type": "Service unavailable",
-                  "paymentProvider": "Service unavailable"
-                }
-              })).to.be.true;
-        });
-      });
+          requireSecureController(mockCharge.withSuccess(), mockToken.withFailure()).new(request, response)
+          var systemErrorObj = {
+            viewName: 'SYSTEM_ERROR',
+            analytics: {
+              'analyticsId': 'Service unavailable',
+              'type': 'Service unavailable',
+              'paymentProvider': 'Service unavailable'
+            }
+          }
+          expect(response.render.calledWith('errors/system_error', systemErrorObj)).to.be.true // eslint-disable-line
+        })
+      })
 
       describe('then destroyed successfully', function () {
         it('should store the service name into the session and redirect', function (done) {
-          requireSecureController(mockCharge.withSuccess(chargeObject), mockToken.withSuccess()).new(request, response);
+          requireSecureController(mockCharge.withSuccess(chargeObject), mockToken.withSuccess()).new(request, response)
 
-          setTimeout(function(){
-            expect(response.redirect.calledWith(303,paths.generateRoute("card.new", {chargeId: chargeObject.externalId}))).to.be.true;
+          setTimeout(function () {
+            expect(response.redirect.calledWith(303, paths.generateRoute('card.new', {chargeId: chargeObject.externalId}))).to.be.true // eslint-disable-line
 
-            expect(request.frontend_state).to.have.all.keys('ch_dh6kpbb4k82oiibbe4b9haujjk');
+            expect(request.frontend_state).to.have.all.keys('ch_dh6kpbb4k82oiibbe4b9haujjk')
             expect(request.frontend_state['ch_dh6kpbb4k82oiibbe4b9haujjk']).to.eql({
               'csrfSecret': 'foo'
-            });
+            })
 
-            done();
-          },0);
-        });
-      });
-    });
-
-  });
-});
-
-
+            done()
+          }, 0)
+        })
+      })
+    })
+  })
+})

--- a/test/controllers/static_controller_test.js
+++ b/test/controllers/static_controller_test.js
@@ -1,65 +1,52 @@
-/*jslint node: true */
-
-require(__dirname + '/../test_helpers/html_assertions.js');
-var sinon = require('sinon');
-var expect = require('chai').expect;
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
+var sinon = require('sinon')
+var expect = require('chai').expect
 
 var requireStaticController = function () {
-  return require(__dirname + '/../../app/controllers/static_controller.js');
-};
+  return require(path.join(__dirname, '/../../app/controllers/static_controller.js'))
+}
 
 describe('static controller', function () {
   describe('privacy endpoint', function () {
-
-    var request, response;
+    var request, response
 
     before(function () {
-
       request = {
-      };
+      }
 
       response = {
         redirect: sinon.spy(),
         render: sinon.spy(),
         status: sinon.spy()
-      };
-    });
-
+      }
+    })
 
     it('should render ok', function () {
-      requireStaticController().privacy(request, response);
-      expect(response.render.calledWith('static/privacy')).to.be.true;
-    });
-  });
-
+      requireStaticController().privacy(request, response)
+      expect(response.render.calledWith('static/privacy')).to.be.true // eslint-disable-line
+    })
+  })
 
   describe('naxsi system error endpoint', function () {
-
-    var request, response;
+    var request, response
 
     before(function () {
-
       request = {
         headers: {}
-      };
+      }
 
       response = {
         redirect: sinon.spy(),
         render: sinon.spy(),
         status: sinon.spy()
-      };
-    });
-
+      }
+    })
 
     it('should render ok', function () {
-      requireStaticController().naxsi_error(request, response);
-      expect(response.render.calledWith('error')).to.be.true;
-      expect(response.status.calledWith(400)).to.be.true;
-
-    });
-  });
-
-
-
-
-});
+      requireStaticController().naxsi_error(request, response)
+      expect(response.render.calledWith('error')).to.be.true // eslint-disable-line
+      expect(response.status.calledWith(400)).to.be.true // eslint-disable-line 
+    })
+  })
+})

--- a/test/enforce_status_views_tests.js
+++ b/test/enforce_status_views_tests.js
@@ -1,81 +1,75 @@
-process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk';
+process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+var path = require('path')
+var request = require('supertest')
+var app = require(path.join(__dirname, '/../server.js')).getApp
+var helper = require(path.join(__dirname, '/test_helpers/test_helpers.js'))
+var nock = require('nock')
 
-var request = require('supertest');
-var portfinder = require('portfinder');
-var app = require(__dirname + '/../server.js').getApp;
-var should = require('chai').should();
-var helper = require(__dirname + '/test_helpers/test_helpers.js');
-var nock = require('nock');
-var paths = require(__dirname + '/../app/paths.js');
+var cookie = require(path.join(__dirname, '/test_helpers/session.js'))
 
-
-
-
-var cookie = require(__dirname + '/test_helpers/session.js');
-
-var chargeId = '23144323';
-var frontendCardDetailsPath = '/card_details';
+var chargeId = '23144323'
+var frontendCardDetailsPath = '/card_details'
 
 describe('The /charge endpoint undealt statuses', function () {
-  var charge_not_allowed_statuses = [
+  var chargeNotAllowedStatuses = [
     'READY_FOR_CAPTURE'
-  ];
+  ]
 
-  charge_not_allowed_statuses.forEach(function (status) {
-    beforeEach(function(){
-      nock.cleanAll();
+  chargeNotAllowedStatuses.forEach(function (status) {
+    beforeEach(function () {
+      nock.cleanAll()
       nock(process.env.CONNECTOR_HOST)
-      .get('/v1/frontend/charges/' + chargeId).reply(200,helper.raw_successful_get_charge(
-        status,"http://www.example.com/service"
-      ));
-    });
+      .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(
+        status, 'http://www.example.com/service'
+      ))
+    })
 
     it('should error when the payment status is ' + status, function (done) {
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId)
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
         .expect(500)
-        .expect(function(res){
-          helper.templateValue(res,"message", "There is a problem, please try again later");
+        .expect(function (res) {
+          helper.templateValue(res, 'message', 'There is a problem, please try again later')
         })
-        .end(done);
-    });
-  });
-});
+        .end(done)
+    })
+  })
+})
 
 describe('The /charge endpoint dealt statuses', function () {
-  var charge_allowed_statuses = [
+  var chargeAllowedStatuses = [
     {
       name: 'authorisation success',
-      view: "AUTHORISATION_SUCCESS"
+      view: 'AUTHORISATION_SUCCESS'
     },
     {
       name: 'authorisation rejected',
-      view: "AUTHORISATION_REJECTED"
+      view: 'AUTHORISATION_REJECTED'
     },
     {
       name: 'authorisation cancelled',
-      view: "AUTHORISATION_CANCELLED"
+      view: 'AUTHORISATION_CANCELLED'
     },
     {
       name: 'authorisation 3ds required',
-      view: "AUTHORISATION_3DS_REQUIRED"
+      view: 'AUTHORISATION_3DS_REQUIRED'
     },
     {
       name: 'system error',
-      view: "SYSTEM_ERROR"
+      view: 'SYSTEM_ERROR'
     },
     {
       name: 'captured',
-      view: "CAPTURED"
+      view: 'CAPTURED'
     },
     {
       name: 'capture failure',
-      view: "CAPTURE_FAILURE"
+      view: 'CAPTURE_FAILURE'
     },
     {
       name: 'capture submitted',
-      view: "CAPTURE_SUBMITTED"
+      view: 'CAPTURE_SUBMITTED'
     },
     {
       name: 'expired',
@@ -103,102 +97,96 @@ describe('The /charge endpoint dealt statuses', function () {
     },
     {
       name: 'system cancel ready',
-      view: "SYSTEM_CANCEL_READY"
+      view: 'SYSTEM_CANCEL_READY'
     },
     {
       name: 'system cancel error',
-      view: "SYSTEM_CANCEL_ERROR"
+      view: 'SYSTEM_CANCEL_ERROR'
     },
     {
       name: 'user cancel ready',
-      view: "USER_CANCEL_READY"
+      view: 'USER_CANCEL_READY'
     },
     {
       name: 'user cancel error',
-      view: "USER_CANCEL_ERROR"
+      view: 'USER_CANCEL_ERROR'
     }
-  ];
-  beforeEach(function() {
-    nock.cleanAll();
-  });
+  ]
+  beforeEach(function () {
+    nock.cleanAll()
+  })
 
-  charge_allowed_statuses.forEach(function (state) {
-
+  chargeAllowedStatuses.forEach(function (state) {
     it('should not error when the payment status is ' + state.name, function (done) {
       nock(process.env.CONNECTOR_HOST)
-      .get('/v1/frontend/charges/' + chargeId).reply(200, helper.raw_successful_get_charge(
-        state.name,"http://www.example.com/service"
-      ));
+      .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(
+        state.name, 'http://www.example.com/service'
+      ))
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId)
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
-        .expect(function(res){
-          helper.templateValue(res,"viewName", state.view);
-          helper.templateValue(res,"chargeId", chargeId);
+        .expect(function (res) {
+          helper.templateValue(res, 'viewName', state.view)
+          helper.templateValue(res, 'chargeId', chargeId)
         })
-        .end(done);
-    });
-  });
-});
-
+        .end(done)
+    })
+  })
+})
 
 describe('The /confirm endpoint undealt statuses', function () {
-  var confirm_not_allowed_statuses = [
+  var confirmNotAllowedStatuses = [
     'CREATED',
     'AUTHORISATION SUBMITTED',
     'READY_FOR_CAPTURE'
-  ];
-  beforeEach(function() {
-    nock.cleanAll();
-  });
+  ]
+  beforeEach(function () {
+    nock.cleanAll()
+  })
 
-  afterEach(function() {
-    nock.cleanAll();
-  });
+  afterEach(function () {
+    nock.cleanAll()
+  })
 
-
-
-
-  confirm_not_allowed_statuses.forEach(function (status) {
+  confirmNotAllowedStatuses.forEach(function (status) {
     it('should error when the payment status is ' + status, function (done) {
       nock(process.env.CONNECTOR_HOST)
-      .get('/v1/frontend/charges/' + chargeId).reply(200,helper.raw_successful_get_charge(
-        status,"http://www.example.com/service"
-      ));
+      .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(
+        status, 'http://www.example.com/service'
+      ))
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId + '/confirm')
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
         .expect(500)
-        .expect(function(res){
-          helper.templateValue(res,"message", "There is a problem, please try again later");
+        .expect(function (res) {
+          helper.templateValue(res, 'message', 'There is a problem, please try again later')
         })
-        .end(done);
-    });
-  });
-});
-
+        .end(done)
+    })
+  })
+})
 
 describe('The /confirm endpoint dealt statuses', function () {
-  var confirm_allowed_statuses = [
+  var confirmAllowedStatuses = [
     {
       name: 'capture submitted',
-      view: "CAPTURE_SUBMITTED",
+      view: 'CAPTURE_SUBMITTED',
       viewState: 'successful'
     },
     {
       name: 'captured',
-      view: "CAPTURED",
+      view: 'CAPTURED',
       viewState: 'successful'
     },
     {
       name: 'capture failure',
-      view: "CAPTURE_FAILURE"
+      view: 'CAPTURE_FAILURE'
     },
     {
       name: 'system error',
-      view: "SYSTEM_ERROR"
+      view: 'SYSTEM_ERROR'
     },
     {
       name: 'expired',
@@ -210,19 +198,19 @@ describe('The /confirm endpoint dealt statuses', function () {
     },
     {
       name: 'authorisation success',
-      view: "AUTHORISATION_SUCCESS"
+      view: 'AUTHORISATION_SUCCESS'
     },
     {
       name: 'authorisation rejected',
-      view: "AUTHORISATION_REJECTED"
+      view: 'AUTHORISATION_REJECTED'
     },
     {
       name: 'authorisation ready',
-      view: "AUTHORISATION_READY"
+      view: 'AUTHORISATION_READY'
     },
     {
       name: 'authorisation 3ds required',
-      view: "AUTHORISATION_3DS_REQUIRED"
+      view: 'AUTHORISATION_3DS_REQUIRED'
     },
     {
       name: 'capture error',
@@ -238,44 +226,44 @@ describe('The /confirm endpoint dealt statuses', function () {
     },
     {
       name: 'system cancel ready',
-      view: "SYSTEM_CANCEL_READY"
+      view: 'SYSTEM_CANCEL_READY'
     },
     {
       name: 'system cancel error',
-      view: "SYSTEM_CANCEL_ERROR"
+      view: 'SYSTEM_CANCEL_ERROR'
     },
     {
       name: 'user cancel ready',
-      view: "USER_CANCEL_READY"
+      view: 'USER_CANCEL_READY'
     },
     {
       name: 'user cancel error',
-      view: "USER_CANCEL_ERROR"
+      view: 'USER_CANCEL_ERROR'
     }
-  ];
-  beforeEach(function() {
-    nock.cleanAll();
-  });
+  ]
+  beforeEach(function () {
+    nock.cleanAll()
+  })
 
-  afterEach(function() {
-    nock.cleanAll();
-  });
+  afterEach(function () {
+    nock.cleanAll()
+  })
 
-  confirm_allowed_statuses.forEach(function (state) {
+  confirmAllowedStatuses.forEach(function (state) {
     it('should not error when the payment status is ' + state.name, function (done) {
       nock(process.env.CONNECTOR_HOST)
-      .get('/v1/frontend/charges/' + chargeId).reply(200,helper.raw_successful_get_charge(
-        state.name,"http://www.example.com/service"
-      ));
+      .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(
+        state.name, 'http://www.example.com/service'
+      ))
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId + '/confirm')
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
-        .expect(function(res){
-          helper.templateValue(res,"viewName", state.view);
-          if (state.viewState) helper.templateValue(res,"status", state.viewState);
+        .expect(function (res) {
+          helper.templateValue(res, 'viewName', state.view)
+          if (state.viewState) helper.templateValue(res, 'status', state.viewState)
         })
-        .end(done);
-    });
-  });
-});
+        .end(done)
+    })
+  })
+})

--- a/test/error_ui_tests.js
+++ b/test/error_ui_tests.js
@@ -1,11 +1,10 @@
+var path = require('path')
+var renderTemplate = require(path.join(__dirname, '/test_helpers/html_assertions.js')).render
 
-var renderTemplate = require(__dirname + '/test_helpers/html_assertions.js').render;
-
- describe('The error view', function() {
-  it('should render an error message', function() {
-    var msg = 'shut up and take my money!';
-    var body = renderTemplate('error', { 'message' : msg });
-    body.should.containSelector('#errorMsg').withText(msg);
-
-  });
-});
+describe('The error view', function () {
+  it('should render an error message', function () {
+    var msg = 'shut up and take my money!'
+    var body = renderTemplate('error', { 'message': msg })
+    body.should.containSelector('#errorMsg').withText(msg)
+  })
+})

--- a/test/integration/charge_ft_tests.js
+++ b/test/integration/charge_ft_tests.js
@@ -1,62 +1,57 @@
-var EMPTY_BODY = '';
+var EMPTY_BODY = ''
 
-var _ = require('lodash');
-var request = require('supertest');
-var nock = require('nock');
-var app = require('../../server.js').getApp;
-var mock_templates = require('../test_helpers/mock_templates.js');
-app.engine('html', mock_templates.__express);
-var csrf = require('csrf');
-var expect = require('chai').expect;
+var _ = require('lodash')
+var request = require('supertest')
+var nock = require('nock')
+var app = require('../../server.js').getApp
+var mockTemplates = require('../test_helpers/mock_templates.js')
+app.engine('html', mockTemplates.__express)
+var expect = require('chai').expect
 
-var should = require('chai').should();
+var should = require('chai').should()
 
-var cookie = require('../test_helpers/session.js');
-var helper = require('../test_helpers/test_helpers.js');
+var cookie = require('../test_helpers/session.js')
+var helper = require('../test_helpers/test_helpers.js')
 
-var winston = require('winston');
+var winston = require('winston')
 
-var {get_charge_request, post_charge_request} = require('../test_helpers/test_helpers.js');
-var connector_response_for_put_charge = require('../test_helpers/test_helpers.js').connector_response_for_put_charge;
-var default_connector_response_for_get_charge = require('../test_helpers/test_helpers.js').default_connector_response_for_get_charge;
-var State = require('../../app/models/state.js');
+var {getChargeRequest, postChargeRequest} = require('../test_helpers/test_helpers.js')
+var connectorResponseForPutCharge = require('../test_helpers/test_helpers.js').connectorResponseForPutCharge
+var defaultConnectorResponseForGetCharge = require('../test_helpers/test_helpers.js').defaultConnectorResponseForGetCharge
+var State = require('../../app/models/state.js')
+var connectorMock
 
-
-
-var defaultCardID = function (cardNumber) {
+var defaultCardID = function () {
   nock(process.env.CARDID_HOST)
-    .post("/v1/api/card", ()=> {
-      return true;
+    .post('/v1/api/card', () => {
+      return true
     })
-    .reply(200, {brand: "visa", label: "visa", type: "D"});
-
-};
+    .reply(200, {brand: 'visa', label: 'visa', type: 'D'})
+}
 
 var defaultCorrelationHeader = {
   reqheaders: {'x-request-id': 'some-unique-id'}
-};
+}
 
 describe('chargeTests', function () {
+  var localServer = process.env.CONNECTOR_HOST
 
-  var localServer = process.env.CONNECTOR_HOST;
+  var connectorChargePath = '/v1/frontend/charges/'
+  var chargeId = '23144323'
+  var frontendCardDetailsPath = '/card_details'
+  var frontendCardDetailsPostPath = '/card_details/' + chargeId
 
-  var connectorChargePath = '/v1/frontend/charges/';
-  var chargeId = '23144323';
-  var frontendCardDetailsPath = '/card_details';
-  var frontendCardDetailsPostPath = '/card_details/' + chargeId;
+  var connectorAuthUrl = localServer + connectorChargePath + chargeId + '/cards'
+  var enteringCardDetailsState = 'ENTERING CARD DETAILS'
+  var RETURN_URL = 'http://www.example.com/service'
 
-  var connectorAuthUrl = localServer + connectorChargePath + chargeId + '/cards';
-  var enteringCardDetailsState = 'ENTERING CARD DETAILS';
-  var RETURN_URL = 'http://www.example.com/service';
-
-
-  function connector_expects(data) {
-    return connectorMock.post(connectorChargePath + chargeId + '/cards', data);
+  function connectorExpects (data) {
+    return connectorMock.post(connectorChargePath + chargeId + '/cards', data)
   }
 
-  function minimum_connector_card_data(card_number) {
+  function minimumConnectorCardData (cardNumber) {
     return {
-      'card_number': card_number,
+      'card_number': cardNumber,
       'cvc': '234',
       'expiry_date': '11/99',
       'card_brand': 'visa',
@@ -67,29 +62,29 @@ describe('chargeTests', function () {
         'country': 'GB',
         'city': 'Willy wonka'
       }
-    };
+    }
   }
 
-  function full_connector_card_data(card_number) {
-    var card_data = minimum_connector_card_data(card_number);
-    card_data.address.line2 = 'bla bla';
-    card_data.address.city = 'London';
-    card_data.address.country = 'GB';
-    return card_data;
+  function fullConnectorCardData (cardNumber) {
+    var cardData = minimumConnectorCardData(cardNumber)
+    cardData.address.line2 = 'bla bla'
+    cardData.address.city = 'London'
+    cardData.address.country = 'GB'
+    return cardData
   }
 
-  function full_form_card_data(card_number) {
-    var card_data = minimum_form_card_data(card_number);
-    card_data.addressLine2 = 'bla bla';
-    return card_data;
+  function fullFormCardData (cardNumber) {
+    var cardData = minimumFormCardData(cardNumber)
+    cardData.addressLine2 = 'bla bla'
+    return cardData
   }
 
-  function minimum_form_card_data(card_number) {
+  function minimumFormCardData (cardNumber) {
     return {
       'returnUrl': RETURN_URL,
       'cardUrl': connectorAuthUrl,
       'chargeId': chargeId,
-      'cardNo': card_number,
+      'cardNo': cardNumber,
       'cvc': '234',
       'expiryMonth': '11',
       'expiryYear': '99',
@@ -99,37 +94,36 @@ describe('chargeTests', function () {
       'addressCity': 'Willy wonka',
       'email': 'willy@wonka.com',
       'addressCountry': 'GB'
-    };
+    }
   }
 
-  function missing_form_card_data() {
+  function missingFormCardData () {
     return {
       'chargeId': chargeId,
       'returnUrl': RETURN_URL
-    };
+    }
   }
 
   beforeEach(function () {
-    nock.cleanAll();
-    connectorMock = nock(localServer);
-
-  });
+    nock.cleanAll()
+    connectorMock = nock(localServer)
+  })
 
   before(function () {
     // Disable logging.
-    winston.level = 'none';
-  });
+    winston.level = 'none'
+  })
 
   describe('The /charge endpoint', function () {
     describe('Different statuses', function () {
-      function get(status) {
+      function get (status) {
         nock(process.env.CONNECTOR_HOST, defaultCorrelationHeader)
-          .get("/v1/frontend/charges/23144323")
+          .get('/v1/frontend/charges/23144323')
           .reply(200, {
             'amount': 2345,
-            'description': "Payment Description",
+            'description': 'Payment Description',
             'status': status,
-            'return_url': "http://www.example.com/service",
+            'return_url': 'http://www.example.com/service',
             'gateway_account': {
               'analytics_id': 'test-1234',
               'type': 'test',
@@ -141,146 +135,144 @@ describe('chargeTests', function () {
                 'label': 'Visa'
               }]
             }
-          });
+          })
         nock(process.env.CONNECTOR_HOST, defaultCorrelationHeader)
-          .put("/v1/frontend/charges/23144323/status")
-          .reply(204);
+          .put('/v1/frontend/charges/23144323/status')
+          .reply(204)
 
-        var cookieValue = cookie.create(chargeId);
-        return get_charge_request(app, cookieValue, chargeId);
+        var cookieValue = cookie.create(chargeId)
+        return getChargeRequest(app, cookieValue, chargeId)
       }
 
-
-      function getAndCheckChargeRequest(status, done) {
+      function getAndCheckChargeRequest (status, done) {
         get(status)
           .expect(200)
           .expect(function (res) {
-            helper.templateValueNotUndefined(res, "csrf");
-            helper.templateValue(res, "amount", '23.45');
-            helper.templateValue(res, "id", chargeId);
-            helper.templateValue(res, "description", "Payment Description");
-            helper.templateValue(res, "gatewayAccount.paymentProvider", "sandbox");
-            helper.templateValue(res, "gatewayAccount.analyticsId", "test-1234");
-            helper.templateValue(res, "gatewayAccount.type", "test");
-            helper.templateValue(res, "post_card_action", frontendCardDetailsPostPath);
+            helper.templateValueNotUndefined(res, 'csrf')
+            helper.templateValue(res, 'amount', '23.45')
+            helper.templateValue(res, 'id', chargeId)
+            helper.templateValue(res, 'description', 'Payment Description')
+            helper.templateValue(res, 'gatewayAccount.paymentProvider', 'sandbox')
+            helper.templateValue(res, 'gatewayAccount.analyticsId', 'test-1234')
+            helper.templateValue(res, 'gatewayAccount.type', 'test')
+            helper.templateValue(res, 'post_card_action', frontendCardDetailsPostPath)
           })
-          .end(done);
+          .end(done)
       }
 
       it('should include the data required for the frontend when entering card details', function (done) {
-        getAndCheckChargeRequest(enteringCardDetailsState, done);
-      });
+        getAndCheckChargeRequest(enteringCardDetailsState, done)
+      })
 
       it('should include the data required for the frontend when in created state', function (done) {
-        getAndCheckChargeRequest("CREATED", done);
-      });
+        getAndCheckChargeRequest('CREATED', done)
+      })
 
       it('should show error page when the charge is not in a state we deal with', function (done) {
-        get("invalid")
+        get('invalid')
           .expect(500)
           .expect(function (res) {
-            helper.templateValue(res, "message", "There is a problem, please try again later");
-          }).end(done);
-      });
+            helper.templateValue(res, 'message', 'There is a problem, please try again later')
+          }).end(done)
+      })
 
       it('should show appropriate error page when the charge is in a state we deal with', function (done) {
-        get("authorisation success")
+        get('authorisation success')
           .expect(200)
           .expect(function (res) {
-            helper.templateValue(res, "viewName", "AUTHORISATION_SUCCESS");
-          }).end(done);
-      });
+            helper.templateValue(res, 'viewName', 'AUTHORISATION_SUCCESS')
+          }).end(done)
+      })
 
       it('should show auth failure page when the authorisation has been rejected', function (done) {
-        get("authorisation rejected")
+        get('authorisation rejected')
           .expect(200)
           .expect(function (res) {
-            helper.templateValue(res, "viewName", "AUTHORISATION_REJECTED");
-          }).end(done);
-      });
+            helper.templateValue(res, 'viewName', 'AUTHORISATION_REJECTED')
+          }).end(done)
+      })
 
       it('should show auth failure page when the authorisation has been cancelled', function (done) {
-        get("authorisation cancelled")
+        get('authorisation cancelled')
           .expect(200)
-          .expect(function(res){
-            helper.templateValue(res,"viewName","AUTHORISATION_CANCELLED");
-          }).end(done);
-      });
-
-    });
+          .expect(function (res) {
+            helper.templateValue(res, 'viewName', 'AUTHORISATION_CANCELLED')
+          }).end(done)
+      })
+    })
 
     it('should redirect user to auth_waiting when connector returns 202', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(200);
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      defaultCardID('4242424242424242');
+        .patch('/v1/frontend/charges/23144323')
+        .reply(200)
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      defaultCardID('4242424242424242')
 
-      connector_expects(minimum_connector_card_data('4242424242424242'))
-        .reply(202);
+      connectorExpects(minimumConnectorCardData('4242424242424242'))
+        .reply(202)
 
-      post_charge_request(app, cookieValue, minimum_form_card_data('4242 4242 4242 4242'), chargeId)
+      postChargeRequest(app, cookieValue, minimumFormCardData('4242 4242 4242 4242'), chargeId)
         .expect(303)
         .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/auth_waiting')
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should redirect user to auth_waiting when connector returns 409', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(200);
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      defaultCardID('4242424242424242');
+        .patch('/v1/frontend/charges/23144323')
+        .reply(200)
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      defaultCardID('4242424242424242')
 
-      connector_expects(minimum_connector_card_data('4242424242424242'))
-        .reply(409);
+      connectorExpects(minimumConnectorCardData('4242424242424242'))
+        .reply(409)
 
-      post_charge_request(app, cookieValue, minimum_form_card_data('4242 4242 4242 4242'), chargeId)
+      postChargeRequest(app, cookieValue, minimumFormCardData('4242 4242 4242 4242'), chargeId)
         .expect(303)
         .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/auth_waiting')
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should redirect user to confirm when connector returns 200 for authorisation success', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(200);
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      defaultCardID('4242424242424242');
+        .patch('/v1/frontend/charges/23144323')
+        .reply(200)
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      defaultCardID('4242424242424242')
 
-      connector_expects(minimum_connector_card_data('4242424242424242'))
-        .reply(200, {status: State.AUTH_SUCCESS});
+      connectorExpects(minimumConnectorCardData('4242424242424242'))
+        .reply(200, {status: State.AUTH_SUCCESS})
 
-      post_charge_request(app, cookieValue, minimum_form_card_data('4242 4242 4242 4242'), chargeId)
+      postChargeRequest(app, cookieValue, minimumFormCardData('4242 4242 4242 4242'), chargeId)
         .expect(303)
         .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/confirm')
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should redirect user to confirm when connector returns 200 for authorisation and 3DS is required', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(200);
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      defaultCardID('4242424242424242');
+        .patch('/v1/frontend/charges/23144323')
+        .reply(200)
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      defaultCardID('4242424242424242')
 
-      connector_expects(minimum_connector_card_data('4242424242424242'))
-        .reply(200, {status: State.AUTH_3DS_REQUIRED});
+      connectorExpects(minimumConnectorCardData('4242424242424242'))
+        .reply(200, {status: State.AUTH_3DS_REQUIRED})
 
-      post_charge_request(app, cookieValue, minimum_form_card_data('4242 4242 4242 4242'), chargeId)
+      postChargeRequest(app, cookieValue, minimumFormCardData('4242 4242 4242 4242'), chargeId)
         .expect(303)
         .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/3ds_required')
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should redirect user from /auth_waiting to /confirm when connector returns a successful status', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
-      default_connector_response_for_get_charge(chargeId, State.AUTH_SUCCESS);
+      defaultConnectorResponseForGetCharge(chargeId, State.AUTH_SUCCESS)
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId + '/auth_waiting')
@@ -289,13 +281,13 @@ describe('chargeTests', function () {
         .set('Accept', 'application/json')
         .expect(303)
         .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/confirm')
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should redirect user from /auth_waiting to /3ds_required when connector returns that 3DS is required for authorisation', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
-      default_connector_response_for_get_charge(chargeId, State.AUTH_3DS_REQUIRED);
+      defaultConnectorResponseForGetCharge(chargeId, State.AUTH_3DS_REQUIRED)
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId + '/auth_waiting')
@@ -304,13 +296,13 @@ describe('chargeTests', function () {
         .set('Accept', 'application/json')
         .expect(303)
         .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/3ds_required')
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should keep user in /auth_waiting when connector returns an authorisation ready state', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
-      default_connector_response_for_get_charge(chargeId, State.AUTH_READY);
+      defaultConnectorResponseForGetCharge(chargeId, State.AUTH_READY)
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId + '/auth_waiting')
@@ -319,15 +311,15 @@ describe('chargeTests', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "auth_waiting");
+          helper.templateValue(res, 'viewName', 'auth_waiting')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should give an error page if user is in entering card details state', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId + '/auth_waiting')
@@ -335,299 +327,293 @@ describe('chargeTests', function () {
         .set('Cookie', ['frontend_state=' + cookieValue])
         .set('Accept', 'application/json')
         .expect(500)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error without csrf', function (done) {
-      var cookieValue = cookie.create(chargeId);
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      connector_expects(minimum_connector_card_data('5105105105105100'))
-        .reply(204);
-      post_charge_request(app, cookieValue, minimum_form_card_data('5105 1051 0510 5100'), chargeId, false)
+      var cookieValue = cookie.create(chargeId)
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      connectorExpects(minimumConnectorCardData('5105105105105100'))
+        .reply(204)
+      postChargeRequest(app, cookieValue, minimumFormCardData('5105 1051 0510 5100'), chargeId, false)
         .expect(500)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should send card data including optional fields to connector', function (done) {
-      var cookieValue = cookie.create(chargeId);
-      defaultCardID('4242424242424242');
+      var cookieValue = cookie.create(chargeId)
+      defaultCardID('4242424242424242')
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(200);
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
+        .patch('/v1/frontend/charges/23144323')
+        .reply(200)
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
 
-      var card_data = full_connector_card_data('5105105105105100');
+      var cardData = fullConnectorCardData('5105105105105100')
 
-      connector_expects(card_data).reply(200);
+      connectorExpects(cardData).reply(200)
 
-      var form_data = minimum_form_card_data('5105105105105100');
-      form_data.addressLine2 = card_data.address.line2;
-      form_data.addressCity = card_data.address.city;
+      var formData = minimumFormCardData('5105105105105100')
+      formData.addressLine2 = cardData.address.line2
+      formData.addressCity = cardData.address.city
 
-      post_charge_request(app, cookieValue, form_data, chargeId)
+      postChargeRequest(app, cookieValue, formData, chargeId)
         .expect(303)
         .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/confirm')
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('show an error page when authorization was refused', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(200);
+        .patch('/v1/frontend/charges/23144323')
+        .reply(200)
 
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      defaultCardID('4242424242424242');
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      defaultCardID('4242424242424242')
 
-      connector_expects(minimum_connector_card_data('5105105105105100'))
-        .reply(400, {'message': 'This transaction was declined.'});
+      connectorExpects(minimumConnectorCardData('5105105105105100'))
+        .reply(400, {'message': 'This transaction was declined.'})
 
-      post_charge_request(app, cookieValue, minimum_form_card_data('5105105105105100'), chargeId)
+      postChargeRequest(app, cookieValue, minimumFormCardData('5105105105105100'), chargeId)
         .expect(303)
         .expect(function (res) {
-          should.equal(res.headers.location, "/card_details/" + chargeId);
+          should.equal(res.headers.location, '/card_details/' + chargeId)
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('show an error page when the chargeId is not found on the session', function (done) {
-      var cookieValue = cookie.create();
+      var cookieValue = cookie.create()
 
-      var card_data = minimum_connector_card_data('5105105105105100');
-      card_data.address.line2 = 'bla bla';
-      card_data.address.city = 'London';
-      card_data.address.country = 'GB';
+      var cardData = minimumConnectorCardData('5105105105105100')
+      cardData.address.line2 = 'bla bla'
+      cardData.address.city = 'London'
+      cardData.address.country = 'GB'
 
-      connector_expects(card_data).reply(200);
+      connectorExpects(cardData).reply(200)
 
-      var form_data = minimum_form_card_data('5105105105105100');
-      form_data.addressLine2 = card_data.address.line2;
-      form_data.addressCity = card_data.address.city;
+      var formData = minimumFormCardData('5105105105105100')
+      formData.addressLine2 = cardData.address.line2
+      formData.addressCity = cardData.address.city
 
-      post_charge_request(app, cookieValue, form_data, chargeId)
+      postChargeRequest(app, cookieValue, formData, chargeId)
         .expect(403)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "UNAUTHORISED");
+          helper.templateValue(res, 'viewName', 'UNAUTHORISED')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('shows an error when a card is submitted that does not pass the luhn algorithm', function (done) {
-      var cookieValue = cookie.create(chargeId);
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      defaultCardID('1111111111111111');
-      post_charge_request(app, cookieValue, minimum_form_card_data('1111111111111111'), chargeId)
+      var cookieValue = cookie.create(chargeId)
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      defaultCardID('1111111111111111')
+      postChargeRequest(app, cookieValue, minimumFormCardData('1111111111111111'), chargeId)
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "id", chargeId);
-          helper.templateValue(res, "post_card_action", frontendCardDetailsPostPath);
-          helper.templateValue(res, "hasError", true);
-          helper.templateValue(res, "amount", '23.45');
-          helper.templateValue(res, "errorFields", [{
-            "cssKey": "card-no",
-            "key": "cardNo",
-            "value": "Enter a valid card number"
-          }]);
-          helper.templateValue(res, "highlightErrorFields", {"cardNo": "Enter a valid card number"});
+          helper.templateValue(res, 'id', chargeId)
+          helper.templateValue(res, 'post_card_action', frontendCardDetailsPostPath)
+          helper.templateValue(res, 'hasError', true)
+          helper.templateValue(res, 'amount', '23.45')
+          helper.templateValue(res, 'errorFields', [{
+            'cssKey': 'card-no',
+            'key': 'cardNo',
+            'value': 'Enter a valid card number'
+          }])
+          helper.templateValue(res, 'highlightErrorFields', {'cardNo': 'Enter a valid card number'})
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
-    it("should return country list when invalid fields submitted", (done) => {
-      var cookieValue = cookie.create(chargeId, {});
-      defaultCardID('4242424242424242');
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      post_charge_request(app, cookieValue, missing_form_card_data(), chargeId)
+    it('should return country list when invalid fields submitted', (done) => {
+      var cookieValue = cookie.create(chargeId, {})
+      defaultCardID('4242424242424242')
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      postChargeRequest(app, cookieValue, missingFormCardData(), chargeId)
         .expect((res) => {
-          var body = JSON.parse(res.text);
-          expect(body.countries.length > 0).to.equal(true);
+          var body = JSON.parse(res.text)
+          expect(body.countries.length > 0).to.equal(true)
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('shows an error when a card is submitted with missing fields', function (done) {
-      var cookieValue = cookie.create(chargeId, {});
-      defaultCardID('4242424242424242');
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      post_charge_request(app, cookieValue, missing_form_card_data(), chargeId)
+      var cookieValue = cookie.create(chargeId, {})
+      defaultCardID('4242424242424242')
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      postChargeRequest(app, cookieValue, missingFormCardData(), chargeId)
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "id", chargeId);
-          helper.templateValue(res, "description", "Payment Description");
-          helper.templateValue(res, "post_card_action", frontendCardDetailsPostPath);
-          helper.templateValue(res, "hasError", true);
-          helper.templateValue(res, "amount", "23.45");
-          helper.templateValue(res, "withdrawalText", "accepted credit and debit card types");
-          helper.templateValue(res, "post_cancel_action", "/card_details/23144323/cancel");
-          helper.templateValue(res, "errorFields", [
-            {"key": "cardNo", "cssKey": "card-no", "value": "Enter a valid card number"},
-            {"key": "expiryMonth", "cssKey": "expiry-date", "value": "Enter a valid expiry date"},
-            {"key": "cardholderName", "cssKey": "cardholder-name", "value": "Enter a valid name"},
-            {"key": "cvc", "cssKey": "cvc", "value": "Enter a valid card security code"},
+          helper.templateValue(res, 'id', chargeId)
+          helper.templateValue(res, 'description', 'Payment Description')
+          helper.templateValue(res, 'post_card_action', frontendCardDetailsPostPath)
+          helper.templateValue(res, 'hasError', true)
+          helper.templateValue(res, 'amount', '23.45')
+          helper.templateValue(res, 'withdrawalText', 'accepted credit and debit card types')
+          helper.templateValue(res, 'post_cancel_action', '/card_details/23144323/cancel')
+          helper.templateValue(res, 'errorFields', [
+            {'key': 'cardNo', 'cssKey': 'card-no', 'value': 'Enter a valid card number'},
+            {'key': 'expiryMonth', 'cssKey': 'expiry-date', 'value': 'Enter a valid expiry date'},
+            {'key': 'cardholderName', 'cssKey': 'cardholder-name', 'value': 'Enter a valid name'},
+            {'key': 'cvc', 'cssKey': 'cvc', 'value': 'Enter a valid card security code'},
             {
-              "key": "addressLine1",
-              "cssKey": "address-line-1",
-              "value": "Enter a valid building name/number and street"
+              'key': 'addressLine1',
+              'cssKey': 'address-line-1',
+              'value': 'Enter a valid building name/number and street'
             },
-            {"key": "addressCity", "cssKey": "address-city", "value": "Enter a valid town/city"},
-            {"key": "addressPostcode", "cssKey": "address-postcode", "value": "Enter a valid postcode"},
-            {"key": "email", "cssKey": "email", "value": "Enter a valid email"},
-            {"key": "addressCountry", "cssKey": "address-country", "value": "Enter a valid country or territory"}
-          ]);
+            {'key': 'addressCity', 'cssKey': 'address-city', 'value': 'Enter a valid town/city'},
+            {'key': 'addressPostcode', 'cssKey': 'address-postcode', 'value': 'Enter a valid postcode'},
+            {'key': 'email', 'cssKey': 'email', 'value': 'Enter a valid email'},
+            {'key': 'addressCountry', 'cssKey': 'address-country', 'value': 'Enter a valid country or territory'}
+          ])
 
-          helper.templateValue(res, "highlightErrorFields", {
-            "cardholderName": "Enter the name as it appears on the card",
-            "cvc": "Enter a valid card security code",
-            "email": "Enter a valid email",
-            "expiryMonth": "Enter a valid expiry date",
-            "expiryYear": "Enter a valid expiry date",
-            "cardNo": "Enter a valid card number",
-            "addressCity": "Enter a valid town/city",
-            "addressLine1": "Enter a valid billing address",
-            "addressPostcode": "Enter a valid postcode",
-            "addressCountry": "Enter a valid country or territory"
-          });
-
+          helper.templateValue(res, 'highlightErrorFields', {
+            'cardholderName': 'Enter the name as it appears on the card',
+            'cvc': 'Enter a valid card security code',
+            'email': 'Enter a valid email',
+            'expiryMonth': 'Enter a valid expiry date',
+            'expiryYear': 'Enter a valid expiry date',
+            'cardNo': 'Enter a valid card number',
+            'addressCity': 'Enter a valid town/city',
+            'addressLine1': 'Enter a valid billing address',
+            'addressPostcode': 'Enter a valid postcode',
+            'addressCountry': 'Enter a valid country or territory'
+          })
         })
-        .end(done);
-    });
-
+        .end(done)
+    })
 
     it('shows an error when a card is submitted that is not supported', function (done) {
-      var cookieValue = cookie.create(chargeId, {});
-      nock.cleanAll();
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
+      var cookieValue = cookie.create(chargeId, {})
+      nock.cleanAll()
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
       nock(process.env.CARDID_HOST)
-        .post("/v1/api/card", ()=> {
-          return true;
+        .post('/v1/api/card', () => {
+          return true
         })
-        .reply(200, {brand: "foobar", label: "foobar", type: "D"});
-      post_charge_request(app, cookieValue, minimum_form_card_data('3528000700000000'), chargeId)
+        .reply(200, {brand: 'foobar', label: 'foobar', type: 'D'})
+      postChargeRequest(app, cookieValue, minimumFormCardData('3528000700000000'), chargeId)
         .expect(200)
         .expect(function (res) {
-
-          helper.templateValue(res, "id", chargeId);
-          helper.templateValue(res, "description", "Payment Description");
-          helper.templateValue(res, "post_card_action", frontendCardDetailsPostPath);
-          helper.templateValue(res, "hasError", true);
-          helper.templateValue(res, "amount", "23.45");
-          helper.templateValue(res, "errorFields", [
-            {"key": "cardNo", "cssKey": "card-no", "value": "Foobar is not supported"},
-          ]);
-          helper.templateValue(res, "highlightErrorFields", {
-            "cardNo": "Foobar is not supported",
-          });
-
+          helper.templateValue(res, 'id', chargeId)
+          helper.templateValue(res, 'description', 'Payment Description')
+          helper.templateValue(res, 'post_card_action', frontendCardDetailsPostPath)
+          helper.templateValue(res, 'hasError', true)
+          helper.templateValue(res, 'amount', '23.45')
+          helper.templateValue(res, 'errorFields', [
+            {'key': 'cardNo', 'cssKey': 'card-no', 'value': 'Foobar is not supported'}
+          ])
+          helper.templateValue(res, 'highlightErrorFields', {
+            'cardNo': 'Foobar is not supported'
+          })
         })
-        .end(done);
-    });
-
+        .end(done)
+    })
 
     it('shows an error when a card is submitted that is not supported withdrawal type', function (done) {
-      var cookieValue = cookie.create(chargeId, {});
-      nock.cleanAll();
+      var cookieValue = cookie.create(chargeId, {})
+      nock.cleanAll()
       nock(process.env.CARDID_HOST)
-        .post("/v1/api/card", ()=> {
-          return true;
+        .post('/v1/api/card', () => {
+          return true
         })
-        .reply(200, {brand: "american-express", label: "american express", type: "D"});
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      post_charge_request(app, cookieValue, minimum_form_card_data('3528000700000000'), chargeId)
+        .reply(200, {brand: 'american-express', label: 'american express', type: 'D'})
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      postChargeRequest(app, cookieValue, minimumFormCardData('3528000700000000'), chargeId)
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "id", chargeId);
-          helper.templateValue(res, "description", "Payment Description");
-          helper.templateValue(res, "post_card_action", frontendCardDetailsPostPath);
-          helper.templateValue(res, "hasError", true);
-          helper.templateValue(res, "amount", "23.45");
-          helper.templateValue(res, "errorFields", [
-            {"key": "cardNo", "cssKey": "card-no", "value": "American Express debit cards are not supported"},
-          ]);
-          helper.templateValue(res, "highlightErrorFields", {
-            "cardNo": "American Express debit cards are not supported",
-          });
-
+          helper.templateValue(res, 'id', chargeId)
+          helper.templateValue(res, 'description', 'Payment Description')
+          helper.templateValue(res, 'post_card_action', frontendCardDetailsPostPath)
+          helper.templateValue(res, 'hasError', true)
+          helper.templateValue(res, 'amount', '23.45')
+          helper.templateValue(res, 'errorFields', [
+            {'key': 'cardNo', 'cssKey': 'card-no', 'value': 'American Express debit cards are not supported'}
+          ])
+          helper.templateValue(res, 'highlightErrorFields', {
+            'cardNo': 'American Express debit cards are not supported'
+          })
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('preserve cardholder name, address lines when a card is submitted with validation errors', function (done) {
-      var cookieValue = cookie.create(chargeId, {});
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
+      var cookieValue = cookie.create(chargeId, {})
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
       nock(process.env.CARDID_HOST)
-        .post("/v1/api/card", ()=> {
-          return true;
+        .post('/v1/api/card', () => {
+          return true
         })
-        .reply(200, {brand: "visa", label: "visa", type: "D"});
-      var cardData = full_form_card_data('4242');
-      post_charge_request(app, cookieValue, cardData, chargeId)
+        .reply(200, {brand: 'visa', label: 'visa', type: 'D'})
+      var cardData = fullFormCardData('4242')
+      postChargeRequest(app, cookieValue, cardData, chargeId)
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "cardholderName", cardData.cardholderName);
-          helper.templateValue(res, "addressLine1", cardData.addressLine1);
-          helper.templateValue(res, "addressLine2", cardData.addressLine2);
-          helper.templateValue(res, "addressCity", cardData.addressCity);
-          helper.templateValue(res, "addressPostcode", cardData.addressPostcode);
-          helper.templateValueUndefined(res, "cardNo");
-          helper.templateValueUndefined(res, "cvc");
+          helper.templateValue(res, 'cardholderName', cardData.cardholderName)
+          helper.templateValue(res, 'addressLine1', cardData.addressLine1)
+          helper.templateValue(res, 'addressLine2', cardData.addressLine2)
+          helper.templateValue(res, 'addressCity', cardData.addressCity)
+          helper.templateValue(res, 'addressPostcode', cardData.addressPostcode)
+          helper.templateValueUndefined(res, 'cardNo')
+          helper.templateValueUndefined(res, 'cvc')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should ignore empty/null address lines when second address line populated', function (done) {
-      var cookieValue = cookie.create(chargeId);
-      defaultCardID('5105105105105100');
-      var card_data = minimum_connector_card_data('5105105105105100');
-      card_data.address.line1 = 'bla bla';
-      delete card_data.address.line3;
+      var cookieValue = cookie.create(chargeId)
+      defaultCardID('5105105105105100')
+      var cardData = minimumConnectorCardData('5105105105105100')
+      cardData.address.line1 = 'bla bla'
+      delete cardData.address.line3
 
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(200);
+        .patch('/v1/frontend/charges/23144323')
+        .reply(200)
 
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      connector_expects(card_data).reply(200);
-      var form_data = minimum_form_card_data('5105105105105100');
-      form_data.addressLine1 = '';
-      form_data.addressLine2 = card_data.address.line1;
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      connectorExpects(cardData).reply(200)
+      var formData = minimumFormCardData('5105105105105100')
+      formData.addressLine1 = ''
+      formData.addressLine2 = cardData.address.line1
 
-      post_charge_request(app, cookieValue, form_data, chargeId)
+      postChargeRequest(app, cookieValue, formData, chargeId)
         .expect(303, EMPTY_BODY)
         .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/confirm')
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should ignore empty/null address lines when only second address line populated', function (done) {
-      var cookieValue = cookie.create(chargeId);
-      defaultCardID('5105105105105100');
-      var card_data = minimum_connector_card_data('5105105105105100');
-      card_data.address.line1 = 'bla bla';
-      delete card_data.address.line2;
+      var cookieValue = cookie.create(chargeId)
+      defaultCardID('5105105105105100')
+      var cardData = minimumConnectorCardData('5105105105105100')
+      cardData.address.line1 = 'bla bla'
+      delete cardData.address.line2
 
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
-      connector_expects(card_data).reply(200);
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
+      connectorExpects(cardData).reply(200)
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(200);
-      var form_data = minimum_form_card_data('5105105105105100');
-      form_data.addressLine1 = '';
-      form_data.addressLine2 = card_data.address.line1;
+        .patch('/v1/frontend/charges/23144323')
+        .reply(200)
+      var formData = minimumFormCardData('5105105105105100')
+      formData.addressLine1 = ''
+      formData.addressLine2 = cardData.address.line1
 
-      post_charge_request(app, cookieValue, form_data, chargeId)
+      postChargeRequest(app, cookieValue, formData, chargeId)
         .expect(303, EMPTY_BODY)
         .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/confirm')
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('show an error page when the chargeId is not found on the session', function (done) {
-      var cookieValue = cookie.create();
-      defaultCardID('5105105105105100');
+      var cookieValue = cookie.create()
+      defaultCardID('5105105105105100')
       connectorMock.post(connectorChargePath + chargeId + '/cards', {
         'card_number': '5105105105105100',
         'cvc': '234',
         'expiry_date': '11/99'
-      }).reply(400, {'message': 'This transaction was declined.'});
+      }).reply(400, {'message': 'This transaction was declined.'})
 
       request(app)
         .post(frontendCardDetailsPostPath)
@@ -641,145 +627,142 @@ describe('chargeTests', function () {
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .set('Accept', 'application/json')
         .expect(function (res) {
-          should.not.exist(res.headers['set-cookie']);
+          should.not.exist(res.headers['set-cookie'])
         })
         .expect(403)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "UNAUTHORISED");
+          helper.templateValue(res, 'viewName', 'UNAUTHORISED')
         })
-        .end(done);
-    });
-
-  });
+        .end(done)
+    })
+  })
 
   describe('The /card_details/charge_id endpoint', function () {
-
     it('It should show card details page if charge status is in "ENTERING CARD DETAILS" state', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
         .put('/v1/frontend/charges/' + chargeId + '/status').reply(200)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.raw_successful_get_charge(enteringCardDetailsState, "http://www.example.com/service"));
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(enteringCardDetailsState, 'http://www.example.com/service'))
 
-      get_charge_request(app, cookieValue, chargeId)
+      getChargeRequest(app, cookieValue, chargeId)
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "id", chargeId);
-          helper.templateValueNotUndefined(res, "csrf");
-          helper.templateValue(res, "id", chargeId);
-          helper.templateValue(res, "amount", '23.45');
-          helper.templateValue(res, "description", 'Payment Description');
-          helper.templateValue(res, "post_card_action", frontendCardDetailsPostPath);
-          helper.templateValue(res, "withdrawalText", 'accepted credit and debit card types');
+          helper.templateValue(res, 'id', chargeId)
+          helper.templateValueNotUndefined(res, 'csrf')
+          helper.templateValue(res, 'id', chargeId)
+          helper.templateValue(res, 'amount', '23.45')
+          helper.templateValue(res, 'description', 'Payment Description')
+          helper.templateValue(res, 'post_card_action', frontendCardDetailsPostPath)
+          helper.templateValue(res, 'withdrawalText', 'accepted credit and debit card types')
         })
-        .end(done);
-    });
+        .end(done)
+    })
     it('It should show card details page with correct text for credit card only', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
         .put('/v1/frontend/charges/' + chargeId + '/status').reply(200)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.raw_successful_get_charge_debit_card_only(enteringCardDetailsState, "http://www.example.com/service"));
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetChargeDebitCardOnly(enteringCardDetailsState, 'http://www.example.com/service'))
 
-      get_charge_request(app, cookieValue, chargeId, "?debitOnly=true")
+      getChargeRequest(app, cookieValue, chargeId, '?debitOnly=true')
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "withdrawalText", 'Credit card payments are not accepted. Please use a debit card.');
+          helper.templateValue(res, 'withdrawalText', 'Credit card payments are not accepted. Please use a debit card.')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('It should not show amex if it is excluded', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
         .put('/v1/frontend/charges/' + chargeId + '/status').reply(200)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.raw_successful_get_charge_debit_card_only(enteringCardDetailsState, "http://www.example.com/service"));
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetChargeDebitCardOnly(enteringCardDetailsState, 'http://www.example.com/service'))
 
-      get_charge_request(app, cookieValue, chargeId, "?removeAmex=true")
+      getChargeRequest(app, cookieValue, chargeId, '?removeAmex=true')
         .expect(200)
         .expect(function (res) {
-          expect(res.text).to.not.contain('american-express');
+          expect(res.text).to.not.contain('american-express')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('It should show 404 page not found if charge status cant be updated to "ENTERING CARD DETAILS" state with a 400 connector response', function (done) {
-      var cookieValue = cookie.create(chargeId);
-      connector_response_for_put_charge(chargeId, 400, {'message': 'some error'});
+      var cookieValue = cookie.create(chargeId)
+      connectorResponseForPutCharge(chargeId, 400, {'message': 'some error'})
 
-      get_charge_request(app, cookieValue, chargeId)
+      getChargeRequest(app, cookieValue, chargeId)
         .expect(500)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "SYSTEM_ERROR");
+          helper.templateValue(res, 'viewName', 'SYSTEM_ERROR')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should fail to authorise when email patch fails', function (done) {
-      var cookieValue = cookie.create(chargeId);
-      nock.cleanAll();
+      var cookieValue = cookie.create(chargeId)
+      nock.cleanAll()
 
       nock(process.env.CARDID_HOST)
-        .post("/v1/api/card", ()=> {
-          return true;
+        .post('/v1/api/card', () => {
+          return true
         })
-        .reply(200, {brand: "visa", label: "visa", type: "D"});
+        .reply(200, {brand: 'visa', label: 'visa', type: 'D'})
 
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(500);
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
+        .patch('/v1/frontend/charges/23144323')
+        .reply(500)
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
 
-      connector_expects(minimum_connector_card_data('5105105105105100'))
-        .reply(200);
+      connectorExpects(minimumConnectorCardData('5105105105105100'))
+        .reply(200)
 
-      post_charge_request(app, cookieValue, minimum_form_card_data('5105 1051 0510 5100'), chargeId, false)
+      postChargeRequest(app, cookieValue, minimumFormCardData('5105 1051 0510 5100'), chargeId, false)
         .expect(500)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('It should show 500 when email patch fails', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
-        .patch("/v1/frontend/charges/23144323")
-        .reply(500);
+        .patch('/v1/frontend/charges/23144323')
+        .reply(500)
 
-      get_charge_request(app, cookieValue, chargeId)
+      getChargeRequest(app, cookieValue, chargeId)
         .expect(500)
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   describe('The /card_details/charge_id/confirm endpoint', function () {
     beforeEach(function () {
-      nock.cleanAll();
-    });
+      nock.cleanAll()
+    })
 
     it('should return the data needed for the UI', function (done) {
-
       nock(process.env.CONNECTOR_HOST)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.raw_successful_get_charge("AUTHORISATION SUCCESS", "http://www.example.com/service"));
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge('AUTHORISATION SUCCESS', 'http://www.example.com/service'))
 
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
-      get_charge_request(app, cookieValue, chargeId, '/confirm')
+      getChargeRequest(app, cookieValue, chargeId, '/confirm')
         .expect(200)
         .expect(function (res) {
-          helper.templateValueNotUndefined(res, "csrf");
-          helper.templateValue(res, "charge.cardDetails.cardNumber", "************1234");
-          helper.templateValue(res, "charge.cardDetails.cardBrand", "Visa");
-          helper.templateValue(res, "charge.cardDetails.expiryDate", "11/99");
-          helper.templateValue(res, "charge.cardDetails.cardholderName", "Test User");
-          helper.templateValue(res, "charge.cardDetails.billingAddress", "line1, line2, city, postcode, United Kingdom");
-          helper.templateValue(res, "charge.gatewayAccount.serviceName", "Pranks incorporated");
-          helper.templateValue(res, "charge.amount", "23.45");
-          helper.templateValue(res, "charge.description", "Payment Description");
+          helper.templateValueNotUndefined(res, 'csrf')
+          helper.templateValue(res, 'charge.cardDetails.cardNumber', '************1234')
+          helper.templateValue(res, 'charge.cardDetails.cardBrand', 'Visa')
+          helper.templateValue(res, 'charge.cardDetails.expiryDate', '11/99')
+          helper.templateValue(res, 'charge.cardDetails.cardholderName', 'Test User')
+          helper.templateValue(res, 'charge.cardDetails.billingAddress', 'line1, line2, city, postcode, United Kingdom')
+          helper.templateValue(res, 'charge.gatewayAccount.serviceName', 'Pranks incorporated')
+          helper.templateValue(res, 'charge.amount', '23.45')
+          helper.templateValue(res, 'charge.description', 'Payment Description')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should post to the connector capture url looked up from the connector when a post arrives', function (done) {
       nock(process.env.CONNECTOR_HOST)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.raw_successful_get_charge(State.AUTH_SUCCESS, "http://www.example.com/service"))
-        .post('/v1/frontend/charges/' + chargeId + "/capture").reply(204);
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(State.AUTH_SUCCESS, 'http://www.example.com/service'))
+        .post('/v1/frontend/charges/' + chargeId + '/capture').reply(204)
 
       request(app)
         .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
@@ -788,27 +771,26 @@ describe('chargeTests', function () {
         .set('Accept', 'application/json')
         .expect(303, {})
         .expect('Location', '/return/' + chargeId)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should error if no csrf token', function (done) {
       nock(process.env.CONNECTOR_HOST)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.raw_successful_get_charge(State.AUTH_SUCCESS, "http://www.example.com/service"))
-        .post('/v1/frontend/charges/' + chargeId + "/capture").reply(200);
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(State.AUTH_SUCCESS, 'http://www.example.com/service'))
+        .post('/v1/frontend/charges/' + chargeId + '/capture').reply(200)
 
       request(app)
         .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
         .set('Accept', 'application/json')
         .expect(500)
-        .end(done);
-    });
-
+        .end(done)
+    })
 
     it('connector failure when trying to capture should result in error page', function (done) {
       nock(process.env.CONNECTOR_HOST)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.raw_successful_get_charge(State.AUTH_SUCCESS, "http://www.example.com/service"))
-        .post('/v1/frontend/charges/' + chargeId + "/capture").reply(500);
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(State.AUTH_SUCCESS, 'http://www.example.com/service'))
+        .post('/v1/frontend/charges/' + chargeId + '/capture').reply(500)
 
       request(app)
         .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
@@ -816,30 +798,29 @@ describe('chargeTests', function () {
         .send({csrfToken: helper.csrfToken()})
         .expect(500)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "SYSTEM_ERROR");
-          helper.templateValue(res, "returnUrl", "/return/" + chargeId);
+          helper.templateValue(res, 'viewName', 'SYSTEM_ERROR')
+          helper.templateValue(res, 'returnUrl', '/return/' + chargeId)
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('connector could not authorise capture results in error page', function (done) {
-
       nock(process.env.CONNECTOR_HOST)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.raw_successful_get_charge(State.AUTH_SUCCESS, "http://www.example.com/service"))
-        .post('/v1/frontend/charges/' + chargeId + "/capture").reply(400);
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(State.AUTH_SUCCESS, 'http://www.example.com/service'))
+        .post('/v1/frontend/charges/' + chargeId + '/capture').reply(400)
 
       request(app)
         .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
         .set('Cookie', ['frontend_state=' + cookie.createWithReturnUrl(chargeId, undefined, 'http://www.example.com/service')])
         .send({csrfToken: helper.csrfToken()})
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "CAPTURE_FAILURE");
+          helper.templateValue(res, 'viewName', 'CAPTURE_FAILURE')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should produce an error if the connector responds with a non 200', function (done) {
-      connectorMock.get(connectorChargePath + chargeId).reply(404);
+      connectorMock.get(connectorChargePath + chargeId).reply(404)
 
       request(app)
         .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
@@ -848,45 +829,44 @@ describe('chargeTests', function () {
         .set('Accept', 'application/json')
         .expect(500)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "SYSTEM_ERROR");
+          helper.templateValue(res, 'viewName', 'SYSTEM_ERROR')
         })
-        .end(done);
-    });
-
+        .end(done)
+    })
 
     it('should produce an error if the connector returns a non-200 status', function (done) {
-      default_connector_response_for_get_charge(chargeId, State.AUTH_SUCCESS);
-      connectorMock.post(connectorChargePath + chargeId + "/capture").reply(1234);
+      defaultConnectorResponseForGetCharge(chargeId, State.AUTH_SUCCESS)
+      connectorMock.post(connectorChargePath + chargeId + '/capture').reply(1234)
       request(app)
         .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
         .send({csrfToken: helper.csrfToken()})
         .expect(500)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "SYSTEM_ERROR");
+          helper.templateValue(res, 'viewName', 'SYSTEM_ERROR')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should produce an error if the connector is unreachable for the confirm', function (done) {
-      default_connector_response_for_get_charge(chargeId, State.AUTH_SUCCESS);
+      defaultConnectorResponseForGetCharge(chargeId, State.AUTH_SUCCESS)
       request(app)
         .post(frontendCardDetailsPath + '/' + chargeId + '/confirm')
         .send({csrfToken: helper.csrfToken()})
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
         .expect(500)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "SYSTEM_ERROR");
+          helper.templateValue(res, 'viewName', 'SYSTEM_ERROR')
         })
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   describe('capture waiting endpoint', function () {
     it('should keep user in /capture_waiting when connector returns a capture ready state', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
-      default_connector_response_for_get_charge(chargeId, State.CAPTURE_READY);
+      defaultConnectorResponseForGetCharge(chargeId, State.CAPTURE_READY)
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId + '/capture_waiting')
@@ -895,15 +875,15 @@ describe('chargeTests', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "capture_waiting");
+          helper.templateValue(res, 'viewName', 'capture_waiting')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should take user to capture submitted view when charge in CAPTURE_SUBMITTED state', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
-      default_connector_response_for_get_charge(chargeId, State.CAPTURE_SUBMITTED);
+      defaultConnectorResponseForGetCharge(chargeId, State.CAPTURE_SUBMITTED)
 
       request(app)
         .get(frontendCardDetailsPath + '/' + chargeId + '/capture_waiting')
@@ -912,19 +892,19 @@ describe('chargeTests', function () {
         .set('Accept', 'application/json')
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "CAPTURE_SUBMITTED");
+          helper.templateValue(res, 'viewName', 'CAPTURE_SUBMITTED')
         })
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   describe('The cancel endpoint', function () {
     it('should take user to cancel page on successful cancel when carge in entering card details state', function (done) {
-      var cancelEndpoint = frontendCardDetailsPath + '/' + chargeId + '/cancel';
-      default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
+      var cancelEndpoint = frontendCardDetailsPath + '/' + chargeId + '/cancel'
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
 
       nock(process.env.CONNECTOR_HOST)
-        .post('/v1/frontend/charges/' + chargeId + '/cancel').reply(204);
+        .post('/v1/frontend/charges/' + chargeId + '/cancel').reply(204)
 
       request(app)
         .post(cancelEndpoint)
@@ -932,17 +912,17 @@ describe('chargeTests', function () {
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "USER_CANCELLED");
+          helper.templateValue(res, 'viewName', 'USER_CANCELLED')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should take user to cancel page on successful cancel when charge in authorisation successful state', function (done) {
-      var cancelEndpoint = frontendCardDetailsPath + '/' + chargeId + '/cancel';
-      default_connector_response_for_get_charge(chargeId, State.AUTH_SUCCESS);
+      var cancelEndpoint = frontendCardDetailsPath + '/' + chargeId + '/cancel'
+      defaultConnectorResponseForGetCharge(chargeId, State.AUTH_SUCCESS)
 
       nock(process.env.CONNECTOR_HOST)
-        .post('/v1/frontend/charges/' + chargeId + '/cancel').reply(204);
+        .post('/v1/frontend/charges/' + chargeId + '/cancel').reply(204)
 
       request(app)
         .post(cancelEndpoint)
@@ -950,17 +930,17 @@ describe('chargeTests', function () {
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
         .expect(200)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "USER_CANCELLED");
+          helper.templateValue(res, 'viewName', 'USER_CANCELLED')
         })
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should take user to error page on failed cancel', function (done) {
-      var cancelEndpoint = frontendCardDetailsPath + '/' + chargeId + '/cancel';
-      default_connector_response_for_get_charge(chargeId, State.AUTH_SUCCESS);
+      var cancelEndpoint = frontendCardDetailsPath + '/' + chargeId + '/cancel'
+      defaultConnectorResponseForGetCharge(chargeId, State.AUTH_SUCCESS)
 
       nock(process.env.CONNECTOR_HOST)
-        .post('/v1/frontend/charges/' + chargeId + '/cancel').reply(400);
+        .post('/v1/frontend/charges/' + chargeId + '/cancel').reply(400)
 
       request(app)
         .post(cancelEndpoint)
@@ -968,159 +948,150 @@ describe('chargeTests', function () {
         .set('Cookie', ['frontend_state=' + cookie.create(chargeId)])
         .expect(500)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "SYSTEM_ERROR");
+          helper.templateValue(res, 'viewName', 'SYSTEM_ERROR')
         })
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   describe('The /card_details/charge_id/3ds_required', function () {
-
-    var testAuth3ds = {
-      auth3dsData: {
-        paRequest: "aPaRequest",
-        issuerUrl: "https://test.com"
-      }
-    };
-
     beforeEach(function () {
-      nock.cleanAll();
-    });
+      nock.cleanAll()
+    })
 
     it('should return the data needed for the iframe UI', function (done) {
-      var chargeResponse = helper.raw_successful_get_charge(State.AUTH_3DS_REQUIRED, "http://www.example.com/service");
+      var chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service')
 
       nock(process.env.CONNECTOR_HOST)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, chargeResponse);
+        .get('/v1/frontend/charges/' + chargeId).reply(200, chargeResponse)
 
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
-      get_charge_request(app, cookieValue, chargeId, '/3ds_required_out')
+      getChargeRequest(app, cookieValue, chargeId, '/3ds_required_out')
         .expect(200)
         .expect(function (res) {
-          var body = JSON.parse(res.text);
-          expect(body.paRequest).to.equal('aPaRequest');
-          expect(body.issuerUrl).to.equal('http://issuerUrl.com');
+          var body = JSON.parse(res.text)
+          expect(body.paRequest).to.equal('aPaRequest')
+          expect(body.issuerUrl).to.equal('http://issuerUrl.com')
         })
-        .end(done);
+        .end(done)
     })
-  });
+  })
 
   describe('The /card_details/charge_id/3ds_required_in', function () {
     beforeEach(function () {
-      nock.cleanAll();
-    });
+      nock.cleanAll()
+    })
 
     it('should return the data needed for the UI', function (done) {
-      var chargeResponse = helper.raw_successful_get_charge(State.AUTH_3DS_REQUIRED, "http://www.example.com/service");
+      var chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service')
 
       nock(process.env.CONNECTOR_HOST)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, chargeResponse);
+        .get('/v1/frontend/charges/' + chargeId).reply(200, chargeResponse)
 
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
       var data = {
         PaRes: 'aPaRes'
-      };
-      post_charge_request(app, cookieValue, data, chargeId, false, '/3ds_required_in')
+      }
+      postChargeRequest(app, cookieValue, data, chargeId, false, '/3ds_required_in')
         .expect(200)
         .expect(function (res) {
-          var body = JSON.parse(res.text);
-          expect(body.paResponse).to.equal('aPaRes');
-          expect(body.threeDsHandlerUrl).to.equal(`/card_details/${chargeId}/3ds_handler`);
+          var body = JSON.parse(res.text)
+          expect(body.paResponse).to.equal('aPaRes')
+          expect(body.threeDsHandlerUrl).to.equal(`/card_details/${chargeId}/3ds_handler`)
         })
-        .end(done);
-    });
-  });
+        .end(done)
+    })
+  })
 
   describe('The /card_details/charge_id/3ds_handler', function () {
     var chargeResponse = _.extend(
-      helper.raw_successful_get_charge(State.AUTH_3DS_REQUIRED, "http://www.example.com/service"));
-
+      helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service'))
 
     beforeEach(function () {
-      nock.cleanAll();
-    });
+      nock.cleanAll()
+    })
 
     it('should send 3ds data to connector and redirect to confirm', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
       nock(process.env.CONNECTOR_HOST)
         .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
-        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: "aPaResponse"}).reply(200);
+        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: 'aPaResponse'}).reply(200)
 
-      post_charge_request(app, cookieValue, {PaRes: "aPaResponse"}, chargeId, true, '/3ds_handler')
+      postChargeRequest(app, cookieValue, {PaRes: 'aPaResponse'}, chargeId, true, '/3ds_handler')
         .expect(303)
         .expect('Location', `${frontendCardDetailsPath}/${chargeId}/confirm`)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should send 3ds data to connector and redirect to auth_waiting if connector returns a 202', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
       nock(process.env.CONNECTOR_HOST)
         .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
-        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: "aPaResponse"}).reply(202);
+        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: 'aPaResponse'}).reply(202)
 
-      post_charge_request(app, cookieValue, {PaRes: "aPaResponse"}, chargeId, true, '/3ds_handler')
+      postChargeRequest(app, cookieValue, {PaRes: 'aPaResponse'}, chargeId, true, '/3ds_handler')
         .expect(303)
         .expect('Location', `${frontendCardDetailsPath}/${chargeId}/auth_waiting`)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should send 3ds data to connector and redirect to auth_waiting if connector returns a 409', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
       nock(process.env.CONNECTOR_HOST)
         .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
-        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: "aPaResponse"}).reply(409);
+        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: 'aPaResponse'}).reply(409)
 
-      post_charge_request(app, cookieValue, {PaRes: "aPaResponse"}, chargeId, true, '/3ds_handler')
+      postChargeRequest(app, cookieValue, {PaRes: 'aPaResponse'}, chargeId, true, '/3ds_handler')
         .expect(303)
         .expect('Location', `${frontendCardDetailsPath}/${chargeId}/auth_waiting`)
-        .end(done);
-    });
+        .end(done)
+    })
 
     it('should send 3ds data to connector and render an error if connector returns an 500', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
       nock(process.env.CONNECTOR_HOST)
         .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
-        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: "aPaResponse"}).reply(500);
+        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: 'aPaResponse'}).reply(500)
 
-      post_charge_request(app, cookieValue, {PaRes: "aPaResponse"}, chargeId, true, '/3ds_handler')
+      postChargeRequest(app, cookieValue, {PaRes: 'aPaResponse'}, chargeId, true, '/3ds_handler')
         .expect(500)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "SYSTEM_ERROR");
-        }).end(done);
-    });
+          helper.templateValue(res, 'viewName', 'SYSTEM_ERROR')
+        }).end(done)
+    })
 
     it('should send 3ds data to connector and render an error if connector returns an invalid status code', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
       nock(process.env.CONNECTOR_HOST)
         .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
-        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: "aPaResponse"}).reply(404);
+        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: 'aPaResponse'}).reply(404)
 
-      post_charge_request(app, cookieValue, {PaRes: "aPaResponse"}, chargeId, true, '/3ds_handler')
+      postChargeRequest(app, cookieValue, {PaRes: 'aPaResponse'}, chargeId, true, '/3ds_handler')
         .expect(500)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "ERROR");
-        }).end(done);
-    });
+          helper.templateValue(res, 'viewName', 'ERROR')
+        }).end(done)
+    })
 
     it('should send 3ds data to connector and render an error if connector post failed', function (done) {
-      var cookieValue = cookie.create(chargeId);
+      var cookieValue = cookie.create(chargeId)
 
       nock(process.env.CONNECTOR_HOST)
         .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
-        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: "aPaResponse"}).replyWithError(404);
+        .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: 'aPaResponse'}).replyWithError(404)
 
-      post_charge_request(app, cookieValue, {PaRes: "aPaResponse"}, chargeId, true, '/3ds_handler')
+      postChargeRequest(app, cookieValue, {PaRes: 'aPaResponse'}, chargeId, true, '/3ds_handler')
         .expect(500)
         .expect(function (res) {
-          helper.templateValue(res, "viewName", "ERROR");
-        }).end(done);
-    });
-  });
-});
+          helper.templateValue(res, 'viewName', 'ERROR')
+        }).end(done)
+    })
+  })
+})

--- a/test/integration/charge_validation_ft_tests.js
+++ b/test/integration/charge_validation_ft_tests.js
@@ -1,44 +1,35 @@
-var EMPTY_BODY = '';
+var nock = require('nock')
+var app = require('../../server.js').getApp
+var mockTemplates = require('../test_helpers/mock_templates.js')
+app.engine('html', mockTemplates.__express)
+var expect = require('chai').expect
+var State = require('../../app/models/state.js')
 
-var _ = require('lodash');
-var nock = require('nock');
-var app = require('../../server.js').getApp;
-var mock_templates = require('../test_helpers/mock_templates.js');
-app.engine('html', mock_templates.__express);
-var csrf = require('csrf');
-var {expect} = require('chai');
-var State = require('../../app/models/state.js');
+var cookie = require('../test_helpers/session.js')
 
-var cookie = require('../test_helpers/session.js');
-
-var winston = require('winston');
-
-var {post_charge_request, default_connector_response_for_get_charge} = require('../test_helpers/test_helpers.js');
+var {postChargeRequest, defaultConnectorResponseForGetCharge} = require('../test_helpers/test_helpers.js')
 
 var defaultCardID = function () {
   nock(process.env.CARDID_HOST)
-    .post("/v1/api/card", ()=> {
-      return true;
+    .post('/v1/api/card', () => {
+      return true
     })
-    .reply(200, {brand: "visa", label: "visa", type: "D"});
+    .reply(200, {brand: 'visa', label: 'visa', type: 'D'})
+}
+var localServer = process.env.CONNECTOR_HOST
 
-};
-var localServer = process.env.CONNECTOR_HOST;
+var connectorChargePath = '/v1/frontend/charges/'
+var chargeId = '23144323'
+var RETURN_URL = 'http://www.example.com/service'
 
-var connectorChargePath = '/v1/frontend/charges/';
-var chargeId = '23144323';
-var frontendCardDetailsPath = '/card_details';
-var frontendCardDetailsPostPath = '/card_details/' + chargeId;
-var RETURN_URL = 'http://www.example.com/service';
-
-var connectorAuthUrl = localServer + connectorChargePath + chargeId + '/cards';
+var connectorAuthUrl = localServer + connectorChargePath + chargeId + '/cards'
 describe('checks for PAN-like numbers', () => {
   beforeEach(function () {
-    nock.cleanAll();
-  });
+    nock.cleanAll()
+  })
 
   it('shows an error when a card is submitted with non-PAN fields containing a suspected PAN', function (done) {
-    const chargeId = '23144323';
+    const chargeId = '23144323'
     const formWithAllFieldsContainingTooManyDigits = {
       'returnUrl': RETURN_URL,
       'cardUrl': connectorAuthUrl,
@@ -54,32 +45,32 @@ describe('checks for PAN-like numbers', () => {
       'addressCity': 'Willy wonka 012345678901',
       'email': '012345678901willy@wonka.com',
       'addressCountry': 'US'
-    };
-    const cookieValue = cookie.create(chargeId, {});
+    }
+    const cookieValue = cookie.create(chargeId, {})
 
-    defaultCardID('4242424242424242');
-    default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
+    defaultCardID('4242424242424242')
+    defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
 
-    post_charge_request(app, cookieValue, formWithAllFieldsContainingTooManyDigits, chargeId)
+    postChargeRequest(app, cookieValue, formWithAllFieldsContainingTooManyDigits, chargeId)
       .expect(200)
-      .end((err,res) => {
-        if (err) return done(err);
+      .end((err, res) => {
+        if (err) return done(err)
 
-        var body = JSON.parse(res.text);
+        var body = JSON.parse(res.text)
 
-        expect(body.highlightErrorFields.cardholderName).to.equal('Enter the name as it appears on the card');
-        expect(body.highlightErrorFields.addressLine1).to.equal('Enter a valid billing address');
-        expect(body.highlightErrorFields.addressLine2).to.equal('Enter valid address information');
-        expect(body.highlightErrorFields.addressCity).to.equal('Enter a valid town/city');
-        expect(body.highlightErrorFields.addressPostcode).to.equal('Enter a valid postcode');
-        expect(body.highlightErrorFields.email).to.equal('Enter a valid email');
+        expect(body.highlightErrorFields.cardholderName).to.equal('Enter the name as it appears on the card')
+        expect(body.highlightErrorFields.addressLine1).to.equal('Enter a valid billing address')
+        expect(body.highlightErrorFields.addressLine2).to.equal('Enter valid address information')
+        expect(body.highlightErrorFields.addressCity).to.equal('Enter a valid town/city')
+        expect(body.highlightErrorFields.addressPostcode).to.equal('Enter a valid postcode')
+        expect(body.highlightErrorFields.email).to.equal('Enter a valid email')
 
-        done();
-      });
-  });
+        done()
+      })
+  })
 
   it('shows an error when a card is submitted with a card holder name containing a suspected CVV', function (done) {
-    const chargeId = '23144323';
+    const chargeId = '23144323'
     const formWithAllFieldsContainingTooManyDigits = {
       'returnUrl': RETURN_URL,
       'cardUrl': connectorAuthUrl,
@@ -95,23 +86,23 @@ describe('checks for PAN-like numbers', () => {
       'addressCity': 'Willy Wonka',
       'email': 'willy@wonka.com',
       'addressCountry': 'US'
-    };
-    const cookieValue = cookie.create(chargeId, {});
+    }
+    const cookieValue = cookie.create(chargeId, {})
 
-    defaultCardID('4242424242424242');
-    default_connector_response_for_get_charge(chargeId, State.ENTERING_CARD_DETAILS);
+    defaultCardID('4242424242424242')
+    defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS)
 
-    post_charge_request(app, cookieValue, formWithAllFieldsContainingTooManyDigits, chargeId)
+    postChargeRequest(app, cookieValue, formWithAllFieldsContainingTooManyDigits, chargeId)
       .expect(200)
-      .end((err,res) => {
-        if (err) return done(err);
+      .end((err, res) => {
+        if (err) return done(err)
 
-        var body = JSON.parse(res.text);
+        var body = JSON.parse(res.text)
 
-        expect(body.highlightErrorFields.cardholderName).to.equal('Enter the name as it appears on the card');
-        expect(body.errorFields.length).to.equal(1);
-        expect(body.errorFields[0].value).to.equal('Enter the name as it appears on the card');
-        done();
-      });
-  });
-});
+        expect(body.highlightErrorFields.cardholderName).to.equal('Enter the name as it appears on the card')
+        expect(body.errorFields.length).to.equal(1)
+        expect(body.errorFields[0].value).to.equal('Enter the name as it appears on the card')
+        done()
+      })
+  })
+})

--- a/test/integration/healthcheck_ft_tests.js
+++ b/test/integration/healthcheck_ft_tests.js
@@ -1,18 +1,17 @@
-const request = require('supertest');
-const app = require('../../server.js').getApp;
-const {expect} = require('chai');
+const request = require('supertest')
+const app = require('../../server.js').getApp
+const expect = require('chai').expect
 
 describe('The /healthcheck endpoint returned json', function () {
-
   it('should return 200 and be healthy', function (done) {
-      const expectedResponse = {'ping': {'healthy': true}};
-      request(app)
+    const expectedResponse = {'ping': {'healthy': true}}
+    request(app)
           .get('/healthcheck')
           .set('Accept', 'application/json')
           .expect(200)
-          .expect(function(res) {
-            response = JSON.parse(res.text);
-            expect(response).to.deep.equal(expectedResponse);
-          }).end(done);
-  });
-});
+          .expect(function (res) {
+            var response = JSON.parse(res.text)
+            expect(response).to.deep.equal(expectedResponse)
+          }).end(done)
+  })
+})

--- a/test/integration/util_cookies_ft_tests.js
+++ b/test/integration/util_cookies_ft_tests.js
@@ -1,20 +1,18 @@
-var should = require('chai').should();
-var assert = require('assert');
-var cookies  = require('../../app/utils/cookies.js');
+var assert = require('assert')
+var cookies = require('../../app/utils/cookies.js')
 
 describe('frontend cookie', function () {
-
   it('should have secure proxy off in unsecured environment', function () {
-    process.env.SECURE_COOKIE_OFF = "true";
-    assert.equal('frontend_state', cookies.getSessionCookieName());
-    assert.equal(true, cookies.namedCookie('name', 'key').proxy);
-    assert.deepEqual({httpOnly: true, secureProxy: false, maxAge: 5400000}, cookies.namedCookie('name', 'key').cookie);
-  });
+    process.env.SECURE_COOKIE_OFF = 'true'
+    assert.equal('frontend_state', cookies.getSessionCookieName())
+    assert.equal(true, cookies.namedCookie('name', 'key').proxy)
+    assert.deepEqual({httpOnly: true, secureProxy: false, maxAge: 5400000}, cookies.namedCookie('name', 'key').cookie)
+  })
 
   it('should have secure proxy on in a secured https environment', function () {
-    process.env.SECURE_COOKIE_OFF="false";
-    assert.equal('frontend_state',cookies.getSessionCookieName());
-    assert.equal(true, cookies.namedCookie('name', 'key').proxy);
-    assert.deepEqual({httpOnly: true, secureProxy: true, maxAge: 5400000}, cookies.namedCookie('name', 'key').cookie);
-  });
-});
+    process.env.SECURE_COOKIE_OFF = 'false'
+    assert.equal('frontend_state', cookies.getSessionCookieName())
+    assert.equal(true, cookies.namedCookie('name', 'key').proxy)
+    assert.deepEqual({httpOnly: true, secureProxy: true, maxAge: 5400000}, cookies.namedCookie('name', 'key').cookie)
+  })
+})

--- a/test/middleware/action_name_test.js
+++ b/test/middleware/action_name_test.js
@@ -1,37 +1,34 @@
-var should = require('chai').should();
-var assert = require('assert');
-var expect = require('chai').expect;
-var views  = require(__dirname + '/../../app/utils/views.js');
-var actionName  = require(__dirname + '/../../app/middleware/action_name.js');
+var path = require('path')
+var assert = require('assert')
+var expect = require('chai').expect
+var actionName = require(path.join(__dirname, '/../../app/middleware/action_name.js'))
 
-var sinon  = require('sinon');
-var _      = require('lodash');
-
+var sinon = require('sinon')
 
 describe('actionName', function () {
   it('should append the viewname to the request', function () {
-    var next = sinon.spy(),
-    req = {
+    var next = sinon.spy()
+    var req = {
       route: {
-        methods: { post: true},
-        path: "/card_details/:chargeId"
+        methods: {post: true},
+        path: '/card_details/:chargeId'
       }
     }
-    actionName(req,{},next);
-    expect(next.calledOnce).to.be.true;
-    assert.equal(req.actionName,"card.create")
-  });
+    actionName(req, {}, next)
+    expect(next.calledOnce).to.be.true // eslint-disable-line
+    assert.equal(req.actionName, 'card.create')
+  })
 
   it('should not append the viewname to the request if it cannot match', function () {
-    var next = sinon.spy(),
-    req = {
+    var next = sinon.spy()
+    var req = {
       route: {
-        methods: { post: true},
-        path: "/invalid"
+        methods: {post: true},
+        path: '/invalid'
       }
     }
-    actionName(req,{},next);
-    expect(next.calledOnce).to.be.true;
-    assert.equal(req.actionName,undefined)
-  });
-});
+    actionName(req, {}, next)
+    expect(next.calledOnce).to.be.true // eslint-disable-line 
+    assert.equal(req.actionName, undefined)
+  })
+})

--- a/test/middleware/csrf.js
+++ b/test/middleware/csrf.js
@@ -1,144 +1,137 @@
-var should = require('chai').should();
-var assert = require('assert');
-var sinon  = require('sinon');
-var _      = require('lodash');
-var expect = require('chai').expect;
-var nock   = require('nock');
-var paths  = require('../../app/paths.js');
-var helper = require(__dirname + '/../test_helpers/test_helpers.js');
+var path = require('path')
+var assert = require('assert')
+var sinon = require('sinon')
+var _ = require('lodash')
+var expect = require('chai').expect
+var nock = require('nock')
+var helper = require(path.join(__dirname, '/../test_helpers/test_helpers.js'))
 
-var {csrfCheck, csrfTokenGeneration} = require(__dirname + '/../../app/middleware/csrf.js');
-
+var {csrfCheck, csrfTokenGeneration} = require(path.join(__dirname, '/../../app/middleware/csrf.js'))
 
 describe('retrieve param test', function () {
-
   var response = {
-    status: function(){},
-    render: function(){},
+    status: function () {},
+    render: function () {},
     locals: {}
-  },
-  status = undefined,
-  render = undefined,
-  next   = undefined,
-  validGetRequest =  {
-    params: { chargeId: "foo" },
+  }
+  var status
+  var render
+  var next
+  var validGetRequest = {
+    params: {chargeId: 'foo'},
     body: {},
-    route: { methods: { get: true}},
+    route: {methods: {get: true}},
     frontend_state: {
       ch_foo: {
         csrfSecret: process.env.CSRF_USER_SECRET
-      },
+      }
     }
-  };
+  }
 
-  var noSession = _.cloneDeep(validGetRequest);
-  delete noSession.frontend_state.ch_foo;
+  var noSession = _.cloneDeep(validGetRequest)
+  delete noSession.frontend_state.ch_foo
 
-  var noSecret = _.cloneDeep(validGetRequest);
-  delete noSecret.frontend_state.ch_foo.csrfSecret;
+  var noSecret = _.cloneDeep(validGetRequest)
+  delete noSecret.frontend_state.ch_foo.csrfSecret
 
-  var invalidPost = _.cloneDeep(validGetRequest);
-  delete invalidPost.route.methods.get;
-  var invalidPut = _.cloneDeep(invalidPost);
+  var invalidPost = _.cloneDeep(validGetRequest)
+  delete invalidPost.route.methods.get
+  var invalidPut = _.cloneDeep(invalidPost)
 
-  invalidPost.route.methods.post  = true;
-  invalidPut.route.methods.put    = true;
+  invalidPost.route.methods.post = true
+  invalidPut.route.methods.put = true
 
-  var validPost = _.cloneDeep(invalidPost);
-  validPost.body.csrfToken = helper.csrfToken();
+  var validPost = _.cloneDeep(invalidPost)
+  validPost.body.csrfToken = helper.csrfToken()
 
-  var validPut = _.cloneDeep(invalidPut);
-  validPut.body.csrfToken = helper.csrfToken();
+  var validPut = _.cloneDeep(invalidPut)
+  validPut.body.csrfToken = helper.csrfToken()
 
-  var assertErrorRequest = function(next,resp,status,render) {
-    expect(next.called).to.not.be.true;
-    expect(resp.locals.csrf).to.be.undefined;
-    assert(status.calledWith(500));
-    assert(render.calledWith("errors/system_error", { viewName: 'SYSTEM_ERROR' }));
-  },
+  var assertErrorRequest = function (next, resp, status, render) {
+    expect(next.called).to.not.be.true // eslint-disable-line
+    expect(resp.locals.csrf).to.be.undefined // eslint-disable-line
+    assert(status.calledWith(500))
+    assert(render.calledWith('errors/system_error', { viewName: 'SYSTEM_ERROR' }))
+  }
 
-  assertUnauthorisedRequest = function(next,resp,status,render) {
-    expect(next.called).to.not.be.true;
-    expect(resp.locals.csrf).to.be.undefined;
-    assert(status.calledWith(403));
-    assert(render.calledWith("errors/system_error", { viewName: 'UNAUTHORISED' }));
-  },
+  var assertUnauthorisedRequest = function (next, resp, status, render) {
+    expect(next.called).to.not.be.true // eslint-disable-line
+    expect(resp.locals.csrf).to.be.undefined // eslint-disable-line
+    assert(status.calledWith(403))
+    assert(render.calledWith('errors/system_error', { viewName: 'UNAUTHORISED' }))
+  }
 
-  assertValidRequest = function(next,resp,status,render) {
-    expect(next.called).to.be.true;
-    expect(resp.locals.csrf).to.not.be.undefined;
-  };
+  var assertValidRequest = function (next, resp, status, render) {
+    expect(next.called).to.be.true // eslint-disable-line
+    expect(resp.locals.csrf).to.not.be.undefined // eslint-disable-line 
+  }
 
+  beforeEach(function () {
+    status = sinon.stub(response, 'status')
+    render = sinon.stub(response, 'render')
+    next = sinon.spy()
+    nock.cleanAll()
+  })
 
-
-  beforeEach(function(){
-    status = sinon.stub(response,"status");
-    render = sinon.stub(response,"render");
-    next   = sinon.spy();
-    nock.cleanAll();
-  });
-
-  afterEach(function(){
-    status.restore();
-    render.restore();
-  });
+  afterEach(function () {
+    status.restore()
+    render.restore()
+  })
 
   it('should append csrf on get request', function () {
-    var resp = _.cloneDeep(response);
-    csrfTokenGeneration(validGetRequest,resp,next);
-    assertValidRequest(next,resp,status,render);
-  });
+    var resp = _.cloneDeep(response)
+    csrfTokenGeneration(validGetRequest, resp, next)
+    assertValidRequest(next, resp, status, render)
+  })
 
   it('should error if no charge in session', function () {
-    var resp = _.cloneDeep(response);
-    csrfCheck(noSession,resp,next);
-    assertUnauthorisedRequest(next,resp,status,render);
-
-  });
+    var resp = _.cloneDeep(response)
+    csrfCheck(noSession, resp, next)
+    assertUnauthorisedRequest(next, resp, status, render)
+  })
 
   it('should error if no secret in session', function () {
-    var resp = _.cloneDeep(response);
-    csrfCheck(noSecret,resp,next);
-    assertUnauthorisedRequest(next,resp,status,render);
-  });
+    var resp = _.cloneDeep(response)
+    csrfCheck(noSecret, resp, next)
+    assertUnauthorisedRequest(next, resp, status, render)
+  })
 
   it('should be successful on post if valid post and append token to used tokens', function () {
-    var resp = _.cloneDeep(response);
-    csrfCheck(validPost,resp,next);
-    csrfTokenGeneration(validGetRequest,resp,next);
-    assertValidRequest(next,resp,status,render);
-    assert.equal(validPost.frontend_state.ch_foo.csrfTokens[0],validPost.body.csrfToken);
-  });
+    var resp = _.cloneDeep(response)
+    csrfCheck(validPost, resp, next)
+    csrfTokenGeneration(validGetRequest, resp, next)
+    assertValidRequest(next, resp, status, render)
+    assert.equal(validPost.frontend_state.ch_foo.csrfTokens[0], validPost.body.csrfToken)
+  })
 
   it('should be unsuccessful on post if token is already used', function () {
-    var resp = _.cloneDeep(response);
-    csrfCheck(validPost,resp,next);
-    assertErrorRequest(next,resp,status,render);
-  });
+    var resp = _.cloneDeep(response)
+    csrfCheck(validPost, resp, next)
+    assertErrorRequest(next, resp, status, render)
+  })
 
   it('should error if no csrfToken in post request', function () {
-    var resp = _.cloneDeep(response);
-    csrfCheck(invalidPost,resp,next);
-    assertErrorRequest(next,resp,status,render);
-  });
+    var resp = _.cloneDeep(response)
+    csrfCheck(invalidPost, resp, next)
+    assertErrorRequest(next, resp, status, render)
+  })
 
   it('should be successful on post if valid put', function () {
-    var resp = _.cloneDeep(response);
-    csrfCheck(validPut,resp,next);
-    csrfTokenGeneration(validGetRequest,resp,next);
-    assertValidRequest(next,resp,status,render);
-  });
+    var resp = _.cloneDeep(response)
+    csrfCheck(validPut, resp, next)
+    csrfTokenGeneration(validGetRequest, resp, next)
+    assertValidRequest(next, resp, status, render)
+  })
 
   it('should be unsuccessful on put if token is already used', function () {
-    var resp = _.cloneDeep(response);
-    csrfCheck(validPut,resp,next);
-    assertErrorRequest(next,resp,status,render);
-  });
+    var resp = _.cloneDeep(response)
+    csrfCheck(validPut, resp, next)
+    assertErrorRequest(next, resp, status, render)
+  })
 
   it('should error if no csrfToken in put request', function () {
-    var resp = _.cloneDeep(response);
-    csrfCheck(invalidPut,resp,next);
-    assertErrorRequest(next,resp,status,render);
-  });
-
-});
+    var resp = _.cloneDeep(response)
+    csrfCheck(invalidPut, resp, next)
+    assertErrorRequest(next, resp, status, render)
+  })
+})

--- a/test/middleware/retrieve_charge_test.js
+++ b/test/middleware/retrieve_charge_test.js
@@ -1,102 +1,92 @@
-var should = require('chai').should();
-var assert = require('assert');
-var sinon  = require('sinon');
-var _      = require('lodash');
-var expect = require('chai').expect;
-var nock   = require('nock');
-var paths  = require('../../app/paths.js');
+var path = require('path')
+var assert = require('assert')
+var sinon = require('sinon')
+var expect = require('chai').expect
+var nock = require('nock')
 
-var retrieveCharge = require(__dirname + '/../../app/middleware/retrieve_charge.js');
+var retrieveCharge = require(path.join(__dirname, '/../../app/middleware/retrieve_charge.js'))
 
 const ANALYTICS_ERROR = {
-    analytics: {
-        analyticsId: "Service unavailable",
-        type: "Service unavailable",
-        paymentProvider: "Service unavailable"
-    }
-};
+  analytics: {
+    analyticsId: 'Service unavailable',
+    type: 'Service unavailable',
+    paymentProvider: 'Service unavailable'
+  }
+}
 
 describe('retrieve param test', function () {
-
   var response = {
-    status: function(){},
-    render: function(){}
-  },
-  status = undefined,
-  render = undefined,
-  next   = undefined,
-  validRequest =  {
-    params: { chargeId: "foo" },
+    status: function () {},
+    render: function () {}
+  }
+  var status
+  var render
+  var next
+  var validRequest = {
+    params: {chargeId: 'foo'},
     body: {},
     method: 'GET',
-    frontend_state: { ch_foo: true },
-    headers:{}
-  },
-  chargeId = 'foo';
+    frontend_state: {ch_foo: true},
+    headers: {}
+  }
+  var chargeId = 'foo'
 
+  beforeEach(function () {
+    status = sinon.stub(response, 'status')
+    render = sinon.stub(response, 'render')
+    next = sinon.spy()
+    nock.cleanAll()
+  })
 
-  beforeEach(function(){
-    status = sinon.stub(response,"status");
-    render = sinon.stub(response,"render");
-    next   = sinon.spy();
-    nock.cleanAll();
-  });
-
-  afterEach(function(){
-    status.restore();
-    render.restore();
-  });
-
-
+  afterEach(function () {
+    status.restore()
+    render.restore()
+  })
 
   // We don't need to test all states as they are tested in
   // the charge param retriever tests
   it('should call not found view if charge param does not return an id', function () {
-    retrieveCharge( { params: {}, body: {} },response,next)
-    assert(status.calledWith(403));
-    assert(render.calledWith("errors/system_error", { viewName: 'UNAUTHORISED', analytics: ANALYTICS_ERROR.analytics}));
-    expect(next.notCalled).to.be.true;
+    retrieveCharge({params: {}, body: {}}, response, next)
+    assert(status.calledWith(403))
+    assert(render.calledWith('errors/system_error', {viewName: 'UNAUTHORISED', analytics: ANALYTICS_ERROR.analytics}))
+    expect(next.notCalled).to.be.true // eslint-disable-line
+  })
 
-  });
+  it('should call not found view if the connector does not respond', function (done) {
+    retrieveCharge(validRequest, response, next)
+    var testPromise = new Promise((resolve, reject) => {
+      setTimeout(() => { resolve() }, 700)
+    })
 
-  it("should call not found view if the connector does not respond", function(done) {
-      retrieveCharge( validRequest,response,next)
-      var testPromise = new Promise((resolve, reject) => {
-          setTimeout(() => { resolve(); }, 700);
-      });
+    testPromise.then((result) => {
+      try {
+        assert(status.calledWith(500))
+        assert(render.calledWith('errors/system_error', {viewName: 'SYSTEM_ERROR', analytics: ANALYTICS_ERROR.analytics}))
+        expect(next.notCalled).to.be.true // eslint-disable-line
+        done()
+      } catch (err) { done(err) }
+    }, done)
+  })
 
-      testPromise.then((result) => {
-        try {
-          assert(status.calledWith(500));
-          assert(render.calledWith("errors/system_error", { viewName: 'SYSTEM_ERROR', analytics: ANALYTICS_ERROR.analytics}));
-          expect(next.notCalled).to.be.true;
-          done();
-        }
-        catch(err) { done(err); }
-      }, done);
-  });
-
-  it("should set chargeData chargeID and call next on success", function(done) {
-      var chargeData = {foo:"bar"};
-      nock(process.env.CONNECTOR_HOST)
+  it('should set chargeData chargeID and call next on success', function (done) {
+    var chargeData = {foo: 'bar'}
+    nock(process.env.CONNECTOR_HOST)
         .get(`/v1/frontend/charges/${chargeId}`)
-        .reply(200,chargeData);
-      retrieveCharge( validRequest,response,next )
+        .reply(200, chargeData)
+    retrieveCharge(validRequest, response, next)
 
-      var testPromise = new Promise((resolve, reject) => {
-          setTimeout(() => { resolve(); }, 100);
-      });
+    var testPromise = new Promise((resolve, reject) => {
+      setTimeout(() => { resolve() }, 100)
+    })
 
-      testPromise.then((result) => {
-        try {
-          expect(status.calledWith(200));
-          expect(validRequest.chargeId).to.equal(chargeId);
-          expect(validRequest.chargeData).to.deep.equal(chargeData);
-          expect(next.called).to.be.true;
-          done();
-        }
-        catch(err) { done(err); }
-      }, done);
-  });
-
+    testPromise.then((result) => {
+      try {
+        expect(status.calledWith(200))
+        expect(validRequest.chargeId).to.equal(chargeId)
+        expect(validRequest.chargeData).to.deep.equal(chargeData)
+        expect(next.called).to.be.true // eslint-disable-line 
+        done()
+      } catch (err) { done(err) }
+    }, done)
+  })
 })

--- a/test/middleware/state_enforcer_test.js
+++ b/test/middleware/state_enforcer_test.js
@@ -1,229 +1,224 @@
-var should = require('chai').should();
-var assert = require('assert');
-var expect = require('chai').expect;
-var views  = require(__dirname + '/../../app/utils/views.js');
-var stateEnforcer  = require(__dirname + '/../../app/middleware/state_enforcer.js');
+var path = require('path')
+var assert = require('assert')
+var expect = require('chai').expect
+var stateEnforcer = require(path.join(__dirname, '/../../app/middleware/state_enforcer.js'))
 
-var sinon  = require('sinon');
-var _      = require('lodash');
-
+var sinon = require('sinon')
 
 describe('state enforcer', function () {
-
   var response = {
-    status: function(){},
-    render: function(){}
-  },
-  status  = undefined,
-  render  = undefined,
-  next    = undefined;
+    status: function () {},
+    render: function () {}
+  }
+  var status
+  var render
+  var next
 
-  beforeEach(function(){
-    status = sinon.stub(response,"status");
-    render = sinon.stub(response,"render");
-    next   = sinon.spy()
-  });
+  beforeEach(function () {
+    status = sinon.stub(response, 'status')
+    render = sinon.stub(response, 'render')
+    next = sinon.spy()
+  })
 
-  afterEach(function(){
-    status.restore();
-    render.restore();
-  });
+  afterEach(function () {
+    status.restore()
+    render.restore()
+  })
 
   it('should call next when everything is in the correct state', function () {
     stateEnforcer({
-      actionName: "card.new",
-      chargeData: { status: 'ENTERING CARD DETAILS'}
-    },{},next)
-    expect(next.calledOnce).to.be.true;
-  });
+      actionName: 'card.new',
+      chargeData: {status: 'ENTERING CARD DETAILS'}
+    }, {}, next)
+    expect(next.calledOnce).to.be.true // eslint-disable-line
+  })
 
   it('should NOT call next when an invalid state is called and render an error', function () {
     stateEnforcer({
-      actionName: "card.new",
-      chargeData: { status: 'INVALID STATE'}
-    },response,next)
-    expect(next.notCalled).to.be.true;
-    assert(status.calledWith(500));
-    assert(render.calledWith("error",
+      actionName: 'card.new',
+      chargeData: {status: 'INVALID STATE'}
+    }, response, next)
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    assert(status.calledWith(500))
+    assert(render.calledWith('error',
       { message: 'There is a problem, please try again later',
-      viewName: 'error' }
-    ));
-  });
+        viewName: 'error' }
+    ))
+  })
 
   it('should NOT call next when the object is in the wrong state is called and render the appropriate error view', function () {
     stateEnforcer({
-      actionName: "card.new",
-      chargeData: { status: 'AUTHORISATION_SUCCESS', return_url: "foo" , gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
+      actionName: 'card.new',
+      chargeData: {status: 'AUTHORISATION_SUCCESS', return_url: 'foo', gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
       chargeId: 1
-    },response,next);
-    expect(next.notCalled).to.be.true;
-    assert(status.calledWith(200));
-    assert(render.calledWith("errors/incorrect_state/auth_success",
+    }, response, next)
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    assert(status.calledWith(200))
+    assert(render.calledWith('errors/incorrect_state/auth_success',
       { chargeId: 1,
         analytics: {
-          analyticsId: "Test AnalyticsID",
-          type: "Test Type",
-          paymentProvider: "Test Provider",
+          analyticsId: 'Test AnalyticsID',
+          type: 'Test Type',
+          paymentProvider: 'Test Provider',
           path: '/card_details/1/in_progress'
         },
         returnUrl: '/return/1',
         viewName: 'AUTHORISATION_SUCCESS' }
-    ));
-  });
+    ))
+  })
 
   it('should render the auth_waiting view the correct analytics when auth is rejected', function () {
     stateEnforcer({
-      actionName: "card.new",
-      chargeData: { status: 'AUTHORISATION_READY', return_url: "foo" , gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
+      actionName: 'card.new',
+      chargeData: {status: 'AUTHORISATION_READY', return_url: 'foo', gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
       chargeId: 1
-    },response,next);
-    expect(next.notCalled).to.be.true;
-    assert(status.calledWith(200));
-    assert(render.calledWith("errors/incorrect_state/auth_waiting",
+    }, response, next)
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    assert(status.calledWith(200))
+    assert(render.calledWith('errors/incorrect_state/auth_waiting',
       { chargeId: 1,
         analytics: {
-          analyticsId: "Test AnalyticsID",
-          type: "Test Type",
-          paymentProvider: "Test Provider",
+          analyticsId: 'Test AnalyticsID',
+          type: 'Test Type',
+          paymentProvider: 'Test Provider',
           path: '/card_details/1/in_progress'
         },
         returnUrl: '/return/1',
         viewName: 'AUTHORISATION_READY' }
-    ));
-  });
+    ))
+  })
   it('should throw an error when a view is passed in without having a state', function () {
-
-    expect(function() { stateEnforcer({
-      actionName: "hellothere",
-      chargeData: { status: 'AUTHORISATION_SUCCESS', return_url: "foo" },
-      chargeId: 1
-    },response,next)}).to.throw(/Cannot find correct states for action/);
-  });
+    expect(function () {
+      stateEnforcer({
+        actionName: 'hellothere',
+        chargeData: {status: 'AUTHORISATION_SUCCESS', return_url: 'foo'},
+        chargeId: 1
+      }, response, next)
+    }).to.throw(/Cannot find correct states for action/)
+  })
 
   it('should render the confirm view when coming back from the service with the correct analytics', function () {
     stateEnforcer({
-      actionName: "card.confirm",
-      chargeData: { status: 'CAPTURED', return_url: "foo" , gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
+      actionName: 'card.confirm',
+      chargeData: {status: 'CAPTURED', return_url: 'foo', gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
       chargeId: 1
-    },response,next);
-    expect(next.notCalled).to.be.true;
-    assert(status.calledWith(200));
-    assert(render.calledWith("errors/charge_confirm_state_completed",
+    }, response, next)
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    assert(status.calledWith(200))
+    assert(render.calledWith('errors/charge_confirm_state_completed',
       { status: 'successful',
         chargeId: 1,
         analytics: {
-          analyticsId: "Test AnalyticsID",
-          type: "Test Type",
-          paymentProvider: "Test Provider",
+          analyticsId: 'Test AnalyticsID',
+          type: 'Test Type',
+          paymentProvider: 'Test Provider',
           path: '/card_details/1/success_return'
         },
         returnUrl: '/return/1',
         viewName: 'CAPTURED' }
-    ));
-  });
+    ))
+  })
 
   it('should render the auth_failure view the correct analytics when auth is rejected', function () {
     stateEnforcer({
-      actionName: "card.new",
-      chargeData: { status: 'AUTHORISATION_REJECTED', return_url: "foo" , gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
+      actionName: 'card.new',
+      chargeData: {status: 'AUTHORISATION_REJECTED', return_url: 'foo', gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
       chargeId: 1
-    },response,next);
-    expect(next.notCalled).to.be.true;
-    assert(status.calledWith(200));
-    assert(render.calledWith("errors/incorrect_state/auth_failure",
+    }, response, next)
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    assert(status.calledWith(200))
+    assert(render.calledWith('errors/incorrect_state/auth_failure',
       { chargeId: 1,
         analytics: {
-          analyticsId: "Test AnalyticsID",
-          type: "Test Type",
-          paymentProvider: "Test Provider",
+          analyticsId: 'Test AnalyticsID',
+          type: 'Test Type',
+          paymentProvider: 'Test Provider',
           path: '/card_details/1/auth_failure'
         },
         returnUrl: '/return/1',
         viewName: 'AUTHORISATION_REJECTED' }
-    ));
-  });
+    ))
+  })
 
   it('should render the auth_failure view the correct analytics when auth is cancelled', function () {
     stateEnforcer({
-      actionName: "card.new",
-      chargeData: { status: 'AUTHORISATION_CANCELLED', return_url: "foo" , gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
+      actionName: 'card.new',
+      chargeData: {status: 'AUTHORISATION_CANCELLED', return_url: 'foo', gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
       chargeId: 1
-    },response,next);
-    expect(next.notCalled).to.be.true;
-    assert(status.calledWith(200));
-    assert(render.calledWith("errors/incorrect_state/auth_failure",
+    }, response, next)
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    assert(status.calledWith(200))
+    assert(render.calledWith('errors/incorrect_state/auth_failure',
       { chargeId: 1,
         analytics: {
-          analyticsId: "Test AnalyticsID",
-          type: "Test Type",
-          paymentProvider: "Test Provider",
+          analyticsId: 'Test AnalyticsID',
+          type: 'Test Type',
+          paymentProvider: 'Test Provider',
           path: '/card_details/1/auth_failure'
         },
         returnUrl: '/return/1',
         viewName: 'AUTHORISATION_CANCELLED' }
-    ));
-  });
+    ))
+  })
   it('should render the capture_failure view the correct analytics when capture fails', function () {
     stateEnforcer({
-      actionName: "card.new",
-      chargeData: { status: 'CAPTURE_FAILURE', return_url: "foo" , gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
+      actionName: 'card.new',
+      chargeData: {status: 'CAPTURE_FAILURE', return_url: 'foo', gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
       chargeId: 1
-    },response,next);
-    expect(next.notCalled).to.be.true;
-    assert(status.calledWith(200));
-    assert(render.calledWith("errors/incorrect_state/capture_failure",
+    }, response, next)
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    assert(render.calledWith('errors/incorrect_state/capture_failure',
       { chargeId: 1,
         analytics: {
-          analyticsId: "Test AnalyticsID",
-          type: "Test Type",
-          paymentProvider: "Test Provider",
+          analyticsId: 'Test AnalyticsID',
+          type: 'Test Type',
+          paymentProvider: 'Test Provider',
           path: '/card_details/1/capture_failure'
         },
         returnUrl: '/return/1',
         viewName: 'CAPTURE_FAILURE' }
-    ));
-  });
+    ))
+  })
 
   it('should render the capture_failure view the correct analytics when capture errors', function () {
     stateEnforcer({
-      actionName: "card.new",
-      chargeData: { status: 'CAPTURE_ERROR', return_url: "foo" , gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
+      actionName: 'card.new',
+      chargeData: {status: 'CAPTURE_ERROR', return_url: 'foo', gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
       chargeId: 1
-    },response,next);
-    expect(next.notCalled).to.be.true;
-    assert(status.calledWith(200));
-    assert(render.calledWith("errors/incorrect_state/capture_failure",
+    }, response, next)
+    expect(next.notCalled).to.be.true // eslint-disable-line
+    assert(status.calledWith(200))
+    assert(render.calledWith('errors/incorrect_state/capture_failure',
       { chargeId: 1,
         analytics: {
-          analyticsId: "Test AnalyticsID",
-          type: "Test Type",
-          paymentProvider: "Test Provider",
+          analyticsId: 'Test AnalyticsID',
+          type: 'Test Type',
+          paymentProvider: 'Test Provider',
           path: '/card_details/1/capture_failure'
         },
         returnUrl: '/return/1',
         viewName: 'CAPTURE_ERROR' }
-    ));
-  });
+    ))
+  })
 
   it('should render the capture_waiting view the correct analytics when capture is ready', function () {
     stateEnforcer({
-      actionName: "card.new",
-      chargeData: { status: 'CAPTURE_READY', return_url: "foo" , gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
+      actionName: 'card.new',
+      chargeData: {status: 'CAPTURE_READY', return_url: 'foo', gateway_account: {analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider'}},
       chargeId: 1
-    },response,next);
-    expect(next.notCalled).to.be.true;
-    assert(status.calledWith(200));
-    assert(render.calledWith("errors/incorrect_state/capture_waiting",
+    }, response, next)
+    expect(next.notCalled).to.be.true // eslint-disable-line 
+    assert(status.calledWith(200))
+    assert(render.calledWith('errors/incorrect_state/capture_waiting',
       { chargeId: 1,
         analytics: {
-          analyticsId: "Test AnalyticsID",
-          type: "Test Type",
-          paymentProvider: "Test Provider",
+          analyticsId: 'Test AnalyticsID',
+          type: 'Test Type',
+          paymentProvider: 'Test Provider',
           path: '/card_details/1/in_progress'
         },
         returnUrl: '/return/1',
         viewName: 'CAPTURE_READY' }
-    ));
-  });
-
-});
+    ))
+  })
+})

--- a/test/models/card_test.js
+++ b/test/models/card_test.js
@@ -1,187 +1,174 @@
-require(__dirname + '/../test_helpers/html_assertions.js');
-var should    = require('chai').should();
-var assert    = require('assert');
-var CardModel = require(__dirname + '/../../app/models/card.js');
-var nock      = require('nock');
-var originalHost = process.env.CONNECTOR_HOST
-var wrongPromise = require(__dirname + '/../test_helpers/test_helpers.js').unexpectedPromise;
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
+var assert = require('assert')
+var CardModel = require(path.join(__dirname, '/../../app/models/card.js'))
+var nock = require('nock')
+var wrongPromise = require(path.join(__dirname, '/../test_helpers/test_helpers.js')).unexpectedPromise
 
-var aRequestId = 'unique-request-id';
+var aRequestId = 'unique-request-id'
 var aCorrelationHeader = {
   reqheaders: {
     'x-request-id': aRequestId
   }
-};
+}
 
 describe('card', function () {
-  describe('check card', function() {
+  describe('check card', function () {
     describe('when card is not found', function () {
-      before(function() {
-
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
         nock(process.env.CARDID_HOST)
-            .post("/v1/api/card")
-            .reply(404);
-      });
+            .post('/v1/api/card')
+            .reply(404)
+      })
 
       it('should return the correct message', function () {
-        return CardModel({}, aRequestId).checkCard(1234).then(wrongPromise,function(message){
-          assert.equal(message,"Your card is not supported");
-        });
-      });
-    });
+        return CardModel({}, aRequestId).checkCard(1234).then(wrongPromise, function (message) {
+          assert.equal(message, 'Your card is not supported')
+        })
+      })
+    })
 
     describe('when an unexpected response code', function () {
-      before(function() {
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
 
         nock(process.env.CARDID_HOST, aCorrelationHeader)
-            .post("/v1/api/card")
-            .reply(201);
-      });
+            .post('/v1/api/card')
+            .reply(201)
+      })
 
       it('should resolve', function () {
-        return CardModel({}, aRequestId).checkCard(1234).then(()=>{},wrongPromise);
-      });
-    });
+        return CardModel({}, aRequestId).checkCard(1234).then(() => {}, wrongPromise)
+      })
+    })
 
     describe('an unkown card', function () {
-      before(function() {
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
 
         nock(process.env.CARDID_HOST)
-            .post("/v1/api/card")
-            .reply(201);
-      });
+            .post('/v1/api/card')
+            .reply(201)
+      })
 
       it('should resolve', function () {
-        return CardModel().checkCard(1234).then(()=>{},wrongPromise);
-      });
-    });
+        return CardModel().checkCard(1234).then(() => {}, wrongPromise)
+      })
+    })
 
     describe('a card that is not allowed', function () {
-      before(function() {
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
         nock(process.env.CARDID_HOST)
-          .post("/v1/api/card")
-          .reply(200,{brand: "bar", label: "bar"});
-      });
+          .post('/v1/api/card')
+          .reply(200, {brand: 'bar', label: 'bar'})
+      })
 
       it('should reject with appropriate message', function () {
-        return CardModel([{brand: "foo", label: "foo", type: "CREDIT", id: "id-0"}])
-        .checkCard(1234).then(wrongPromise,function(message){
-          assert.equal(message,"Bar is not supported");
-        });
-      });
-    });
+        return CardModel([{brand: 'foo', label: 'foo', type: 'CREDIT', id: 'id-0'}])
+        .checkCard(1234).then(wrongPromise, function (message) {
+          assert.equal(message, 'Bar is not supported')
+        })
+      })
+    })
 
     describe('a card that is not allowed debit withrawal type', function () {
-      before(function() {
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
         nock(process.env.CARDID_HOST)
-          .post("/v1/api/card")
-          .reply(200,{brand: "bar", label: "bar", type: 'D'});
-      });
+          .post('/v1/api/card')
+          .reply(200, {brand: 'bar', label: 'bar', type: 'D'})
+      })
 
       it('should reject with appropriate message', function () {
-        return CardModel([{brand: "bar", label: "bar", type: "CREDIT", id: "id-0"}], aRequestId)
-        .checkCard(1234).then(wrongPromise,function(message){
-          assert.equal(message,"Bar debit cards are not supported");
-        });
-      });
-    });
-
+        return CardModel([{brand: 'bar', label: 'bar', type: 'CREDIT', id: 'id-0'}], aRequestId)
+        .checkCard(1234).then(wrongPromise, function (message) {
+          assert.equal(message, 'Bar debit cards are not supported')
+        })
+      })
+    })
 
     describe('a card that is not allowed Credit withrawal type', function () {
-      before(function() {
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
         nock(process.env.CARDID_HOST)
-          .post("/v1/api/card")
-          .reply(200,{brand: "bar", label: "bar", type: 'C'});
-      });
+          .post('/v1/api/card')
+          .reply(200, {brand: 'bar', label: 'bar', type: 'C'})
+      })
 
       it('should reject with appropriate message', function () {
-        return CardModel([{brand: "bar", label: "bar", type: "DEBIT", id: "id-0"}])
-        .checkCard(1234).then(wrongPromise,function(message){
-          assert.equal(message,"Bar credit cards are not supported");
-        });
-      });
-    });
-
+        return CardModel([{brand: 'bar', label: 'bar', type: 'DEBIT', id: 'id-0'}])
+        .checkCard(1234).then(wrongPromise, function (message) {
+          assert.equal(message, 'Bar credit cards are not supported')
+        })
+      })
+    })
 
     describe('a card that is allowed', function () {
-      before(function() {
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
         nock(process.env.CARDID_HOST)
-          .post("/v1/api/card")
-          .reply(200,{brand: "bar", label: "bar", type: 'C'});
-      });
+          .post('/v1/api/card')
+          .reply(200, {brand: 'bar', label: 'bar', type: 'C'})
+      })
 
       it('should resolve with correct card brand', function () {
-        return CardModel([{brand: "bar", label: "bar", type: "CREDIT", id: "id-0"}])
-          .checkCard(1234).then((cardBrand)=>{
-            assert.equal(cardBrand, "bar");
-          },wrongPromise);
-      });
-    });
+        return CardModel([{brand: 'bar', label: 'bar', type: 'CREDIT', id: 'id-0'}])
+          .checkCard(1234).then((cardBrand) => {
+            assert.equal(cardBrand, 'bar')
+          }, wrongPromise)
+      })
+    })
 
     describe('a card that is allowed but of unknown type', function () {
-      before(function() {
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
         nock(process.env.CARDID_HOST)
-          .post("/v1/api/card")
-          .reply(200,{brand: "bar", label: "bar", type: 'CD'});
-      });
+          .post('/v1/api/card')
+          .reply(200, {brand: 'bar', label: 'bar', type: 'CD'})
+      })
 
       it('should resolve with correct card brand', function () {
-        return CardModel([{brand: "bar", label: "bar", type: "CREDIT", id: "id-0"}])
-          .checkCard(1234).then((cardBrand)=>{
-            assert.equal(cardBrand, "bar");
-          },wrongPromise);
-      });
-    });
-  });
+        return CardModel([{brand: 'bar', label: 'bar', type: 'CREDIT', id: 'id-0'}])
+          .checkCard(1234).then((cardBrand) => {
+            assert.equal(cardBrand, 'bar')
+          }, wrongPromise)
+      })
+    })
+  })
 
-  describe('allowedCards',function() {
-
+  describe('allowedCards', function () {
     it('should return the passed in cards', function () {
-      var cards = [{brand: "foo", debit: true}];
-      var Card = CardModel(cards);
-      var CardCopy = CardModel(cards);
-      assert.deepEqual(Card.allowed,cards);
+      var cards = [{brand: 'foo', debit: true}]
+      var Card = CardModel(cards)
+      var CardCopy = CardModel(cards)
+      assert.deepEqual(Card.allowed, cards)
       // shoudl return a copy
-      assert.notEqual(Card.allowed,cards);
-      assert.notEqual(Card.allowed,CardCopy.allowed);
-    });
+      assert.notEqual(Card.allowed, cards)
+      assert.notEqual(Card.allowed, CardCopy.allowed)
+    })
 
     it('should return the passed in cards wityhdrawal types', function () {
-      var debitOnly = CardModel([{brand: "foo", debit: true}]);
-      var creditOnly = CardModel([{brand: "foo", credit: true}]);
-      var both = CardModel([{brand: "foo", credit: true, debit: true}]);
+      var debitOnly = CardModel([{brand: 'foo', debit: true}])
+      var creditOnly = CardModel([{brand: 'foo', credit: true}])
+      var both = CardModel([{brand: 'foo', credit: true, debit: true}])
 
-      assert.deepEqual(debitOnly.withdrawalTypes,["debit"]);
-      assert.deepEqual(creditOnly.withdrawalTypes,["credit"]);
-      assert.deepEqual(both.withdrawalTypes,["debit","credit"]);
+      assert.deepEqual(debitOnly.withdrawalTypes, ['debit'])
+      assert.deepEqual(creditOnly.withdrawalTypes, ['credit'])
+      assert.deepEqual(both.withdrawalTypes, ['debit', 'credit'])
+    })
+  })
 
-    });
-
-  });
-
-
-  describe('withdrawalTypes',function() {
-
+  describe('withdrawalTypes', function () {
     it('should return the passed in cards wityhdrawal types', function () {
-      var debitOnly = CardModel([{brand: "foo", debit: true}]);
-      var creditOnly = CardModel([{brand: "foo", credit: true}]);
-      var both = CardModel([{brand: "foo", credit: true, debit: true}]);
+      var debitOnly = CardModel([{brand: 'foo', debit: true}])
+      var creditOnly = CardModel([{brand: 'foo', credit: true}])
+      var both = CardModel([{brand: 'foo', credit: true, debit: true}])
 
-      assert.deepEqual(debitOnly.withdrawalTypes,["debit"]);
-      assert.deepEqual(creditOnly.withdrawalTypes,["credit"]);
-      assert.deepEqual(both.withdrawalTypes,["debit","credit"]);
-
-    });
-
-  });
-});
-
-
+      assert.deepEqual(debitOnly.withdrawalTypes, ['debit'])
+      assert.deepEqual(creditOnly.withdrawalTypes, ['credit'])
+      assert.deepEqual(both.withdrawalTypes, ['debit', 'credit'])
+    })
+  })
+})

--- a/test/models/charge_test.js
+++ b/test/models/charge_test.js
@@ -1,246 +1,236 @@
-require(__dirname + '/../test_helpers/html_assertions.js');
-var should    = require('chai').should();
-var assert    = require('assert');
-var Charge    = require(__dirname + '/../../app/models/charge.js');
-var nock      = require('nock');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
+var assert = require('assert')
+var Charge = require(path.join(__dirname, '/../../app/models/charge.js'))
+var nock = require('nock')
 var originalHost = process.env.CONNECTOR_HOST
-var wrongPromise = require(__dirname + '/../test_helpers/test_helpers.js').unexpectedPromise;
+var wrongPromise = require(path.join(__dirname, '/../test_helpers/test_helpers.js')).unexpectedPromise
 
-describe('updateStatus',function(){
-
+describe('updateStatus', function () {
   describe('when connector is unavailable', function () {
-    beforeEach(function() {
-      nock.cleanAll();
-      process.env.CONNECTOR_HOST = "http://unavailableServer:65535"
-    });
+    beforeEach(function () {
+      nock.cleanAll()
+      process.env.CONNECTOR_HOST = 'http://unavailableServer:65535'
+    })
 
-    afterEach(function() {
-      process.env.CONNECTOR_HOST = originalHost;
-    });
+    afterEach(function () {
+      process.env.CONNECTOR_HOST = originalHost
+    })
 
     it('should return client unavailable', function () {
-        var chargeModel = Charge('');
-        return chargeModel.updateStatus(1,'ENTERING CARD DETAILS').then(wrongPromise,
-          function rejected(error){
-            assert.equal(error.message,"CLIENT_UNAVAILABLE")
-        });
-    });
-  });
+      var chargeModel = Charge('')
+      return chargeModel.updateStatus(1, 'ENTERING CARD DETAILS').then(wrongPromise,
+          function rejected (error) {
+            assert.equal(error.message, 'CLIENT_UNAVAILABLE')
+          })
+    })
+  })
 
   describe('when connector returns wrong response', function () {
-    before(function() {
-      nock.cleanAll();
+    before(function () {
+      nock.cleanAll()
       nock(originalHost)
-      .put("/v1/frontend/charges/1/status")
+      .put('/v1/frontend/charges/1/status')
       .reply(422, '{}')
-    });
-
+    })
 
     it('should return update_failed', function () {
-      var chargeModel = Charge('');
-      return chargeModel.updateStatus(1,'ENTERING CARD DETAILS').then(wrongPromise,
-        function rejected(error){
-          assert.equal(error.message,"UPDATE_FAILED")
-      });
-    });
-  });
+      var chargeModel = Charge('')
+      return chargeModel.updateStatus(1, 'ENTERING CARD DETAILS').then(wrongPromise,
+        function rejected (error) {
+          assert.equal(error.message, 'UPDATE_FAILED')
+        })
+    })
+  })
 
   describe('it returns everything correctly', function () {
-    before(function() {
+    before(function () {
       nock(originalHost)
-      .put("/v1/frontend/charges/1/status")
-      .reply(204);
+      .put('/v1/frontend/charges/1/status')
+      .reply(204)
 
       nock(originalHost)
-      .get("/v1/frontend/charges/1")
-      .reply(200, {foo: 'bar'});
-    });
-
+      .get('/v1/frontend/charges/1')
+      .reply(200, {foo: 'bar'})
+    })
 
     it('should return the correct json', function () {
-      var chargeModel = Charge('');
-      return chargeModel.updateStatus(1,'ENTERING CARD DETAILS')
-      .then(function(data,response){
-        assert.equal(data.success,'OK');
-      },wrongPromise);
-    });
-  });
+      var chargeModel = Charge('')
+      return chargeModel.updateStatus(1, 'ENTERING CARD DETAILS')
+      .then(function (data, response) {
+        assert.equal(data.success, 'OK')
+      }, wrongPromise)
+    })
+  })
+})
 
-});
-
-describe('find',function(){
-
+describe('find', function () {
   describe('when connector is unavailable', function () {
-    before(function() {
-      nock.cleanAll();
-    });
+    before(function () {
+      nock.cleanAll()
+    })
 
     it('should return client unavailable', function () {
-      var chargeModel = Charge('');
+      var chargeModel = Charge('')
       return chargeModel.find(1).then(wrongPromise,
-        function rejected(error){
-          assert.equal(error.message,"CLIENT_UNAVAILABLE")
-      });
-    });
-  });
-
+        function rejected (error) {
+          assert.equal(error.message, 'CLIENT_UNAVAILABLE')
+        })
+    })
+  })
 
   describe('when connector returns incorrect response code', function () {
-    before(function() {
-      nock.cleanAll();
+    before(function () {
+      nock.cleanAll()
 
       nock(originalHost)
-      .get("/v1/frontend/charges/1")
-      .reply(404, '{}');
-    });
+      .get('/v1/frontend/charges/1')
+      .reply(404, '{}')
+    })
 
     it('should return get_failed', function () {
-      var chargeModel = Charge('');
+      var chargeModel = Charge('')
       return chargeModel.find(1).then(wrongPromise,
-        function rejected(error){
-          assert.equal(error.message,"GET_FAILED")
-      });
-    });
-  });
-
+        function rejected (error) {
+          assert.equal(error.message, 'GET_FAILED')
+        })
+    })
+  })
 
   describe('when connector returns correctly', function () {
-    before(function() {
-      nock.cleanAll();
+    before(function () {
+      nock.cleanAll()
 
       nock(originalHost)
-      .get("/v1/frontend/charges/1")
-      .reply(200, {foo: "bar"});
-    });
+      .get('/v1/frontend/charges/1')
+      .reply(200, {foo: 'bar'})
+    })
 
     it('should return get_failed', function () {
-      var chargeModel = Charge('');
-      return chargeModel.find(1).then(function(data){
-        assert.equal(data.foo,'bar');
-      },wrongPromise);
-    });
-  });
-});
+      var chargeModel = Charge('')
+      return chargeModel.find(1).then(function (data) {
+        assert.equal(data.foo, 'bar')
+      }, wrongPromise)
+    })
+  })
+})
 
-describe('capture',function(){
+describe('capture', function () {
   describe('when connector returns with 204 it should resolve the correct promise', function () {
-    before(function() {
-      nock.cleanAll();
+    before(function () {
+      nock.cleanAll()
 
       nock(originalHost)
-      .post("/v1/frontend/charges/1/capture")
-      .reply(204);
-    });
+      .post('/v1/frontend/charges/1/capture')
+      .reply(204)
+    })
 
     it('should return into the correct promise', function () {
-      var chargeModel = Charge('');
-      return chargeModel.capture(1).then(function(){
+      var chargeModel = Charge('')
+      return chargeModel.capture(1).then(function () {
         // correct promise returned so no need to check anything
-      },wrongPromise);
-    });
-  });
-
+      }, wrongPromise)
+    })
+  })
 
   describe('when connector is unavailable', function () {
-    before(function() {
-      nock.cleanAll();
-    });
+    before(function () {
+      nock.cleanAll()
+    })
 
     it('should return CLIENT_UNAVAILABLE when post fails', function () {
-      var chargeModel = Charge('');
+      var chargeModel = Charge('')
       return chargeModel.capture(1).then(wrongPromise,
-        function rejected(error){
-          assert.equal(error.message,"CLIENT_UNAVAILABLE");
-      });
-    });
-  });
-
+        function rejected (error) {
+          assert.equal(error.message, 'CLIENT_UNAVAILABLE')
+        })
+    })
+  })
 
   describe('when connector returns with auth failed should return error CAPTURE_FAILED', function () {
-    before(function() {
-      nock.cleanAll();
+    before(function () {
+      nock.cleanAll()
 
       nock(originalHost)
-      .post("/v1/frontend/charges/1/capture")
-      .reply(400);
-    });
+      .post('/v1/frontend/charges/1/capture')
+      .reply(400)
+    })
 
     it('should return AUTH_FAILED', function () {
-      var chargeModel = Charge('');
+      var chargeModel = Charge('')
       return chargeModel.capture(1).then(wrongPromise,
-        function rejected(error){
-          assert.equal(error.message,"CAPTURE_FAILED")
-      });
-    });
-  });
+        function rejected (error) {
+          assert.equal(error.message, 'CAPTURE_FAILED')
+        })
+    })
+  })
 
   describe('when connector returns with ! (204||400) should return error POST_FAILED', function () {
-    before(function() {
-      nock.cleanAll();
+    before(function () {
+      nock.cleanAll()
 
       nock(originalHost)
-      .post("/v1/frontend/charges/1/capture")
-      .reply(410);
-    });
+      .post('/v1/frontend/charges/1/capture')
+      .reply(410)
+    })
 
     it('should return AUTH_FAILED', function () {
-      var chargeModel = Charge('');
+      var chargeModel = Charge('')
       return chargeModel.capture(1).then(wrongPromise,
-        function rejected(error){
-          assert.equal(error.message,"POST_FAILED")
-      });
-    });
-  });
-});
+        function rejected (error) {
+          assert.equal(error.message, 'POST_FAILED')
+        })
+    })
+  })
+})
 
-describe('findByToken',function(){
-
+describe('findByToken', function () {
   describe('when connector is unavailable', function () {
-    before(function() {
-      nock.cleanAll();
-    });
+    before(function () {
+      nock.cleanAll()
+    })
 
     it('should return client unavailable', function () {
-      var chargeModel = Charge('');
+      var chargeModel = Charge('')
       return chargeModel.findByToken(1).then(wrongPromise,
-          function rejected(error){
-            assert.equal(error.message,"CLIENT_UNAVAILABLE")
-          });
-    });
-  });
+          function rejected (error) {
+            assert.equal(error.message, 'CLIENT_UNAVAILABLE')
+          })
+    })
+  })
 
   describe('when connector returns incorrect response code', function () {
-    before(function() {
-      nock.cleanAll();
+    before(function () {
+      nock.cleanAll()
 
       nock(originalHost)
-          .get("/v1/frontend/tokens/1/charge")
-          .reply(404, '{}');
-    });
+          .get('/v1/frontend/tokens/1/charge')
+          .reply(404, '{}')
+    })
 
     it('should return get_failed', function () {
-      var chargeModel = Charge('');
+      var chargeModel = Charge('')
       return chargeModel.findByToken(1).then(wrongPromise,
-          function rejected(error){
-            assert.equal(error.message,"GET_FAILED")
-          });
-    });
-  });
+          function rejected (error) {
+            assert.equal(error.message, 'GET_FAILED')
+          })
+    })
+  })
 
   describe('when connector returns correctly', function () {
-    before(function() {
-      nock.cleanAll();
+    before(function () {
+      nock.cleanAll()
 
       nock(originalHost)
-          .get("/v1/frontend/tokens/1/charge")
-          .reply(200, {foo: "bar"});
-    });
+          .get('/v1/frontend/tokens/1/charge')
+          .reply(200, {foo: 'bar'})
+    })
 
     it('should return get_failed', function () {
-      var chargeModel = Charge('');
-      return chargeModel.findByToken(1).then(function(data){
-        assert.equal(data.foo,'bar');
-      },wrongPromise);
-    });
-  });
-});
+      var chargeModel = Charge('')
+      return chargeModel.findByToken(1).then(function (data) {
+        assert.equal(data.foo, 'bar')
+      }, wrongPromise)
+    })
+  })
+})

--- a/test/models/token_test.js
+++ b/test/models/token_test.js
@@ -1,69 +1,67 @@
-require(__dirname + '/../test_helpers/html_assertions.js');
-var should    = require('chai').should();
-var assert    = require('assert');
-var Token     = require(__dirname + '/../../app/models/token.js');
-var nock      = require('nock');
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
+var assert = require('assert')
+var Token = require(path.join(__dirname, '/../../app/models/token.js'))
+var nock = require('nock')
 var originalHost = process.env.CONNECTOR_HOST
-var wrongPromise = require(__dirname + '/../test_helpers/test_helpers.js').unexpectedPromise;
+var wrongPromise = require(path.join(__dirname, '/../test_helpers/test_helpers.js')).unexpectedPromise
 
-describe('token model', function() {
-  describe('destroy', function(){
-
+describe('token model', function () {
+  describe('destroy', function () {
     describe('when connector is unavailable', function () {
-      before(function() {
-        nock.cleanAll();
-      });
+      before(function () {
+        nock.cleanAll()
+      })
 
       it('should return client unavailable', function () {
-        var token = Token('blah');
+        var token = Token('blah')
         return token.destroy(1).then(wrongPromise,
-            function rejected(error){
-              assert.equal(error.message,"CLIENT_UNAVAILABLE")
-            });
-      });
-    });
+            function rejected (error) {
+              assert.equal(error.message, 'CLIENT_UNAVAILABLE')
+            })
+      })
+    })
 
     describe('when connector returns incorrect response code', function () {
-      before(function() {
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
         nock(originalHost, {
           reqheaders: {
             'x-request-id': 'blah'
           }
         })
-          .delete("/v1/frontend/tokens/1")
-          .reply(404, '{}');
-      });
+          .delete('/v1/frontend/tokens/1')
+          .reply(404, '{}')
+      })
 
       it('should return delete_failed', function () {
-        var token = Token('blah');
+        var token = Token('blah')
         return token.destroy(1).then(wrongPromise,
-            function rejected(error){
-              assert.equal(error.message,"DELETE_FAILED")
-            });
-      });
-    });
+            function rejected (error) {
+              assert.equal(error.message, 'DELETE_FAILED')
+            })
+      })
+    })
 
     describe('when connector returns correctly', function () {
-      before(function() {
-        nock.cleanAll();
+      before(function () {
+        nock.cleanAll()
         nock(originalHost, {
           reqheaders: {
             'x-request-id': 'unique-request-id'
           }
         })
-          .delete("/v1/frontend/tokens/1")
-          .reply(204);
-      });
+          .delete('/v1/frontend/tokens/1')
+          .reply(204)
+      })
 
       it('should return delete_failed', function () {
-        var token = Token('unique-request-id');
-        return token.destroy(1).then(function(data){
+        var token = Token('unique-request-id')
+        return token.destroy(1).then(function (data) {
           //
-          //assert.equal(data.foo,'bar');
-        },wrongPromise);
-      });
-    });
-  });
-});
-
+          // assert.equal(data.foo,'bar');
+        }, wrongPromise)
+      })
+    })
+  })
+})

--- a/test/nightwatch/pages/demo_service.js
+++ b/test/nightwatch/pages/demo_service.js
@@ -1,31 +1,29 @@
 
 var commands = {
-  generateCharge: function(params) {
-
+  generateCharge: function (params) {
     return this.navigate()
-      .setValue("@tokenInput", params.token)
-      .submitForm("@tokenForm")
-      .assert.title("Set up payment")
-      .setValue("@paymentDescription", params.description)
-      .setValue("@paymentReference", params.reference)
-      .setValue("@paymentAmount", params.amount)
-      .submitForm("@paymentForm")
+      .setValue('@tokenInput', params.token)
+      .submitForm('@tokenForm')
+      .assert.title('Set up payment')
+      .setValue('@paymentDescription', params.description)
+      .setValue('@paymentReference', params.reference)
+      .setValue('@paymentAmount', params.amount)
+      .submitForm('@paymentForm')
       .submitForm('@submitPaymentForm')
-      .assert.title("Enter your card details.");
+      .assert.title('Enter your card details.')
   }
-};
+}
 
 module.exports = {
   url: 'http://localhost:9000',
   elements: {
-    tokenInput: { selector: "#auth-token" },
-    tokenForm: { selector:".payment-summary form" },
-    paymentForm: { selector:'.payment-summary form[action="/pay"]' },
-    paymentDescription: { selector:'.payment-summary form[action="/pay"] input#description' },
-    paymentReference: { selector:'.payment-summary form[action="/pay"] input#reference' },
-    paymentAmount: { selector:'.payment-summary form[action="/pay"] input#amount' },
-    submitPaymentForm: "#submit-payment-form"
+    tokenInput: { selector: '#auth-token' },
+    tokenForm: { selector: '.payment-summary form' },
+    paymentForm: { selector: '.payment-summary form[action="/pay"]' },
+    paymentDescription: { selector: '.payment-summary form[action="/pay"] input#description' },
+    paymentReference: { selector: '.payment-summary form[action="/pay"] input#reference' },
+    paymentAmount: { selector: '.payment-summary form[action="/pay"] input#amount' },
+    submitPaymentForm: '#submit-payment-form'
   },
-  commands: [commands],
-};
-
+  commands: [commands]
+}

--- a/test/nightwatch/pages/payment_new.js
+++ b/test/nightwatch/pages/payment_new.js
@@ -1,38 +1,37 @@
 
 var commands = {
-  EnterValidDetails: function(){
+  EnterValidDetails: function () {
     return this
-      .setValue("@cardNo", "4242424242424242")
-      .setValue("@cardName", "a name")
-      .setValue("@cvc", "123")
-      .setValue("@expiryMonth", "10")
-      .setValue("@expiryYear", "18")
-      .setValue("@addressLine1", "its an address")
-      .setValue("@addressCity", "its a city")
-      .setValue("@addressPostcode", "n4 1bq");
+      .setValue('@cardNo', '4242424242424242')
+      .setValue('@cardName', 'a name')
+      .setValue('@cvc', '123')
+      .setValue('@expiryMonth', '10')
+      .setValue('@expiryYear', '18')
+      .setValue('@addressLine1', 'its an address')
+      .setValue('@addressCity', 'its a city')
+      .setValue('@addressPostcode', 'n4 1bq')
   }
-};
+}
 
 module.exports = {
   url: 'http://localhost:9200',
   elements: {
-   cardName: "#cardholder-name",
-   cardNo: "#card-no",
-   cardNoLabel: "#card-no-lbl span[data-label-replace]",
-   cvc: "#cvc",
-   cvcLabel: ".cvc-label",
-   expiryMonth: "input#expiry-month" ,
-   expiryYear: "input#expiry-year" ,
-   expiryLabel: ".expiry-date-label" ,
-   addressLine1: "#address-line-1",
-   addressCity: "#address-city",
-   addressPostcode: "#address-postcode",
-   addressPostcodeLabel: ".address-postcode-label",
-   "error-summary": "#error-summary",
-   "form": "form#card-details",
-   "visaLabel": ".accepted-cards .visa",
-   "highlightedCardLabel": ".accepted-cards .selected"
+    cardName: '#cardholder-name',
+    cardNo: '#card-no',
+    cardNoLabel: '#card-no-lbl span[data-label-replace]',
+    cvc: '#cvc',
+    cvcLabel: '.cvc-label',
+    expiryMonth: 'input#expiry-month',
+    expiryYear: 'input#expiry-year',
+    expiryLabel: '.expiry-date-label',
+    addressLine1: '#address-line-1',
+    addressCity: '#address-city',
+    addressPostcode: '#address-postcode',
+    addressPostcodeLabel: '.address-postcode-label',
+    'error-summary': '#error-summary',
+    'form': 'form#card-details',
+    'visaLabel': '.accepted-cards .visa',
+    'highlightedCardLabel': '.accepted-cards .selected'
   },
-  commands: [commands],
-};
-
+  commands: [commands]
+}

--- a/test/nightwatch/tests/charge_validation_cvc.js
+++ b/test/nightwatch/tests/charge_validation_cvc.js
@@ -1,22 +1,21 @@
 module.exports = {
   '@tags': ['chargeValidation', 'chargeValidationCvc'],
-  beforeEach: function(browser){
-    var demoService = browser.page.demo_service();
+  beforeEach: function (browser) {
+    var demoService = browser.page.demo_service()
     demoService.navigate().generateCharge({
       token: process.env.demo_token,
-      description: "hello",
+      description: 'hello',
       amount: 1234,
-      reference: "hi"
-    });
+      reference: 'hi'
+    })
   },
-
 
   'label gets replaced on invalid': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
       .setValue('@cvc', '12')
-      .click('@expiryYear');
-    cardDetails.expect.element('@cvcLabel').text.to.contain('Enter a valid card security code').before(300);
-    browser.end();
-  },
-};
+      .click('@expiryYear')
+    cardDetails.expect.element('@cvcLabel').text.to.contain('Enter a valid card security code').before(300)
+    browser.end()
+  }
+}

--- a/test/nightwatch/tests/charge_validation_form_group.js
+++ b/test/nightwatch/tests/charge_validation_form_group.js
@@ -1,42 +1,42 @@
 module.exports = {
   '@tags': ['chargeValidation', 'chargeValidationFormGroup'],
-  beforeEach: function(browser){
-    var demoService = browser.page.demo_service();
+  beforeEach: function (browser) {
+    var demoService = browser.page.demo_service()
     demoService.navigate().generateCharge({
       token: process.env.demo_token,
-      description: "hello",
+      description: 'hello',
       amount: 1234,
-      reference: "hi"
-    });
+      reference: 'hi'
+    })
   },
 
   'Does Not trigger validation when not on last of group': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
-      .setValue('@expiryMonth', ['11',browser.keys.TAB]);
-    cardDetails.expect.element('@expiryLabel').text.to.contain('Expiry Date').before(100);
-    browser.end();
+      .setValue('@expiryMonth', ['11', browser.keys.TAB])
+    cardDetails.expect.element('@expiryLabel').text.to.contain('Expiry Date').before(100)
+    browser.end()
   },
 
   'label gets replaced when validation fails and you tab past the form group': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
-      .setValue('@expiryMonth', ['11',browser.keys.TAB,browser.keys.TAB])
-      .click('@addressLine1');
-    cardDetails.expect.element('@expiryLabel').text.to.contain('Enter a valid expiry date').before(100);
-    browser.end();
+      .setValue('@expiryMonth', ['11', browser.keys.TAB, browser.keys.TAB])
+      .click('@addressLine1')
+    cardDetails.expect.element('@expiryLabel').text.to.contain('Enter a valid expiry date').before(100)
+    browser.end()
   },
 
   'error label gets replaced when in error state and you fix it without leaving the form group': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
       .setValue('@expiryYear', '17')
-      .click('@addressLine1');
-    cardDetails.expect.element('@expiryLabel').text.to.contain('Enter a valid expiry date').before(100);
+      .click('@addressLine1')
+    cardDetails.expect.element('@expiryLabel').text.to.contain('Enter a valid expiry date').before(100)
     cardDetails
-      .setValue('@expiryMonth', ['11',browser.Keys.TAB]);
-    cardDetails.expect.element('@expiryLabel').text.to.contain('Expiry Date').before(100);
-    browser.end();
+      .setValue('@expiryMonth', ['11', browser.Keys.TAB])
+    cardDetails.expect.element('@expiryLabel').text.to.contain('Expiry Date').before(100)
+    browser.end()
   }
 
-};
+}

--- a/test/nightwatch/tests/charge_validation_highlight_card.js
+++ b/test/nightwatch/tests/charge_validation_highlight_card.js
@@ -1,38 +1,37 @@
 module.exports = {
   'tags': ['chargeValidation', 'chargeValidationSelectCard'],
-  beforeEach: function(browser){
-    var demoService = browser.page.demo_service();
+  beforeEach: function (browser) {
+    var demoService = browser.page.demo_service()
     demoService.navigate().generateCharge({
       token: process.env.demo_token,
-      description: "hello",
+      description: 'hello',
       amount: 1234,
-      reference: "hi"
-    });
+      reference: 'hi'
+    })
   },
 
-
   'visa gets selected when that is available': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
-      .setValue('@cardNo', '4');
+      .setValue('@cardNo', '4')
 
     cardDetails.expect.element('@visaLabel')
-      .to.have.attribute('class').which.contains('selected');
-    browser.end();
+      .to.have.attribute('class').which.contains('selected')
+    browser.end()
   },
 
   'visa gets deselected when the number changes': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
-      .setValue('@cardNo', '4');
+      .setValue('@cardNo', '4')
 
     cardDetails.expect.element('@visaLabel')
-      .to.have.attribute('class').which.contains('selected');
+      .to.have.attribute('class').which.contains('selected')
 
-    cardDetails.setValue('@cardNo', [browser.Keys.BACK_SPACE,browser.Keys.BACK_SPACE]);
+    cardDetails.setValue('@cardNo', [browser.Keys.BACK_SPACE, browser.Keys.BACK_SPACE])
 
-    cardDetails.expect.element("@highlightedCardLabel").to.not.be.present;
-    browser.end();
-  },
+    cardDetails.expect.element('@highlightedCardLabel').to.not.be.present // eslint-disable-line 
+    browser.end()
+  }
 
-};
+}

--- a/test/nightwatch/tests/charge_validation_postcode.js
+++ b/test/nightwatch/tests/charge_validation_postcode.js
@@ -1,22 +1,22 @@
 module.exports = {
   '@tags': ['chargeValidation', 'chargeValidationCvc'],
-  beforeEach: function(browser){
-    var demoService = browser.page.demo_service();
+  beforeEach: function (browser) {
+    var demoService = browser.page.demo_service()
     demoService.navigate().generateCharge({
       token: process.env.demo_token,
-      description: "hello",
+      description: 'hello',
       amount: 1234,
-      reference: "hi"
-    });
+      reference: 'hi'
+    })
   },
 
   'label gets replaced on invalid': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
       .setValue('@addressPostcode', 'N4')
-      .click('@expiryYear');
+      .click('@expiryYear')
     cardDetails.expect.element('@addressPostcodeLabel')
-      .text.to.contain('Enter a valid postcode').before(300);
-    browser.end();
-  },
-};
+      .text.to.contain('Enter a valid postcode').before(300)
+    browser.end()
+  }
+}

--- a/test/nightwatch/tests/charge_validations_inline.js
+++ b/test/nightwatch/tests/charge_validations_inline.js
@@ -1,68 +1,67 @@
 module.exports = {
   'tags': ['chargeValidation', 'chargeValidationInline'],
-  beforeEach: function(browser){
-    var demoService = browser.page.demo_service();
+  beforeEach: function (browser) {
+    var demoService = browser.page.demo_service()
     demoService.navigate().generateCharge({
       token: process.env.demo_token,
-      description: "hello",
+      description: 'hello',
       amount: 1234,
-      reference: "hi"
-    });
+      reference: 'hi'
+    })
   },
 
-
   'label gets replaced on invalid': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
       .setValue('@cardNo', '12')
-      .click('@expiryYear');
+      .click('@expiryYear')
 
-    cardDetails.expect.element('@cardNoLabel').text.to.contain('Card number is not the correct length').before(300);
+    cardDetails.expect.element('@cardNoLabel').text.to.contain('Card number is not the correct length').before(300)
 
-    browser.end();
+    browser.end()
   },
 
   'label gets replaced back to valid after invalid': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
       .setValue('@cardNo', '12')
-      .click('@expiryYear');
-    cardDetails.expect.element('@cardNoLabel').text.to.contain('Card number is not the correct length').before(300);
+      .click('@expiryYear')
+    cardDetails.expect.element('@cardNoLabel').text.to.contain('Card number is not the correct length').before(300)
 
     cardDetails
       .setValue('@cardNo', '4242424242424242')
-      .click('@expiryYear');
-    cardDetails.expect.element('@cardNoLabel').text.to.contain('Card number').before(300);
+      .click('@expiryYear')
+    cardDetails.expect.element('@cardNoLabel').text.to.contain('Card number').before(300)
 
-    browser.end();
+    browser.end()
   },
 
   'Label does not get replaced if the focused element is in the same form group': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
       .setValue('@expiryMonth', '13')
-      .click('@expiryYear');
-    cardDetails.expect.element('@expiryLabel').text.to.contain('Expiry Date').before(300);
-    browser.end();
+      .click('@expiryYear')
+    cardDetails.expect.element('@expiryLabel').text.to.contain('Expiry Date').before(300)
+    browser.end()
   },
 
   'Label gets replaced if the focused element is outside the same form group': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
       .setValue('@expiryMonth', '13')
       .setValue('@expiryYear', '13')
-      .click('@cardNo');
-    cardDetails.expect.element('@expiryLabel').text.to.contain('Enter a valid expiry date').before(300);
-    browser.end();
+      .click('@cardNo')
+    cardDetails.expect.element('@expiryLabel').text.to.contain('Enter a valid expiry date').before(300)
+    browser.end()
   },
 
   'card number highlights when you try and enter a name': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
       .clearValue('@cardNo')
-      .setValue('@cardNo', 'Ste');
-    cardDetails.expect.element('@cardNoLabel').text.to.contain('Enter a valid card number').before(300);
-    browser.end();
+      .setValue('@cardNo', 'Ste')
+    cardDetails.expect.element('@cardNoLabel').text.to.contain('Enter a valid card number').before(300)
+    browser.end()
   }
 
-};
+}

--- a/test/nightwatch/tests/charge_validations_submit.js
+++ b/test/nightwatch/tests/charge_validations_submit.js
@@ -1,27 +1,27 @@
 module.exports = {
   '@tags': ['chargeValidation', 'chargeValidationSubmit'],
-  beforeEach: function(browser){
-    var demoService = browser.page.demo_service();
+  beforeEach: function (browser) {
+    var demoService = browser.page.demo_service()
     demoService.navigate().generateCharge({
       token: process.env.demo_token,
-      description: "hello",
+      description: 'hello',
       amount: 1234,
-      reference: "hi"
-    });
+      reference: 'hi'
+    })
   },
   'shows errors and highlightbox and lets submit on correct details': function (browser) {
-    var cardDetails = browser.page.payment_new();
+    var cardDetails = browser.page.payment_new()
     cardDetails
       .setValue('@cardNo', '12')
-      .submitForm('@form');
+      .submitForm('@form')
 
-    cardDetails.expect.element('@cardNoLabel').text.to.contain('Card number is not the correct length');
-    cardDetails.expect.element('@expiryLabel').text.to.contain('Enter a valid expiry date');
-    cardDetails.clearValue("@cardNo");
-    cardDetails.EnterValidDetails();
-    cardDetails.submitForm('@form');
-    browser.assert.title("Confirm your details.");
-    browser.end();
+    cardDetails.expect.element('@cardNoLabel').text.to.contain('Card number is not the correct length')
+    cardDetails.expect.element('@expiryLabel').text.to.contain('Enter a valid expiry date')
+    cardDetails.clearValue('@cardNo')
+    cardDetails.EnterValidDetails()
+    cardDetails.submitForm('@form')
+    browser.assert.title('Confirm your details.')
+    browser.end()
   }
 
-};
+}

--- a/test/propositional_navigation_ui_tests.js
+++ b/test/propositional_navigation_ui_tests.js
@@ -1,9 +1,10 @@
-var renderTemplate = require(__dirname + '/test_helpers/html_assertions.js').render;
+var path = require('path')
+var renderTemplate = require(path.join(__dirname, '/test_helpers/html_assertions.js')).render
 
- describe('The propositional navigation layout include', function() {
-  it('should render the service name', function() {
-    var serviceName = 'Service Name';
-    var body = renderTemplate('includes/propositional_navigation', { gatewayAccount: { 'serviceName': serviceName }});
-    body.should.containSelector('#proposition-menu span').withText(serviceName);
-  });
-});
+describe('The propositional navigation layout include', function () {
+  it('should render the service name', function () {
+    var serviceName = 'Service Name'
+    var body = renderTemplate('includes/propositional_navigation', {gatewayAccount: {'serviceName': serviceName}})
+    body.should.containSelector('#proposition-menu span').withText(serviceName)
+  })
+})

--- a/test/services/charge_param_retriever_test.js
+++ b/test/services/charge_param_retriever_test.js
@@ -1,58 +1,54 @@
-require(__dirname + '/../test_helpers/html_assertions.js');
-var should = require('chai').should();
-var assert = require('assert');
-var chargeParam  = require(__dirname + '/../../app/services/charge_param_retriever.js');
-
-
+var path = require('path')
+require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
+var assert = require('assert')
+var chargeParam = require(path.join(__dirname, '/../../app/services/charge_param_retriever.js'))
 
 describe('charge param retreiver', function () {
-  var EMPTY_RESPONSE = { params: {}, body: {} },
+  var EMPTY_RESPONSE = { params: {}, body: {} }
 
-  NO_SESSION_GET_RESPONSE = {
-    params: { chargeId: "foo" },
+  var NO_SESSION_GET_RESPONSE = {
+    params: { chargeId: 'foo' },
     body: {},
     method: 'GET'
-  },
+  }
 
-  NO_SESSION_POST_RESPONSE = {
+  var NO_SESSION_POST_RESPONSE = {
     params: {},
-    body: { chargeId: "foo" },
+    body: { chargeId: 'foo' },
     method: 'POST'
-  },
+  }
 
-  VALID_GET_RESPONSE = {
-    params: { chargeId: "foo" },
+  var VALID_GET_RESPONSE = {
+    params: { chargeId: 'foo' },
     body: {},
     method: 'GET',
     frontend_state: { ch_foo: true }
-  },
+  }
 
-  VALID_POST_RESPONSE = {
+  var VALID_POST_RESPONSE = {
     params: {},
-    body: { chargeId: "foo" },
+    body: { chargeId: 'foo' },
     method: 'POST',
     frontend_state: { ch_foo: true }
-  };
-
+  }
 
   it('should return false if the charge param is not present in params or body', function () {
-      assert.equal(chargeParam.retrieve(EMPTY_RESPONSE),false);
-  });
+    assert.equal(chargeParam.retrieve(EMPTY_RESPONSE), false)
+  })
 
   it('should return false if the charge param is in params but not in session', function () {
-      assert.equal(chargeParam.retrieve(NO_SESSION_GET_RESPONSE),false);
-  });
+    assert.equal(chargeParam.retrieve(NO_SESSION_GET_RESPONSE), false)
+  })
 
   it('should return false if the charge param is in THE BODY but not in session', function () {
-      assert.equal(chargeParam.retrieve(NO_SESSION_POST_RESPONSE),false);
-  });
+    assert.equal(chargeParam.retrieve(NO_SESSION_POST_RESPONSE), false)
+  })
 
   it('should return THE ID if the charge param is in params and has session', function () {
-      assert.equal(chargeParam.retrieve(VALID_GET_RESPONSE),"foo");
-  });
+    assert.equal(chargeParam.retrieve(VALID_GET_RESPONSE), 'foo')
+  })
 
   it('should return false if the charge param is in THE BODY and has session', function () {
-      assert.equal(chargeParam.retrieve(VALID_POST_RESPONSE),"foo");
-  });
-
-});
+    assert.equal(chargeParam.retrieve(VALID_POST_RESPONSE), 'foo')
+  })
+})

--- a/test/services/mornalise_charge_test.js
+++ b/test/services/mornalise_charge_test.js
@@ -1,11 +1,11 @@
-var expect = require('chai').expect;
-var normalise = require(__dirname + '/../../app/services/normalise_charge.js');
+var path = require('path')
+var expect = require('chai').expect
+var normalise = require(path.join(__dirname, '/../../app/services/normalise_charge.js'))
 
 describe('normalise', function () {
-  it('expiry date should retunr correctly on multiple formats', function () {
-    expect(normalise.expiryDate('1','17')).to.eql('01/17');
-    expect(normalise.expiryDate('01','17')).to.eql('01/17');
-    expect(normalise.expiryDate('01','2017')).to.eql('01/17');
-
-  });
-});
+  it('expiry date should return correctly on multiple formats', function () {
+    expect(normalise.expiryDate('1', '17')).to.eql('01/17')
+    expect(normalise.expiryDate('01', '17')).to.eql('01/17')
+    expect(normalise.expiryDate('01', '2017')).to.eql('01/17')
+  })
+})

--- a/test/services/normalise_cards_test.js
+++ b/test/services/normalise_cards_test.js
@@ -1,18 +1,18 @@
-var expect = require('chai').expect;
-var normalise = require(__dirname + '/../../app/services/normalise_cards.js');
+var path = require('path')
+var expect = require('chai').expect
+var normalise = require(path.join(__dirname, '/../../app/services/normalise_cards.js'))
 var testCards = [{ id: 'b29c58d8-2ab4-4ac7-adbe-f8f46ba1c27c',
-        brand: 'visa',
-        label: 'Visa',
-        type: 'DEBIT' },
-      { id: '11ff6653-adea-460f-9987-1658a05280ce',
-        brand: 'visa',
-        label: 'Visa',
-        type: 'CREDIT' },
-      { id: '0332336e-61df-4108-8f40-51c9789256dd',
-        brand: 'diners-club',
-        label: 'Diners Club',
-        type: 'CREDIT' }];
-
+  brand: 'visa',
+  label: 'Visa',
+  type: 'DEBIT' },
+{ id: '11ff6653-adea-460f-9987-1658a05280ce',
+  brand: 'visa',
+  label: 'Visa',
+  type: 'CREDIT' },
+{ id: '0332336e-61df-4108-8f40-51c9789256dd',
+  brand: 'diners-club',
+  label: 'Diners Club',
+  type: 'CREDIT' }]
 
 describe('normalise cards', function () {
   it('shoudl return the correct format for the model', function () {
@@ -25,7 +25,6 @@ describe('normalise cards', function () {
         debit: false,
         credit: true
       }
-    ]);
-  });
-});
-
+    ])
+  })
+})

--- a/test/services/state_service_test.js
+++ b/test/services/state_service_test.js
@@ -1,45 +1,44 @@
-var expect = require('chai').expect;
-var stateService = require(__dirname + '/../../app/services/state_service.js');
-var State = require(__dirname + '/../../app/models/state.js');
+var path = require('path')
+var expect = require('chai').expect
+var stateService = require(path.join(__dirname, '/../../app/services/state_service.js'))
+var State = require(path.join(__dirname, '/../../app/models/state.js'))
 
 describe('state service', function () {
   describe('resolveStates', function () {
     describe('when states cannot be resolved', function () {
       it('should throw an error', function () {
         expect(function () {
-          stateService.resolveStates('unknown.action.name');
-        }).to.throw(/Cannot find correct states for action/);
+          stateService.resolveStates('unknown.action.name')
+        }).to.throw(/Cannot find correct states for action/)
       })
-    });
+    })
 
     describe('when states can be resolved', function () {
       it('should return the states', function () {
-        expect(stateService.resolveStates('card.new')).to.eql([State.ENTERING_CARD_DETAILS, State.CREATED]);
+        expect(stateService.resolveStates('card.new')).to.eql([State.ENTERING_CARD_DETAILS, State.CREATED])
       })
-    });
-  });
+    })
+  })
 
   describe('resolveActionName', function () {
     describe('when action name cannot be resolved', function () {
       expect(function () {
-        stateService.resolveActionName('unknown.action.name','foo');
-      }).to.throw(/No actionName found for state: unknown.action.name and verb: foo/);
-    });
-  });
-
+        stateService.resolveActionName('unknown.action.name', 'foo')
+      }).to.throw(/No actionName found for state: unknown.action.name and verb: foo/)
+    })
+  })
 
   describe('when action name can be resolved', function () {
-    expect(stateService.resolveActionName(State.AUTH_SUCCESS, 'get')).to.eql('card.confirm');
+    expect(stateService.resolveActionName(State.AUTH_SUCCESS, 'get')).to.eql('card.confirm')
 
-    expect(stateService.resolveActionName(State.AUTH_READY, 'get')).to.eql('card.authWaiting');
-    expect(stateService.resolveActionName(State.AUTH_3DS_REQUIRED, 'get')).to.eql('card.auth3dsRequired');
-    expect(stateService.resolveActionName(State.AUTH_3DS_READY, 'get')).to.eql('card.authWaiting');
+    expect(stateService.resolveActionName(State.AUTH_READY, 'get')).to.eql('card.authWaiting')
+    expect(stateService.resolveActionName(State.AUTH_3DS_REQUIRED, 'get')).to.eql('card.auth3dsRequired')
+    expect(stateService.resolveActionName(State.AUTH_3DS_READY, 'get')).to.eql('card.authWaiting')
 
-    expect(stateService.resolveActionName(State.AUTH_SUCCESS, 'post')).to.eql('card.capture');
-    expect(stateService.resolveActionName(State.CREATED, 'get')).to.eql('card.new');
+    expect(stateService.resolveActionName(State.AUTH_SUCCESS, 'post')).to.eql('card.capture')
+    expect(stateService.resolveActionName(State.CREATED, 'get')).to.eql('card.new')
 
-    expect(stateService.resolveActionName(State.CAPTURE_READY, 'get')).to.eql('card.captureWaiting');
-    expect(stateService.resolveActionName(State.CAPTURE_SUBMITTED, 'get')).to.eql('card.captureWaiting');
-  });
-
-});
+    expect(stateService.resolveActionName(State.CAPTURE_READY, 'get')).to.eql('card.captureWaiting')
+    expect(stateService.resolveActionName(State.CAPTURE_SUBMITTED, 'get')).to.eql('card.captureWaiting')
+  })
+})

--- a/test/test_helpers/html_assertions.js
+++ b/test/test_helpers/html_assertions.js
@@ -1,16 +1,19 @@
-var TemplateEngine = require(__dirname + '/../../lib/template-engine.js');
-var cheerio = require('cheerio');
-var chai = require('chai');
+var path = require('path')
+var TemplateEngine = require(path.join(__dirname, '/../../lib/template-engine.js'))
+var cheerio = require('cheerio')
+var chai = require('chai')
 
-function render(templateName, templateData) {
-  var templates = TemplateEngine._getTemplates([__dirname + '/../../app/views',
-    __dirname + '/../../govuk_modules/govuk_template/views/layouts']);
-  return templates[templateName].render(templateData, templates);
+function render (templateName, templateData) {
+  var templates = TemplateEngine._getTemplates([
+    path.join(__dirname, '/../../app/views'),
+    path.join(__dirname, '/../../govuk_modules/govuk_template/views/layouts')
+  ])
+  return templates[templateName].render(templateData, templates)
 }
 
 module.exports = {
   render: render
-};
+}
 
 chai.use(function (_chai, utils) {
   // See http://chaijs.com/guide/plugins/ and http://chaijs.com/guide/helpers/
@@ -21,25 +24,25 @@ chai.use(function (_chai, utils) {
   // inputFieldId: The input field id of the last containInputField call.
 
   chai.Assertion.addMethod('containSelector', function (selector) {
-    utils.flag(this,"rawHtml", this._obj);
-    var $ = cheerio.load(this._obj);
-    var result = $(selector);
+    utils.flag(this, 'rawHtml', this._obj)
+    var $ = cheerio.load(this._obj)
+    var result = $(selector)
     this.assert(result.length > 0,
         "Expected #{this} to contain '" + selector + "'",
         "Did not expect #{this} to contain '" + selector + "'"
-    );
-    this._obj = result;
-  });
+    )
+    this._obj = result
+  })
 
   chai.Assertion.addMethod('withText', function (msg) {
-    var actual = this._obj.text();
+    var actual = this._obj.text()
     this.assert(actual.indexOf(msg) > -1,
         "Expected #{act} to contain '" + msg + "'.",
         "Did not expect #{act} to contain '" + msg + "'.",
         msg,
         actual
-    );
-  });
+    )
+  })
 
   chai.Assertion.addMethod('withAttribute', function (expectedAttr, expectedValue) {
     this.assert(this._obj.attr(expectedAttr) !== undefined,
@@ -47,40 +50,39 @@ chai.use(function (_chai, utils) {
         "Did not expect #{act} to contain '" + expectedAttr + "'",
         expectedAttr,
         JSON.stringify(this._obj['0'].attribs)
-    );
+    )
 
-    if (arguments.length == 2) {
+    if (arguments.length === 2) {
       this.assert(this._obj.attr(expectedAttr) === expectedValue,
           "Expected #{act} to contain '" + expectedAttr + "' with value '" + expectedValue + "'",
           "Did not expect #{act} to contain '" + expectedAttr + "' with value '" + expectedValue + "'",
           expectedAttr,
           JSON.stringify(this._obj['0'].attribs)
-      );
+      )
     }
-  });
+  })
 
   chai.Assertion.addMethod('withAttributes', function (attributes) {
     for (var attr in attributes) {
       if (attributes.hasOwnProperty(attr)) {
-        this.withAttribute(attr, attributes[attr]);
+        this.withAttribute(attr, attributes[attr])
       }
     }
-  });
+  })
 
-  chai.Assertion.addMethod('containInputField', function(idAndName, type) {
+  chai.Assertion.addMethod('containInputField', function (idAndName, type) {
     this.containSelector('input#' + idAndName).withAttributes({name: idAndName, type: type})
-    utils.flag(this, 'inputFieldId', idAndName);
-  });
+    utils.flag(this, 'inputFieldId', idAndName)
+  })
 
-  chai.Assertion.addMethod('containInputWithIdAndName', function(id, name, type) {
+  chai.Assertion.addMethod('containInputWithIdAndName', function (id, name, type) {
     this.containSelector('input#' + id).withAttributes({name: name, type: type})
-    utils.flag(this, 'inputFieldId', id);
-  });
+    utils.flag(this, 'inputFieldId', id)
+  })
 
-  chai.Assertion.addMethod('withLabel', function(labelId, labelText) {
-    var inputFieldId = utils.flag(this, 'inputFieldId');
-    var subAssertion = new chai.Assertion(utils.flag(this, "rawHtml"));
+  chai.Assertion.addMethod('withLabel', function (labelId, labelText) {
+    var inputFieldId = utils.flag(this, 'inputFieldId')
+    var subAssertion = new chai.Assertion(utils.flag(this, 'rawHtml'))
     subAssertion.containSelector('label#' + labelId).withAttribute('for', inputFieldId)
-  });
-
-});
+  })
+})

--- a/test/test_helpers/mock_templates.js
+++ b/test/test_helpers/mock_templates.js
@@ -1,8 +1,8 @@
-function TemplateEngine() {
+function TemplateEngine () {
 }
 
 TemplateEngine.__express = function (templatePath, templateData, next) {
-   next("", JSON.stringify(templateData));
-};
+  next('', JSON.stringify(templateData))
+}
 
-module.exports = TemplateEngine;
+module.exports = TemplateEngine

--- a/test/test_helpers/session.js
+++ b/test/test_helpers/session.js
@@ -1,39 +1,40 @@
-/*jslint node: true */
-"use strict";
-var clientSessions = require("client-sessions");
-var cookies = require(__dirname + '/../../app/utils/cookies.js');
+'use strict'
 
-function createSessionChargeKey(chargeId) {
-	return 'ch_' + chargeId;
+var path = require('path')
+var clientSessions = require('client-sessions')
+var cookies = require(path.join(__dirname, '/../../app/utils/cookies.js'))
+
+function createSessionChargeKey (chargeId) {
+  return 'ch_' + chargeId
 }
 
-function createReturnUrlKey(chargeId) {
-	return 'return_url_' + chargeId;
+function createReturnUrlKey (chargeId) {
+  return 'return_url_' + chargeId
 }
 
-function createSessionWithReturnUrl(chargeId, chargeSession, returnUrl) {
-	chargeSession = chargeSession || {};
-	chargeSession.csrfSecret = process.env.CSRF_USER_SECRET;
-	var session = {};
-	if (arguments.length > 0) {
-		session[createSessionChargeKey(chargeId)] = chargeSession;
-		session[createReturnUrlKey(chargeId)] = encodeURIComponent(returnUrl);
-	}
+function createSessionWithReturnUrl (chargeId, chargeSession, returnUrl) {
+  chargeSession = chargeSession || {}
+  chargeSession.csrfSecret = process.env.CSRF_USER_SECRET
+  var session = {}
+  if (arguments.length > 0) {
+    session[createSessionChargeKey(chargeId)] = chargeSession
+    session[createReturnUrlKey(chargeId)] = encodeURIComponent(returnUrl)
+  }
 
-	return clientSessions.util.encode(cookies.namedCookie('frontend_state', process.env.SESSION_ENCRYPTION_KEY), session);
+  return clientSessions.util.encode(cookies.namedCookie('frontend_state', process.env.SESSION_ENCRYPTION_KEY), session)
 }
 
 module.exports = {
-	createWithReturnUrl : function (chargeId, chargeSession, returnUrl) {
-		return createSessionWithReturnUrl(chargeId, chargeSession, returnUrl);
-	},
+  createWithReturnUrl: function (chargeId, chargeSession, returnUrl) {
+    return createSessionWithReturnUrl(chargeId, chargeSession, returnUrl)
+  },
 
-	create : function (chargeId, chargeSession) {
-		return createSessionWithReturnUrl(chargeId, chargeSession, undefined);
-	},
+  create: function (chargeId, chargeSession) {
+    return createSessionWithReturnUrl(chargeId, chargeSession, undefined)
+  },
 
-	decrypt: function decryptCookie(res, chargeId) {
-	  var content = clientSessions.util.decode(cookies.namedCookie('frontend_state', process.env.SESSION_ENCRYPTION_KEY), res.headers['set-cookie'][0].split(";")[0].split("=")[1]).content;
-	  return chargeId ? content[createSessionChargeKey(chargeId)] : content;
-	}
-};
+  decrypt: function decryptCookie (res, chargeId) {
+    var content = clientSessions.util.decode(cookies.namedCookie('frontend_state', process.env.SESSION_ENCRYPTION_KEY), res.headers['set-cookie'][0].split(';')[0].split('=')[1]).content
+    return chargeId ? content[createSessionChargeKey(chargeId)] : content
+  }
+}

--- a/test/unit/base_client_test.js
+++ b/test/unit/base_client_test.js
@@ -1,144 +1,142 @@
-const nock = require("nock");
-const chai = require('chai');
-const should = chai.should;
+const nock = require('nock')
+const path = require('path')
 
-const assert = require('assert');
+const assert = require('assert')
 
-var baseClient = require(__dirname + "/../../app/utils/base_client");
+var baseClient = require(path.join(__dirname, '/../../app/utils/base_client'))
 
-const url = "http://www.example.com:65535";
-const arbitraryRequestData = {foo: 'bar'};
-const arbitraryCorrelationId = 123;
-const arbitraryResponseData = {response: 'I am a response'};
+const url = 'http://www.example.com:65535'
+const arbitraryRequestData = {foo: 'bar'}
+const arbitraryCorrelationId = 123
+const arbitraryResponseData = {response: 'I am a response'}
 
+describe('base client', () => {
+  beforeEach(function () {
+    nock.cleanAll()
+  })
 
-describe("base client", () => {
-  beforeEach(function() {
-    nock.cleanAll();
-  });
+  afterEach(function () {
+    nock.cleanAll()
+  })
 
-  afterEach(function() {
-    nock.cleanAll();
-  });
-
-  it("should post data correctly", (done) => {
+  it('should post data correctly', (done) => {
     nock(url)
       .post('/', arbitraryRequestData)
-      .reply(200);
+      .reply(200)
 
     // literally just making sure data is passed to mocked service correctly
-    baseClient.post(url, {data: arbitraryRequestData, correlationId: arbitraryCorrelationId}, done);
-  });
+    baseClient.post(url, {data: arbitraryRequestData, correlationId: arbitraryCorrelationId}, done)
+  })
 
-  it("should put data correctly", (done) => {
+  it('should put data correctly', (done) => {
     nock(url)
       .put('/', arbitraryRequestData)
-      .reply(200);
+      .reply(200)
 
-    baseClient.put(url, {data: arbitraryRequestData, correlationId: arbitraryCorrelationId}, done);
-  });
+    baseClient.put(url, {data: arbitraryRequestData, correlationId: arbitraryCorrelationId}, done)
+  })
 
-  it("should patch data correctly", (done) => {
+  it('should patch data correctly', (done) => {
     nock(url)
       .patch('/', arbitraryRequestData)
-      .reply(200);
+      .reply(200)
 
-    baseClient.patch(url, {data: arbitraryRequestData, correlationId: arbitraryCorrelationId}, done);
-  });
+    baseClient.patch(url, {data: arbitraryRequestData, correlationId: arbitraryCorrelationId}, done)
+  })
 
-  it("should get correctly", (done) => {
+  it('should get correctly', (done) => {
     nock(url)
       .get('/')
-      .reply(200, arbitraryResponseData);
+      .reply(200, arbitraryResponseData)
 
     baseClient.get(url, {correlationId: arbitraryCorrelationId}, (data) => {
-      assert.equal(data.response, 'I am a response');
-      done();
-    });
-  });
+      assert.equal(data.response, 'I am a response')
+      done()
+    })
+  })
 
-  it("should pass status code correctly to callback", (done) => {
+  it('should pass status code correctly to callback', (done) => {
     nock(url)
       .get('/')
-      .reply(201, '{}');
+      .reply(201, '{}')
 
     baseClient.get(url, {correlationId: arbitraryCorrelationId}, (data, res) => {
-      assert.equal(res.statusCode, 201);
-      done();
-    });
-  });
+      assert.equal(res.statusCode, 201)
+      done()
+    })
+  })
 
   it('should pass response data to callback', (done) => {
     nock(url)
       .post('/', arbitraryRequestData)
-      .reply(200, arbitraryResponseData);
+      .reply(200, arbitraryResponseData)
 
     baseClient.post(url, {data: arbitraryRequestData, correlationId: '123'}, (data) => {
-      assert.equal(data.response, "I am a response");
-      done();
-    });
-  });
+      assert.equal(data.response, 'I am a response')
+      done()
+    })
+  })
 
   it('should call callback with null when there is no data', (done) => {
     nock(url)
       .post('/', arbitraryRequestData)
-      .reply(200);
+      .reply(200)
 
     baseClient.post(url, {data: arbitraryRequestData, correlationId: '123'}, (data) => {
-      assert.equal(data, null);
-      done();
-    });
-  });
+      assert.equal(data, null)
+      done()
+    })
+  })
 
-  it("should handle non JSON response gracefully", (done) => {
+  it('should handle non JSON response gracefully', (done) => {
     nock(url)
       .get('/')
-      .reply(200, '<html></html>');
+      .reply(200, '<html></html>')
 
     baseClient.get(url, {correlationId: 'reee'}, (data) => {
-      assert.equal(data, null);
-      done();
+      assert.equal(data, null)
+      done()
     })
-  });
+  })
 
-  it("should always make keep-alive connections", (done) => {
+  it('should always make keep-alive connections', (done) => {
     nock(url)
       .get('/')
-      .reply('{}');
+      .reply('{}')
 
-    let req = baseClient.get(url, {correlationId: 'reee'}, done);
+    let req = baseClient.get(url, {correlationId: 'reee'}, done)
 
-    assert.equal(req.shouldKeepAlive, true);
-  });
+    assert.equal(req.shouldKeepAlive, true)
+  })
 
-  it("should set x-request-id header correctly", (done) => {
+  it('should set x-request-id header correctly', (done) => {
     nock(url)
       .get('/')
-      .reply('{}');
+      .reply('{}')
 
-    let req = baseClient.get(url, {correlationId: 'reee'}, done);
+    let req = baseClient.get(url, {correlationId: 'reee'}, done)
 
-    assert.equal(req.headers['x-request-id'], 'reee');
-  });
+    assert.equal(req.headers['x-request-id'], 'reee')
+  })
 
-  it("should always set request content-type header to application/json", (done) => {
+  it('should always set request content-type header to application/json', (done) => {
     nock(url)
       .get('/')
-      .reply('{}');
+      .reply('{}')
 
-    let req = baseClient.get(url, {}, done);
+    let req = baseClient.get(url, {}, done)
 
-    assert.equal(req.headers['content-type'], 'application/json');
-  });
+    assert.equal(req.headers['content-type'], 'application/json')
+  })
 
-  it("should ignore response content-type header and assume JSON", (done) => {
+  it('should ignore response content-type header and assume JSON', (done) => {
     nock(url)
       .get('/')
-      .reply(200, arbitraryResponseData, {'content-type': 'text/html'});
+      .reply(200, arbitraryResponseData, {'content-type': 'text/html'})
 
     baseClient.get(url, {correlationId: arbitraryCorrelationId}, (data) => {
-      assert.equal(data.response, 'I am a response');
-      done();
-    });
-  });
-});
+      assert.equal(data.response, 'I am a response')
+      done()
+    })
+  })
+})

--- a/test/unit/cookies_test.js
+++ b/test/unit/cookies_test.js
@@ -1,63 +1,61 @@
-var should = require('chai').should();
-var expect = require('chai').expect;
-var assert = require('assert');
-var sinon = require('sinon');
-var proxyquire = require('proxyquire');
-
+var expect = require('chai').expect
+var path = require('path')
+var sinon = require('sinon')
+var proxyquire = require('proxyquire')
 
 var getCookiesUtil = function (clientSessionsStub) {
   if (clientSessionsStub) {
-    return proxyquire(__dirname + '/../../app/utils/cookies', {
+    return proxyquire(path.join(__dirname, '/../../app/utils/cookies'), {
       'client-sessions': clientSessionsStub
-    });
+    })
   } else {
-    return require(__dirname + '/../../app/utils/cookies');
+    return require(path.join(__dirname, '/../../app/utils/cookies'))
   }
-};
+}
 
 describe('cookie configuration', function () {
-  it('should configure cookie correctly', function(){
+  it('should configure cookie correctly', function () {
     let app = {
       use: sinon.stub()
-    };
-    let clientSessionsStub = sinon.stub();
-    let cookies = getCookiesUtil(clientSessionsStub);
+    }
+    let clientSessionsStub = sinon.stub()
+    let cookies = getCookiesUtil(clientSessionsStub)
 
     let expectedConfig = {
       cookieName: 'frontend_state',
       proxy: true,
-      secret: "naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk",
+      secret: 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk',
       cookie: {
         maxAge: 5400000,
         httpOnly: true,
         secureProxy: true
       }
-    };
+    }
 
-    cookies.configureSessionCookie(app);
+    cookies.configureSessionCookie(app)
 
-    expect(clientSessionsStub.calledWith(expectedConfig)).to.equal(true);
-  });
+    expect(clientSessionsStub.calledWith(expectedConfig)).to.equal(true)
+  })
 
-  it('should configure two cookies if two session keys are set', function() {
-    let key2 = 'bobbobbobbob';
-    process.env.SESSION_ENCRYPTION_KEY_2 = key2;
+  it('should configure two cookies if two session keys are set', function () {
+    let key2 = 'bobbobbobbob'
+    process.env.SESSION_ENCRYPTION_KEY_2 = key2
     let app = {
       use: sinon.spy()
-    };
-    let clientSessionsStub = sinon.stub();
-    let cookies = getCookiesUtil(clientSessionsStub);
+    }
+    let clientSessionsStub = sinon.stub()
+    let cookies = getCookiesUtil(clientSessionsStub)
 
     let expectedConfig1 = {
       cookieName: 'frontend_state',
       proxy: true,
-      secret: "naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk",
+      secret: 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk',
       cookie: {
         maxAge: 5400000,
         httpOnly: true,
         secureProxy: true
       }
-    };
+    }
 
     let expectedConfig2 = {
       cookieName: 'frontend_state_2',
@@ -68,175 +66,170 @@ describe('cookie configuration', function () {
         httpOnly: true,
         secureProxy: true
       }
-    };
+    }
 
-    cookies.configureSessionCookie(app);
+    cookies.configureSessionCookie(app)
 
-    expect(clientSessionsStub.calledWith(expectedConfig1)).to.equal(true);
-    expect(clientSessionsStub.calledWith(expectedConfig2)).to.equal(true);
-    expect(clientSessionsStub.callCount).to.equal(2);
+    expect(clientSessionsStub.calledWith(expectedConfig1)).to.equal(true)
+    expect(clientSessionsStub.calledWith(expectedConfig2)).to.equal(true)
+    expect(clientSessionsStub.callCount).to.equal(2)
 
-    delete process.env.SESSION_ENCRYPTION_KEY_2;
-  });
+    delete process.env.SESSION_ENCRYPTION_KEY_2
+  })
 
-  it('should configure two cookies if two session keys are set', function() {
-    process.env.SESSION_ENCRYPTION_KEY_2 = '';
+  it('should configure two cookies if two session keys are set', function () {
+    process.env.SESSION_ENCRYPTION_KEY_2 = ''
     let app = {
       use: sinon.spy()
-    };
-    let clientSessionsStub = sinon.stub();
-    let cookies = getCookiesUtil(clientSessionsStub);
+    }
+    let clientSessionsStub = sinon.stub()
+    let cookies = getCookiesUtil(clientSessionsStub)
 
     let expectedConfig1 = {
       cookieName: 'frontend_state',
       proxy: true,
-      secret: "naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk",
+      secret: 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk',
       cookie: {
         maxAge: 5400000,
         httpOnly: true,
         secureProxy: true
       }
-    };
+    }
 
-    cookies.configureSessionCookie(app);
+    cookies.configureSessionCookie(app)
 
-    expect(clientSessionsStub.calledWith(expectedConfig1)).to.equal(true);
-    expect(clientSessionsStub.callCount).to.equal(1);
+    expect(clientSessionsStub.calledWith(expectedConfig1)).to.equal(true)
+    expect(clientSessionsStub.callCount).to.equal(1)
 
-    delete process.env.SESSION_ENCRYPTION_KEY_2;
-  });
+    delete process.env.SESSION_ENCRYPTION_KEY_2
+  })
 
-  it('should throw an error if no session keys are set', function() {
-    let originalKey = process.env.SESSION_ENCRYPTION_KEY;
-    delete process.env.SESSION_ENCRYPTION_KEY_2;
-    process.env.SESSION_ENCRYPTION_KEY = '';
+  it('should throw an error if no session keys are set', function () {
+    let originalKey = process.env.SESSION_ENCRYPTION_KEY
+    delete process.env.SESSION_ENCRYPTION_KEY_2
+    process.env.SESSION_ENCRYPTION_KEY = ''
 
-    let clientSessionsStub = sinon.stub();
-    let cookies = getCookiesUtil(clientSessionsStub);
+    let clientSessionsStub = sinon.stub()
+    let cookies = getCookiesUtil(clientSessionsStub)
 
-    expect(() => cookies.configureSessionCookie({})).to.throw(/cookie encryption key is not set/);
+    expect(() => cookies.configureSessionCookie({})).to.throw(/cookie encryption key is not set/)
 
-    process.env.SESSION_ENCRYPTION_KEY = originalKey;
-  });
+    process.env.SESSION_ENCRYPTION_KEY = originalKey
+  })
 
-  it('should throw an error if no valid session keys are set', function() {
-    let originalKey = process.env.SESSION_ENCRYPTION_KEY;
-    process.env.SESSION_ENCRYPTION_KEY_2 = 'asfdwv';
-    process.env.SESSION_ENCRYPTION_KEY = '';
+  it('should throw an error if no valid session keys are set', function () {
+    let originalKey = process.env.SESSION_ENCRYPTION_KEY
+    process.env.SESSION_ENCRYPTION_KEY_2 = 'asfdwv'
+    process.env.SESSION_ENCRYPTION_KEY = ''
 
-    let clientSessionsStub = sinon.stub();
-    let cookies = getCookiesUtil(clientSessionsStub);
+    let clientSessionsStub = sinon.stub()
+    let cookies = getCookiesUtil(clientSessionsStub)
 
-    expect(() => cookies.configureSessionCookie({})).to.throw(/cookie encryption key is not set/);
+    expect(() => cookies.configureSessionCookie({})).to.throw(/cookie encryption key is not set/)
 
-    process.env.SESSION_ENCRYPTION_KEY = originalKey;
-    delete process.env.SESSION_ENCRYPTION_KEY_2;
-  });
-});
+    process.env.SESSION_ENCRYPTION_KEY = originalKey
+    delete process.env.SESSION_ENCRYPTION_KEY_2
+  })
+})
 
-describe('setting value on session', function() {
-  it('should set value on frontend_state if SESSION_ENCRYPTION_KEY set', function() {
-    let cookies = getCookiesUtil();
+describe('setting value on session', function () {
+  it('should set value on frontend_state if SESSION_ENCRYPTION_KEY set', function () {
+    let cookies = getCookiesUtil()
     let req = {
       frontend_state: {
 
       }
-    };
+    }
 
-    cookies.setSessionVariable(req, 'foo', 'bar');
+    cookies.setSessionVariable(req, 'foo', 'bar')
 
-    expect(req.frontend_state.foo).to.equal('bar');
-  });
+    expect(req.frontend_state.foo).to.equal('bar')
+  })
 
-  it('should set value on frontend_state_2 if SESSION_ENCRYPTION_KEY_2 set', function() {
-    let originalKey = process.env.SESSION_ENCRYPTION_KEY;
-    process.env.SESSION_ENCRYPTION_KEY = '';
+  it('should set value on frontend_state_2 if SESSION_ENCRYPTION_KEY_2 set', function () {
+    let originalKey = process.env.SESSION_ENCRYPTION_KEY
+    process.env.SESSION_ENCRYPTION_KEY = ''
 
-    process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2';
+    process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2'
 
-
-    let cookies = getCookiesUtil();
+    let cookies = getCookiesUtil()
     let req = {
       frontend_state_2: {
 
       }
-    };
+    }
 
-    cookies.setSessionVariable(req, 'foo', 'baz');
+    cookies.setSessionVariable(req, 'foo', 'baz')
 
-    expect(req.frontend_state_2.foo).to.equal('baz');
+    expect(req.frontend_state_2.foo).to.equal('baz')
 
-    process.env.SESSION_ENCRYPTION_KEY = originalKey;
+    process.env.SESSION_ENCRYPTION_KEY = originalKey
 
-    delete process.env.SESSION_ENCRYPTION_KEY_2;
-  });
+    delete process.env.SESSION_ENCRYPTION_KEY_2
+  })
 
+  it('should set values on frontend_state and frontend_state_2 if both keys set', function () {
+    process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2'
 
-  it('should set values on frontend_state and frontend_state_2 if both keys set', function() {
-    process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2';
-
-
-    let cookies = getCookiesUtil();
+    let cookies = getCookiesUtil()
     let req = {
       frontend_state: {},
       frontend_state_2: {}
-    };
+    }
 
-    cookies.setSessionVariable(req, 'foo', 'baz');
+    cookies.setSessionVariable(req, 'foo', 'baz')
 
-    expect(req.frontend_state.foo).to.equal('baz');
-    expect(req.frontend_state_2.foo).to.equal('baz');
+    expect(req.frontend_state.foo).to.equal('baz')
+    expect(req.frontend_state_2.foo).to.equal('baz')
 
-    delete process.env.SESSION_ENCRYPTION_KEY_2;
-
-  });
-
-  it('does not try to set value on non-existent cookie', function() {
-    let cookies = getCookiesUtil();
-    let req = {};
-
-    cookies.setSessionVariable(req, 'foo', 'bar');
-
-    expect(req).to.deep.equal({});
+    delete process.env.SESSION_ENCRYPTION_KEY_2
   })
-});
 
-describe('getting value from session', function() {
-  it('should get value on frontend_state if only SESSION_ENCRYPTION_KEY set', function() {
-    let cookies = getCookiesUtil();
+  it('does not try to set value on non-existent cookie', function () {
+    let cookies = getCookiesUtil()
+    let req = {}
+
+    cookies.setSessionVariable(req, 'foo', 'bar')
+
+    expect(req).to.deep.equal({})
+  })
+})
+
+describe('getting value from session', function () {
+  it('should get value on frontend_state if only SESSION_ENCRYPTION_KEY set', function () {
+    let cookies = getCookiesUtil()
     let req = {
       frontend_state: {
         foo: 'bar'
       }
-    };
+    }
 
-    expect(cookies.getSessionVariable(req, 'foo')).to.equal('bar');
-  });
+    expect(cookies.getSessionVariable(req, 'foo')).to.equal('bar')
+  })
 
-  it('should get value on frontend_state_2 if only SESSION_ENCRYPTION_KEY_2 set', function() {
-    let originalKey = process.env.SESSION_ENCRYPTION_KEY;
-    delete process.env.SESSION_ENCRYPTION_KEY;
+  it('should get value on frontend_state_2 if only SESSION_ENCRYPTION_KEY_2 set', function () {
+    let originalKey = process.env.SESSION_ENCRYPTION_KEY
+    delete process.env.SESSION_ENCRYPTION_KEY
 
-    process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2';
+    process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2'
 
-    let cookies = getCookiesUtil();
+    let cookies = getCookiesUtil()
     let req = {
       frontend_state_2: {
         foo: 'baz'
       }
-    };
+    }
 
-    expect(cookies.getSessionVariable(req, 'foo')).to.equal('baz');
+    expect(cookies.getSessionVariable(req, 'foo')).to.equal('baz')
 
-    process.env.SESSION_ENCRYPTION_KEY = originalKey;
-    delete process.env.SESSION_ENCRYPTION_KEY_2;
+    process.env.SESSION_ENCRYPTION_KEY = originalKey
+    delete process.env.SESSION_ENCRYPTION_KEY_2
+  })
 
-  });
+  it('should get value from frontend_state if both keys set', function () {
+    process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2key'
 
-  it('should get value from frontend_state if both keys set', function() {
-    process.env.SESSION_ENCRYPTION_KEY_2 = 'key2key2key2key2key';
-
-    let cookies = getCookiesUtil();
+    let cookies = getCookiesUtil()
     let req = {
       frontend_state: {
         foo: 'bar'
@@ -244,10 +237,10 @@ describe('getting value from session', function() {
       frontend_state_2: {
         foo: 'baz'
       }
-    };
+    }
 
-    expect(cookies.getSessionVariable(req, 'foo')).to.equal('bar');
+    expect(cookies.getSessionVariable(req, 'foo')).to.equal('bar')
 
-    delete process.env.SESSION_ENCRYPTION_KEY_2;
-  });
-});
+    delete process.env.SESSION_ENCRYPTION_KEY_2
+  })
+})

--- a/test/unit/custom_certificate_tests.js
+++ b/test/unit/custom_certificate_tests.js
@@ -1,18 +1,18 @@
-var should = require('chai').should();
-var assert = require('assert');
-var customCertificate  = require(__dirname + '/../../app/utils/custom_certificate.js');
+var path = require('path')
+var assert = require('assert')
+var customCertificate = require(path.join(__dirname, '/../../app/utils/custom_certificate.js'))
 
 describe('custom certificate', function () {
-  beforeEach(function(){
-    process.env.CERTS_PATH = __dirname + '/../test_helpers/certs';
-  });
+  beforeEach(function () {
+    process.env.CERTS_PATH = path.join(__dirname, '/../test_helpers/certs')
+  })
 
-  afterEach(function(){
-    process.env.CERTS_PATH = undefined;
-  });
-  
-  it('should set secure options', function(){
-    let ca = customCertificate.getCertOptions();
-    assert.equal(1, ca.length);
-  });
-});
+  afterEach(function () {
+    process.env.CERTS_PATH = undefined
+  })
+
+  it('should set secure options', function () {
+    let ca = customCertificate.getCertOptions()
+    assert.equal(1, ca.length)
+  })
+})

--- a/test/unit/server_config_tests.js
+++ b/test/unit/server_config_tests.js
@@ -1,20 +1,18 @@
-'use strict';
+'use strict'
 
-const request = require('supertest');
-const {expect} = require('chai');
+const request = require('supertest')
+const {expect} = require('chai')
 
-const app = require('../../server').getApp;
+const app = require('../../server').getApp
 
 describe('server config:', () => {
-
   it(`should not return the 'x-powered-by' header by default`, done => {
     request(app)
       .get('/')
       .end((err, res) => {
-        expect(err).to.equal(null);
-        expect(res.headers['x-powered-by']).to.equal(undefined);
-        done();
-      });
-  });
-
-});
+        expect(err).to.equal(null)
+        expect(res.headers['x-powered-by']).to.equal(undefined)
+        done()
+      })
+  })
+})

--- a/test/unit/validation_tests.js
+++ b/test/unit/validation_tests.js
@@ -1,26 +1,27 @@
-var randomString = require('randomstring');
-var validationLib = require(__dirname + '/../../app/utils/charge_validation_fields');
-var cardFactory = require(__dirname + '/../../app/models/card.js');
-var card = cardFactory();
-var fieldValidators = validationLib(card).fieldValidations;
+var randomString = require('randomstring')
+var path = require('path')
+var validationLib = require(path.join(__dirname, '/../../app/utils/charge_validation_fields'))
+var cardFactory = require(path.join(__dirname, '/../../app/models/card.js'))
+var card = cardFactory()
+var fieldValidators = validationLib(card).fieldValidations
 
-var chai = require('chai');
-var expect = chai.expect;
+var chai = require('chai')
+var expect = chai.expect
 
 describe('form validations', function () {
-  it('should allow a correctly formatted email', function(){
-    expect(fieldValidators.email("bob@bobbington.cbobbjb")).to.equal(true);
-    expect(fieldValidators.email("b@bobbington.cbobbjb.dwf")).to.equal(true);
-    expect(fieldValidators.email("customer/department=shipping@example.com")).to.equal(true);
-  });
+  it('should allow a correctly formatted email', function () {
+    expect(fieldValidators.email('bob@bobbington.cbobbjb')).to.equal(true)
+    expect(fieldValidators.email('b@bobbington.cbobbjb.dwf')).to.equal(true)
+    expect(fieldValidators.email('customer/department=shipping@example.com')).to.equal(true)
+  })
 
-  it('should deny an incorrectly formatted email', function(){
-    expect(fieldValidators.email("bob@bob")).to.equal("message");
-    expect(fieldValidators.email("@bobbington.cbobbjb.dwf")).to.equal("message");
-    expect(fieldValidators.email(123)).to.equal("message");
-  });
+  it('should deny an incorrectly formatted email', function () {
+    expect(fieldValidators.email('bob@bob')).to.equal('message')
+    expect(fieldValidators.email('@bobbington.cbobbjb.dwf')).to.equal('message')
+    expect(fieldValidators.email(123)).to.equal('message')
+  })
 
-  it('should deny a correctly formated email with the incorrect length', function(){
-    expect(fieldValidators.email(randomString.generate(255)+"@bobbington.cbobbjb")).to.equal("invalid_length");
-  });
-});
+  it('should deny a correctly formated email with the incorrect length', function () {
+    expect(fieldValidators.email(randomString.generate(255) + '@bobbington.cbobbjb')).to.equal('invalid_length')
+  })
+})

--- a/test/utils/charge_validation_fields/address_field_validation.js
+++ b/test/utils/charge_validation_fields/address_field_validation.js
@@ -1,118 +1,103 @@
-'use strict';
+'use strict'
 
-var assert = require('assert');
-var expect = require('chai').expect;
-var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes();
-var Card  = require('../../../app/models/card.js')(cardTypes);
-var fields= require('../../../app/utils/charge_validation_fields.js')(Card);
+var expect = require('chai').expect
+var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes()
+var Card = require('../../../app/models/card.js')(cardTypes)
+var fields = require('../../../app/utils/charge_validation_fields.js')(Card)
 
-let result;
+let result
 
 describe('card validation: address', () => {
-
   describe('addressLine1', function () {
     describe('should validate if does not contain 12 digits', () => {
-
       it('and it contains only text', () => {
-        result = fields.fieldValidations.addressLine1('Spooner Street');
-        expect(result).to.equal(true);
-      });
+        result = fields.fieldValidations.addressLine1('Spooner Street')
+        expect(result).to.equal(true)
+      })
 
       it('and it contains 11 digits', () => {
-        result = fields.fieldValidations.addressLine1('Spooner Street 01234567890');
-        expect(result).to.equal(true);
-      });
-
-
-    });
+        result = fields.fieldValidations.addressLine1('Spooner Street 01234567890')
+        expect(result).to.equal(true)
+      })
+    })
 
     describe('should not validate if it contains 12 or more digits', () => {
       it('and it contains only digits', () => {
-        result = fields.fieldValidations.addressLine1('012345678901');
-        expect(result).to.equal('contains_too_many_digits');
-      });
+        result = fields.fieldValidations.addressLine1('012345678901')
+        expect(result).to.equal('contains_too_many_digits')
+      })
 
       it('and it contains both digits and text and the digits are consecutive', () => {
-        result = fields.fieldValidations.addressLine1('Spooner Street 012345678901');
-        expect(result).to.equal('contains_too_many_digits');
-      });
+        result = fields.fieldValidations.addressLine1('Spooner Street 012345678901')
+        expect(result).to.equal('contains_too_many_digits')
+      })
 
       it('and it contains both digits and text and the digits are not consecutive', () => {
-        result = fields.fieldValidations.addressLine2('Spoo-012345-ner-678901-Street');
-        expect(result).to.equal('contains_too_many_digits');
-      });
-    });
-
-  });
+        result = fields.fieldValidations.addressLine2('Spoo-012345-ner-678901-Street')
+        expect(result).to.equal('contains_too_many_digits')
+      })
+    })
+  })
 
   describe('addressLine2', function () {
     describe('should validate if does not contain 12 digits', () => {
-
       it('and it contains only text', () => {
-        result = fields.fieldValidations.addressLine2('Spooner Street');
-        expect(result).to.equal(true);
-      });
+        result = fields.fieldValidations.addressLine2('Spooner Street')
+        expect(result).to.equal(true)
+      })
 
       it('and it contains 11 digits', () => {
-        result = fields.fieldValidations.addressLine2('Spooner Street 01234567890');
-        expect(result).to.equal(true);
-      });
-
-
-    });
+        result = fields.fieldValidations.addressLine2('Spooner Street 01234567890')
+        expect(result).to.equal(true)
+      })
+    })
 
     describe('should not validate if it contains 12 or more digits', () => {
       it('and it contains only digits', () => {
-        result = fields.fieldValidations.addressLine2('012345678901');
-        expect(result).to.equal('contains_too_many_digits');
-      });
+        result = fields.fieldValidations.addressLine2('012345678901')
+        expect(result).to.equal('contains_too_many_digits')
+      })
 
       it('and it contains both digits and text and the digits are consecutive', () => {
-        result = fields.fieldValidations.addressLine2('Spooner Street 0123456789012');
-        expect(result).to.equal('contains_too_many_digits');
-      });
+        result = fields.fieldValidations.addressLine2('Spooner Street 0123456789012')
+        expect(result).to.equal('contains_too_many_digits')
+      })
 
       it('and it contains both digits and text and the digits are not consecutive', () => {
-        result = fields.fieldValidations.addressLine2('Spoo-012345-ner-678901-Street');
-        expect(result).to.equal('contains_too_many_digits');
-      });
-    });
-
-  });
+        result = fields.fieldValidations.addressLine2('Spoo-012345-ner-678901-Street')
+        expect(result).to.equal('contains_too_many_digits')
+      })
+    })
+  })
 
   describe('addressCity', function () {
     describe('should validate if does not contain 12 digits', () => {
-
       it('and it contains only text', () => {
-        result = fields.fieldValidations.addressCity('Mr Quahog');
-        expect(result).to.equal(true);
-      });
+        result = fields.fieldValidations.addressCity('Mr Quahog')
+        expect(result).to.equal(true)
+      })
 
       it('and it contains 11 digits', () => {
-        result = fields.fieldValidations.addressCity('Mr Quahog 01234567890');
-        expect(result).to.equal(true);
-      });
-
-
-    });
+        result = fields.fieldValidations.addressCity('Mr Quahog 01234567890')
+        expect(result).to.equal(true)
+      })
+    })
 
     describe('should not validate if it contains 12 or more digits', () => {
       it('and it contains only digits', () => {
-        result = fields.fieldValidations.addressCity('012345678901');
-        expect(result).to.equal('contains_too_many_digits');
-      });
+        result = fields.fieldValidations.addressCity('012345678901')
+        expect(result).to.equal('contains_too_many_digits')
+      })
 
       it('and it contains both digits and text and the digits are consecutive', () => {
-        result = fields.fieldValidations.addressCity('Quahog 012345678901');
-        expect(result).to.equal('contains_too_many_digits');
-      });
+        result = fields.fieldValidations.addressCity('Quahog 012345678901')
+        expect(result).to.equal('contains_too_many_digits')
+      })
 
       it('and it contains both digits and text and the digits are not consecutive', () => {
-        result = fields.fieldValidations.addressCity('Qua-012345-h-678901-og');
-        expect(result).to.equal('contains_too_many_digits');
-      });
-    });
-
-  });
-
-});
+        result = fields.fieldValidations.addressCity('Qua-012345-h-678901-og')
+        expect(result).to.equal('contains_too_many_digits')
+      })
+    })
+  })
+})

--- a/test/utils/charge_validation_fields/card_number_field_validation_test.js
+++ b/test/utils/charge_validation_fields/card_number_field_validation_test.js
@@ -1,43 +1,37 @@
-var should = require('chai').should();
-var assert = require('assert');
-var expect = require('chai').expect;
-var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes();
-var Card  = require('../../../app/models/card.js')(cardTypes);
-var fields= require('../../../app/utils/charge_validation_fields.js')(Card);
-
+var expect = require('chai').expect
+var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes()
+var Card = require('../../../app/models/card.js')(cardTypes)
+var fields = require('../../../app/utils/charge_validation_fields.js')(Card)
 
 describe('card validation: card number', function () {
-
   it('should return true when the card is correct', function () {
-    var result = fields.fieldValidations.cardNo("4242424242424242");
-    expect(result).to.equal(true);
-  });
+    var result = fields.fieldValidations.cardNo('4242424242424242')
+    expect(result).to.equal(true)
+  })
 
   it('should strip non numbers', function () {
-    var result = fields.fieldValidations.cardNo("42424242424242dsakljl42");
-    expect(result).to.equal(true);
-  });
+    var result = fields.fieldValidations.cardNo('42424242424242dsakljl42')
+    expect(result).to.equal(true)
+  })
 
   it('should return incorrect length', function () {
-    var short = fields.fieldValidations.cardNo("4242");
-    var correct = fields.fieldValidations.cardNo("4917610000000000003");
+    var short = fields.fieldValidations.cardNo('4242')
+    var correct = fields.fieldValidations.cardNo('4917610000000000003')
 
-    var long = fields.fieldValidations.cardNo("42424242424242424242");
+    var long = fields.fieldValidations.cardNo('42424242424242424242')
 
-    expect(short).to.equal("number_incorrect_length");
-    expect(correct).to.equal(true);
-    expect(long).to.equal("number_incorrect_length");
-
-  });
+    expect(short).to.equal('number_incorrect_length')
+    expect(correct).to.equal(true)
+    expect(long).to.equal('number_incorrect_length')
+  })
 
   it('should return luhn invalid', function () {
-    var result = fields.fieldValidations.cardNo("4242424242424241");
-    expect(result).to.equal("luhn_invalid");
-  });
+    var result = fields.fieldValidations.cardNo('4242424242424241')
+    expect(result).to.equal('luhn_invalid')
+  })
 
   it('should return card_not_supported if the card is not supported', function () {
-    var result = fields.fieldValidations.cardNo("6759649826438453");
-    expect(result).to.equal("card_not_supported");
-  });
-
-});
+    var result = fields.fieldValidations.cardNo('6759649826438453')
+    expect(result).to.equal('card_not_supported')
+  })
+})

--- a/test/utils/charge_validation_fields/cardholder_name_field_validation_test.js
+++ b/test/utils/charge_validation_fields/cardholder_name_field_validation_test.js
@@ -1,91 +1,85 @@
-'use strict';
+'use strict'
 
-var assert = require('assert');
-var expect = require('chai').expect;
-var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes();
-var Card  = require('../../../app/models/card.js')(cardTypes);
-var fields= require('../../../app/utils/charge_validation_fields.js')(Card);
+var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes()
+var Card = require('../../../app/models/card.js')(cardTypes)
+var fields = require('../../../app/utils/charge_validation_fields.js')(Card)
 
-let result;
+let result
 
 describe('card validation: cardholder name', function () {
   describe('should validate if it is not suspected of containing a PAN or CVV', () => {
-    
     it('and it contains only text', () => {
-      result = fields.fieldValidations.cardholderName('Mr Peter Griffin');
-      expect(result).to.equal(true);
-    });
+      result = fields.fieldValidations.cardholderName('Mr Peter Griffin')
+      expect(result).to.equal(true)
+    })
 
     it('and it contains only 2 consecutive digits', () => {
-      result = fields.fieldValidations.cardholderName('Mr Peter Griffin 22');
-      expect(result).to.equal(true);
-    });
+      result = fields.fieldValidations.cardholderName('Mr Peter Griffin 22')
+      expect(result).to.equal(true)
+    })
 
     it('and it contains only 3 non-consecutive digits', () => {
-      result = fields.fieldValidations.cardholderName('Mr Peter 2 Griffin 22');
-      expect(result).to.equal(true);
-    });
+      result = fields.fieldValidations.cardholderName('Mr Peter 2 Griffin 22')
+      expect(result).to.equal(true)
+    })
 
     it('and it contains only 4 non-consecutive digits', () => {
-      result = fields.fieldValidations.cardholderName('Mr Peter 22 Griffin 22');
-      expect(result).to.equal(true);
-    });
-    
-    it('and it contains 11 digits', () => {
-      result = fields.fieldValidations.cardholderName('Mr Peter Griffin 01234567890');
-      expect(result).to.equal(true);
-    });
+      result = fields.fieldValidations.cardholderName('Mr Peter 22 Griffin 22')
+      expect(result).to.equal(true)
+    })
 
-    
-  });
+    it('and it contains 11 digits', () => {
+      result = fields.fieldValidations.cardholderName('Mr Peter Griffin 01234567890')
+      expect(result).to.equal(true)
+    })
+  })
 
   describe('should not validate if it contains a suspected PAN', () => {
     it('and it consists entirely of an excessive amount of digits', () => {
-      result = fields.fieldValidations.cardholderName('012345678901');
-      expect(result).to.equal('contains_too_many_digits');
-    });
+      result = fields.fieldValidations.cardholderName('012345678901')
+      expect(result).to.equal('contains_too_many_digits')
+    })
 
     it('and it contains both text and excessive consecutive digits', () => {
-      result = fields.fieldValidations.cardholderName('Mr Peter Griffin 01234567890121');
-      expect(result).to.equal('contains_too_many_digits');
-    });
+      result = fields.fieldValidations.cardholderName('Mr Peter Griffin 01234567890121')
+      expect(result).to.equal('contains_too_many_digits')
+    })
 
     it('and it contains both text and excessive non-consecutive digits', () => {
-      result = fields.fieldValidations.cardholderName('Mr Peter 0123-45 Gri--ffin 678901');
-      expect(result).to.equal('contains_too_many_digits');
-    });
-  });
+      result = fields.fieldValidations.cardholderName('Mr Peter 0123-45 Gri--ffin 678901')
+      expect(result).to.equal('contains_too_many_digits')
+    })
+  })
 
   describe('it should not validate if it contains a suspected CVV', () => {
     it('because it consists of a number that is 3 digits long', () => {
-      result = fields.fieldValidations.cardholderName(170);
-      expect(result).to.equal('contains_suspected_cvv');
-    });
+      result = fields.fieldValidations.cardholderName(170)
+      expect(result).to.equal('contains_suspected_cvv')
+    })
 
     it('because it consists of a number that is 4 digits long', () => {
-      result = fields.fieldValidations.cardholderName(1760);
-      expect(result).to.equal('contains_suspected_cvv');
-    });
+      result = fields.fieldValidations.cardholderName(1760)
+      expect(result).to.equal('contains_suspected_cvv')
+    })
 
     it('because it consists entirely of 3 consecutive digits', () => {
-      result = fields.fieldValidations.cardholderName('170');
-      expect(result).to.equal('contains_suspected_cvv');
-    });
+      result = fields.fieldValidations.cardholderName('170')
+      expect(result).to.equal('contains_suspected_cvv')
+    })
 
     it('because it consists entirely of 4 consecutive digits', () => {
-      result = fields.fieldValidations.cardholderName('1760');
-      expect(result).to.equal('contains_suspected_cvv');
-    });
+      result = fields.fieldValidations.cardholderName('1760')
+      expect(result).to.equal('contains_suspected_cvv')
+    })
 
     it('because it consists entirely of 3 consecutive digits surrounded by spaces', () => {
-      result = fields.fieldValidations.cardholderName(' 170 ');
-      expect(result).to.equal('contains_suspected_cvv');
-    });
+      result = fields.fieldValidations.cardholderName(' 170 ')
+      expect(result).to.equal('contains_suspected_cvv')
+    })
 
     it('because it consists entirely of 4 consecutive digits surrounded by spaces', () => {
-      result = fields.fieldValidations.cardholderName(' 1760 ');
-      expect(result).to.equal('contains_suspected_cvv');
-    });
+      result = fields.fieldValidations.cardholderName(' 1760 ')
+      expect(result).to.equal('contains_suspected_cvv')
+    })
   })
-
-});
+})

--- a/test/utils/charge_validation_fields/cvc_validation_test.js
+++ b/test/utils/charge_validation_fields/cvc_validation_test.js
@@ -1,35 +1,31 @@
-var should = require('chai').should();
-var assert = require('assert');
-var expect = require('chai').expect;
-var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes();
-var Card  = require('../../../app/models/card.js')(cardTypes);
-var fields= require('../../../app/utils/charge_validation_fields.js')(Card);
-
+var expect = require('chai').expect
+var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes()
+var Card = require('../../../app/models/card.js')(cardTypes)
+var fields = require('../../../app/utils/charge_validation_fields.js')(Card)
 
 describe('card validation: cvc', function () {
-
   it('should true if correct', function () {
-    var result = fields.fieldValidations.cvc("123");
-    expect(result).to.equal(true);
-  });
+    var result = fields.fieldValidations.cvc('123')
+    expect(result).to.equal(true)
+  })
 
   it('should invalid length if too long', function () {
-    var result = fields.fieldValidations.cvc("12345");
-    expect(result).to.equal("invalid_length");
-  });
+    var result = fields.fieldValidations.cvc('12345')
+    expect(result).to.equal('invalid_length')
+  })
 
   it('should invalid length if too short', function () {
-    var result = fields.fieldValidations.cvc("12");
-    expect(result).to.equal("invalid_length");
-  });
+    var result = fields.fieldValidations.cvc('12')
+    expect(result).to.equal('invalid_length')
+  })
 
   it('should invalid length if undefined', function () {
-    var result = fields.fieldValidations.cvc(undefined);
-    expect(result).to.equal("invalid_length");
-  });
+    var result = fields.fieldValidations.cvc(undefined)
+    expect(result).to.equal('invalid_length')
+  })
 
   it('should invalid length if empty', function () {
-    var result = fields.fieldValidations.cvc('');
-    expect(result).to.equal("invalid_length");
-  });
-});
+    var result = fields.fieldValidations.cvc('')
+    expect(result).to.equal('invalid_length')
+  })
+})

--- a/test/utils/charge_validation_fields/email_field_test.js
+++ b/test/utils/charge_validation_fields/email_field_test.js
@@ -1,38 +1,34 @@
-'use strict';
+'use strict'
 
-var assert = require('assert');
-var expect = require('chai').expect;
-var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes();
-var Card  = require('../../../app/models/card.js')(cardTypes);
-var fields= require('../../../app/utils/charge_validation_fields.js')(Card);
+var expect = require('chai').expect
+var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes()
+var Card = require('../../../app/models/card.js')(cardTypes)
+var fields = require('../../../app/utils/charge_validation_fields.js')(Card)
 
-let result;
+let result
 
 describe('card validation: email', function () {
   describe('should validate if does not contain 12 digits', () => {
-    
     it('and it contains only text', () => {
-      result = fields.fieldValidations.email('pumpkinlover@example.com');
-      expect(result).to.equal(true);
-    });
-    
+      result = fields.fieldValidations.email('pumpkinlover@example.com')
+      expect(result).to.equal(true)
+    })
+
     it('and it contains 11 digits', () => {
-      result = fields.fieldValidations.email('pumpkinlover1234567890@example.com');
-      expect(result).to.equal(true);
-    });
-    
-  });
+      result = fields.fieldValidations.email('pumpkinlover1234567890@example.com')
+      expect(result).to.equal(true)
+    })
+  })
 
   describe('should not validate if it contains 12 or more digits', () => {
     it('and the digits are consecutive', () => {
-      result = fields.fieldValidations.email('1234567890123@example.com');
-      expect(result).to.equal('contains_too_many_digits');
-    });
+      result = fields.fieldValidations.email('1234567890123@example.com')
+      expect(result).to.equal('contains_too_many_digits')
+    })
 
     it('and the digits are not consecutive', () => {
-      result = fields.fieldValidations.email('012345AB678901@cheesey-feet.com');
-      expect(result).to.equal('contains_too_many_digits');
-    });
-  });
-
-});
+      result = fields.fieldValidations.email('012345AB678901@cheesey-feet.com')
+      expect(result).to.equal('contains_too_many_digits')
+    })
+  })
+})

--- a/test/utils/charge_validation_fields/expiry_month_validation_test.js
+++ b/test/utils/charge_validation_fields/expiry_month_validation_test.js
@@ -1,62 +1,58 @@
-var should = require('chai').should();
-var assert = require('assert');
-var expect = require('chai').expect;
-var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes();
-var Card  = require('../../../app/models/card.js')(cardTypes);
-var fields= require('../../../app/utils/charge_validation_fields.js')(Card);
+var expect = require('chai').expect
+var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes()
+var Card = require('../../../app/models/card.js')(cardTypes)
+var fields = require('../../../app/utils/charge_validation_fields.js')(Card)
 
 describe('card validation: expiry month', function () {
-
   it('should true if correct', function () {
-    var future = new Date();
-    future.setDate(future.getDate() + 30);
-    var fullYear = future.getFullYear().toString();
+    var future = new Date()
+    future.setDate(future.getDate() + 30)
+    var fullYear = future.getFullYear().toString()
 
-    var result = fields.fieldValidations.expiryMonth(12, {expiryYear: fullYear.substr(2,2)} );
-    var longYear = fields.fieldValidations.expiryMonth(12, {expiryYear: fullYear} );
+    var result = fields.fieldValidations.expiryMonth(12, {expiryYear: fullYear.substr(2, 2)})
+    var longYear = fields.fieldValidations.expiryMonth(12, {expiryYear: fullYear})
 
-    expect(result).to.equal(true);
-    expect(longYear).to.equal(true);
-
-  });
+    expect(result).to.equal(true)
+    expect(longYear).to.equal(true)
+  })
 
   it('should fails if month is too large or small', function () {
-    var small = fields.fieldValidations.expiryMonth(0.1, {expiryYear: 16} );
-    var large = fields.fieldValidations.expiryMonth(13, {expiryYear: 16} );
-    var chars = fields.fieldValidations.expiryMonth("a12", {expiryYear: 16} );
+    var small = fields.fieldValidations.expiryMonth(0.1, {expiryYear: 16})
+    var large = fields.fieldValidations.expiryMonth(13, {expiryYear: 16})
+    var chars = fields.fieldValidations.expiryMonth('a12', {expiryYear: 16})
 
-    expect(small).to.equal("invalid_month");
-    expect(large).to.equal("invalid_month");
-    expect(chars).to.equal("invalid_month");
-  });
+    expect(small).to.equal('invalid_month')
+    expect(large).to.equal('invalid_month')
+    expect(chars).to.equal('invalid_month')
+  })
 
   it('should fails if year is not 2 or 4 digits', function () {
-    var future = new Date();
-    future.setDate(future.getDate() + 30);
-    var fullYear = future.getFullYear().toString();
+    var future = new Date()
+    future.setDate(future.getDate() + 30)
+    var fullYear = future.getFullYear().toString()
 
-    var two = fields.fieldValidations.expiryMonth(12, {expiryYear: fullYear.substr(2,2)});
-    var three = fields.fieldValidations.expiryMonth(12, {expiryYear: "016"} );
-    var four = fields.fieldValidations.expiryMonth(12, {expiryYear: fullYear} );
+    var two = fields.fieldValidations.expiryMonth(12, {expiryYear: fullYear.substr(2, 2)})
+    var three = fields.fieldValidations.expiryMonth(12, {expiryYear: '016'})
+    var four = fields.fieldValidations.expiryMonth(12, {expiryYear: fullYear})
 
-    expect(two).to.equal(true);
-    expect(three).to.equal("invalid_year");
-    expect(four).to.equal(true);
-  });
+    expect(two).to.equal(true)
+    expect(three).to.equal('invalid_year')
+    expect(four).to.equal(true)
+  })
 
   it('should fail is date is in past', function () {
-    var month = fields.fieldValidations.expiryMonth(1, {expiryYear: 16} );
-    var year = fields.fieldValidations.expiryMonth(1, {expiryYear: 15} );
-    var longYear = fields.fieldValidations.expiryMonth(1, {expiryYear: "2015"} );
+    var month = fields.fieldValidations.expiryMonth(1, {expiryYear: 16})
+    var year = fields.fieldValidations.expiryMonth(1, {expiryYear: 15})
+    var longYear = fields.fieldValidations.expiryMonth(1, {expiryYear: '2015'})
 
-    expect(month).to.equal("in_the_past");
-    expect(year).to.equal("in_the_past");
-    expect(longYear).to.equal("in_the_past");
-  });
+    expect(month).to.equal('in_the_past')
+    expect(year).to.equal('in_the_past')
+    expect(longYear).to.equal('in_the_past')
+  })
 
   it('should fail year is not defined', function () {
-    var noYear = fields.fieldValidations.expiryMonth("12", {} );
+    var noYear = fields.fieldValidations.expiryMonth('12', {})
 
-    expect(noYear).to.equal("message");
-  });
-});
+    expect(noYear).to.equal('message')
+  })
+})

--- a/test/utils/charge_validation_fields/postcode_validation_test.js
+++ b/test/utils/charge_validation_fields/postcode_validation_test.js
@@ -1,81 +1,73 @@
-var should = require('chai').should();
-var assert = require('assert');
-var expect = require('chai').expect;
-var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes();
-var Card  = require('../../../app/models/card.js')(cardTypes);
-var fields= require('../../../app/utils/charge_validation_fields.js')(Card);
-let result;
+var expect = require('chai').expect
+var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes()
+var Card = require('../../../app/models/card.js')(cardTypes)
+var fields = require('../../../app/utils/charge_validation_fields.js')(Card)
+let result
 
 describe('card validation: postcode', function () {
-
   it('should return true if a valid postcode', function () {
-    result = fields.fieldValidations.addressPostcode("N4 2BQ", { addressCountry: "GB" });
-    expect(result).to.equal(true);
-  });
+    result = fields.fieldValidations.addressPostcode('N4 2BQ', {addressCountry: 'GB'})
+    expect(result).to.equal(true)
+  })
 
   it('should always validate if foreign country - undefined', function () {
-    result = fields.fieldValidations.addressPostcode(undefined,{ addressCountry: "FOO"});
-    expect(result).to.equal(true);
-  });
+    result = fields.fieldValidations.addressPostcode(undefined, {addressCountry: 'FOO'})
+    expect(result).to.equal(true)
+  })
 
   it('should always validate if foreign country - bad format', function () {
-    result = fields.fieldValidations.addressPostcode("asdf",{ addressCountry: "FOO"});
-    expect(result).to.equal(true);
-  });
+    result = fields.fieldValidations.addressPostcode('asdf', {addressCountry: 'FOO'})
+    expect(result).to.equal(true)
+  })
 
   it('should not validate if not defined', function () {
-    result = fields.fieldValidations.addressPostcode(undefined, { addressCountry: "GB" });
-    expect(result).to.equal("message");
-  });
+    result = fields.fieldValidations.addressPostcode(undefined, {addressCountry: 'GB'})
+    expect(result).to.equal('message')
+  })
 
   it('should not validate if empty', function () {
-    result = fields.fieldValidations.addressPostcode('', { addressCountry: "GB" });
-    expect(result).to.equal("message");
-  });
+    result = fields.fieldValidations.addressPostcode('', {addressCountry: 'GB'})
+    expect(result).to.equal('message')
+  })
 
   describe('should not validate if a UK postcode and its length is', () => {
     it('too long', function () {
-      result = fields.fieldValidations.addressPostcode("N4 2BQQ", { addressCountry: "GB" });
-      expect(result).to.equal("message");
-    });
+      result = fields.fieldValidations.addressPostcode('N4 2BQQ', {addressCountry: 'GB'})
+      expect(result).to.equal('message')
+    })
 
     it('too short', function () {
-      result = fields.fieldValidations.addressPostcode("N4", { addressCountry: "GB" });
-      expect(result).to.equal("message");
-    });
-  });
+      result = fields.fieldValidations.addressPostcode('N4', {addressCountry: 'GB'})
+      expect(result).to.equal('message')
+    })
+  })
 
   describe('should validate if does not contain 12 digits', () => {
-
     it('and it contains only text', () => {
-      result = fields.fieldValidations.addressPostcode('ABCDEF', { addressCountry: "US" });
-      expect(result).to.equal(true);
-    });
+      result = fields.fieldValidations.addressPostcode('ABCDEF', {addressCountry: 'US'})
+      expect(result).to.equal(true)
+    })
 
     it('and it contains 11 digits', () => {
-      result = fields.fieldValidations.addressPostcode('AB01234567890', { addressCountry: "US" });
-      expect(result).to.equal(true);
-    });
-
-    
-
-  });
+      result = fields.fieldValidations.addressPostcode('AB01234567890', {addressCountry: 'US'})
+      expect(result).to.equal(true)
+    })
+  })
 
   describe('should not validate if it contains 12 or more digits', () => {
     it('and it contains only digits', () => {
-      result = fields.fieldValidations.addressPostcode('012345678901', { addressCountry: "US" });
-      expect(result).to.equal('contains_too_many_digits');
-    });
+      result = fields.fieldValidations.addressPostcode('012345678901', {addressCountry: 'US'})
+      expect(result).to.equal('contains_too_many_digits')
+    })
 
     it('and it contains both digits and text and the digits are consecutive', () => {
-      result = fields.fieldValidations.addressPostcode('ABCDEF0123456789012', { addressCountry: "US" });
-      expect(result).to.equal('contains_too_many_digits');
-    });
+      result = fields.fieldValidations.addressPostcode('ABCDEF0123456789012', {addressCountry: 'US'})
+      expect(result).to.equal('contains_too_many_digits')
+    })
 
     it('and it contains both digits and text and the digits are not consecutive', () => {
-      result = fields.fieldValidations.addressPostcode('012345AB678901', { addressCountry: "US" });
-      expect(result).to.equal('contains_too_many_digits');
-    });
-  });
-
-});
+      result = fields.fieldValidations.addressPostcode('012345AB678901', {addressCountry: 'US'})
+      expect(result).to.equal('contains_too_many_digits')
+    })
+  })
+})

--- a/test/utils/charge_validation_test.js
+++ b/test/utils/charge_validation_test.js
@@ -1,69 +1,56 @@
-const should = require('chai').should();
-const assert = require('assert');
-const expect = require('chai').expect;
-const charge = require('../../app/utils/charge_validation.js');
-const i18n   = require('i18n');
-const _      = require('lodash');
-const Card   = require('../../app/models/card.js')();
-let result;
-i18n.setLocale('en');
-const validator = charge(i18n.__("chargeController.fieldErrors"),{info: ()=>{}},Card);
+const expect = require('chai').expect
+const charge = require('../../app/utils/charge_validation.js')
+const i18n = require('i18n')
+const Card = require('../../app/models/card.js')()
+let result
+i18n.setLocale('en')
+const validator = charge(i18n.__('chargeController.fieldErrors'), {info: () => {}}, Card)
 
 describe('charge validator', () => {
-
   describe('Method: verify', () => {
-
     it('when there is any sort of error, the hasError property of the returned object should be true', () => {
-      result = validator.verify({});
-      expect(result.hasError).to.equal(true);
-    });
+      result = validator.verify({})
+      expect(result.hasError).to.equal(true)
+    })
 
     describe('when there is an error in a required field', () => {
       before(() => {
-        result = validator.verify({"cardNo" : "4242"});
-      });
+        result = validator.verify({'cardNo': '4242'})
+      })
 
       it('it should add any fields containing errors to the \'errorFields\' array of the returned object', () => {
-        const errorFields = result.errorFields.map(field => field.key);
-        expect(errorFields.length).to.equal(validator.required.length - 1); // month/year combined for this
-      });
+        const errorFields = result.errorFields.map(field => field.key)
+        expect(errorFields.length).to.equal(validator.required.length - 1) // month/year combined for this
+      })
 
       it('it should add any fields containing errors to the \'highlightErrorFields\' array of the returned object', () => {
-        const highlightErrorFields = Object.keys(result.highlightErrorFields);
-        expect(highlightErrorFields.length).to.equal(validator.required.length);
-      });
+        const highlightErrorFields = Object.keys(result.highlightErrorFields)
+        expect(highlightErrorFields.length).to.equal(validator.required.length)
+      })
 
       it('it should run custom validators against any defined fields', () => {
-        expect(result.errorFields.find(field => field.key === 'cardNo').value).to.eq('Card number is not the correct length');
-      });
-    });
+        expect(result.errorFields.find(field => field.key === 'cardNo').value).to.eq('Card number is not the correct length')
+      })
+    })
 
     describe('when there is an error in an optional field', () => {
       before(() => {
-        result = validator.verify({"addressLine2" : "012345678901 Cheese Avenue"});
-
-      });
+        result = validator.verify({'addressLine2': '012345678901 Cheese Avenue'})
+      })
 
       it('it should add any fields containing errors to the \'errorFields\' array of the returned object', () => {
-        const errorFields = result.errorFields.map(field => field.key).filter(field => validator.optional.includes(field));
-        expect(errorFields.length).to.equal(1);
-      });
+        const errorFields = result.errorFields.map(field => field.key).filter(field => validator.optional.includes(field))
+        expect(errorFields.length).to.equal(1)
+      })
 
       it('it should add any fields containing errors to the \'highlightErrorFields\' array of the returned object', () => {
-        const highlightErrorFields = Object.keys(result.highlightErrorFields).filter(field => validator.optional.includes(field));
-        expect(highlightErrorFields.length).to.equal(1);
-      });
+        const highlightErrorFields = Object.keys(result.highlightErrorFields).filter(field => validator.optional.includes(field))
+        expect(highlightErrorFields.length).to.equal(1)
+      })
 
       it('it should run custom validators against any defined fields', () => {
-        expect(result.errorFields.find(field => field.key === 'addressLine2').value).to.eq('Enter valid address information');
-      });
-    });
-  });
-
-
-
-
-
-
-
-});
+        expect(result.errorFields.find(field => field.key === 'addressLine2').value).to.eq('Enter valid address information')
+      })
+    })
+  })
+})

--- a/test/utils/normalise_test.js
+++ b/test/utils/normalise_test.js
@@ -1,20 +1,18 @@
-var should = require('chai').should();
-var assert = require('assert');
-var expect = require('chai').expect;
-var normalise = require(__dirname + '/../../app/services/normalise_charge.js');
-
-var _ = require('lodash');
+var expect = require('chai').expect
+var path = require('path')
+var _ = require('lodash')
+var normalise = require(path.join(__dirname, '/../../app/services/normalise_charge.js'))
 
 var unNormalisedCharge = {
   amount: 1234,
-  return_url: "foo",
-  description: "bar",
+  return_url: 'foo',
+  description: 'bar',
   links: [{
-    rel: "rar",
-    href: "http://foo"
+    rel: 'rar',
+    href: 'http://foo'
   }],
-  status: "status",
-  email: "bobbybobby@bobby.bob",
+  status: 'status',
+  email: 'bobbybobby@bobby.bob',
   auth_3ds_data: {
     paRequest: 'paRequest',
     issuerUrl: 'issuerUrl'
@@ -30,19 +28,19 @@ var unNormalisedCharge = {
       label: 'Visa'
     }]
   }
-};
+}
 
 var normalisedCharge = {
   id: 1,
-  amount: "12.34",
-  service_return_url: "foo",
-  description: "bar",
+  amount: '12.34',
+  service_return_url: 'foo',
+  description: 'bar',
   links: [{
-    rel: "rar",
-    href: "http://foo"
+    rel: 'rar',
+    href: 'http://foo'
   }],
-  status: "status",
-  email: "bobbybobby@bobby.bob",
+  status: 'status',
+  email: 'bobbybobby@bobby.bob',
   auth3dsData: {
     paRequest: 'paRequest',
     issuerUrl: 'issuerUrl'
@@ -58,113 +56,109 @@ var normalisedCharge = {
       credit: true
     }]
   }
-};
+}
 
 var unNormalisedAddress = {
-  addressLine1: "a",
-  addressLine2: "b",
-  addressCity: "c",
-  addressPostcode: "d",
-  addressCountry: "GB"
-};
+  addressLine1: 'a',
+  addressLine2: 'b',
+  addressCity: 'c',
+  addressPostcode: 'd',
+  addressCountry: 'GB'
+}
 
 var normalisedApiAddress = {
-  line1: "a",
-  line2: "b",
-  city: "c",
-  postcode: "d",
-  country: "GB"
-};
-
+  line1: 'a',
+  line2: 'b',
+  city: 'c',
+  postcode: 'd',
+  country: 'GB'
+}
 
 describe('normalise', function () {
-
   describe('charge', function () {
     it('should return a refined state', function () {
-      var result = normalise.charge(unNormalisedCharge, 1);
-      expect(result).to.deep.equal(normalisedCharge);
-    });
-  });
+      var result = normalise.charge(unNormalisedCharge, 1)
+      expect(result).to.deep.equal(normalisedCharge)
+    })
+  })
 
   describe('api address', function () {
     it('should return a refined address for the api', function () {
-      var result = normalise.addressForApi(unNormalisedAddress);
-      expect(result).to.deep.equal(normalisedApiAddress);
-    });
-  });
+      var result = normalise.addressForApi(unNormalisedAddress)
+      expect(result).to.deep.equal(normalisedApiAddress)
+    })
+  })
 
   describe('addresslines', function () {
     it('should return the body with adressline 2 moved to address line 1 if filled', function () {
-      var passedByReference = {addressLine2: "foo"}
-      normalise.addressLines(passedByReference);
-      expect(passedByReference).to.deep.equal({addressLine1: "foo"});
-      expect(passedByReference.addressLine2).to.be.undefined;
-    });
+      var passedByReference = {addressLine2: 'foo'}
+      normalise.addressLines(passedByReference)
+      expect(passedByReference).to.deep.equal({addressLine1: 'foo'})
+      expect(passedByReference.addressLine2).to.be.undefined // eslint-disable-line 
+    })
 
     it('should do nothing if there is addressLine1', function () {
-      var passedByReference = {addressLine1: "bar", addressLine2: "foo"}
-      normalise.addressLines(passedByReference);
-      expect(passedByReference).to.deep.equal({addressLine1: "bar", addressLine2: "foo"});
-    });
-  });
+      var passedByReference = {addressLine1: 'bar', addressLine2: 'foo'}
+      normalise.addressLines(passedByReference)
+      expect(passedByReference).to.deep.equal({addressLine1: 'bar', addressLine2: 'foo'})
+    })
+  })
 
   describe('whitespace', function () {
     it('should return the body with no surrounding whitespace', function () {
       var passedByReference = {
-        email: " foo@foo.com",
-        name: "Foo Bar ",
-        postcode: " WC2B 6NH "
-      };
-      normalise.whitespace(passedByReference);
+        email: ' foo@foo.com',
+        name: 'Foo Bar ',
+        postcode: ' WC2B 6NH '
+      }
+      normalise.whitespace(passedByReference)
       expect(passedByReference).to.deep.equal({
-        email: "foo@foo.com",
-        name: "Foo Bar",
-        postcode: "WC2B 6NH"
-      });
-    });
+        email: 'foo@foo.com',
+        name: 'Foo Bar',
+        postcode: 'WC2B 6NH'
+      })
+    })
 
     it('should return the body with no surrounding whitespace but within the email', function () {
       var passedByReference = {
-          email: ' fo" "o@foo.com',
-          name: "Foo Bar ",
-          postcode: " WC2B 6NH "
-      };
-      normalise.whitespace(passedByReference);
+        email: ' fo" "o@foo.com',
+        name: 'Foo Bar ',
+        postcode: ' WC2B 6NH '
+      }
+      normalise.whitespace(passedByReference)
       expect(passedByReference).to.deep.equal({
-          email: 'fo" "o@foo.com',
-          name: "Foo Bar",
-          postcode: "WC2B 6NH"
-      });
-    });
-  });
+        email: 'fo" "o@foo.com',
+        name: 'Foo Bar',
+        postcode: 'WC2B 6NH'
+      })
+    })
+  })
 
   describe('address for view', function () {
     it('should return a comma seperated address', function () {
-      var address = normalise.addressForView(unNormalisedAddress);
-      expect(address).to.deep.equal("a, b, c, d, United Kingdom");
-    });
+      var address = normalise.addressForView(unNormalisedAddress)
+      expect(address).to.deep.equal('a, b, c, d, United Kingdom')
+    })
 
     it('should return a comma seperated address even with something missing', function () {
-      var unNormalised = _.cloneDeep(unNormalisedAddress);
-      delete unNormalised.addressCity;
-      var address = normalise.addressForView(unNormalised);
-      expect(address).to.deep.equal("a, b, d, United Kingdom");
-    });
-
-  });
+      var unNormalised = _.cloneDeep(unNormalisedAddress)
+      delete unNormalised.addressCity
+      var address = normalise.addressForView(unNormalised)
+      expect(address).to.deep.equal('a, b, d, United Kingdom')
+    })
+  })
 
   describe('credit card', function () {
     it('should return stripping spaces', function () {
-      var card = "1234 5678"
-      var address = normalise.creditCard(card);
-      expect(address).to.deep.equal("12345678");
-    });
+      var card = '1234 5678'
+      var address = normalise.creditCard(card)
+      expect(address).to.deep.equal('12345678')
+    })
 
     it('should return stripping hyphens', function () {
-      var card = "1234-5678"
-      var address = normalise.creditCard(card);
-      expect(address).to.deep.equal("12345678");
-    });
-
-  });
-});
+      var card = '1234-5678'
+      var address = normalise.creditCard(card)
+      expect(address).to.deep.equal('12345678')
+    })
+  })
+})

--- a/test/utils/views_test.js
+++ b/test/utils/views_test.js
@@ -1,84 +1,77 @@
-var should = require('chai').should();
-var assert = require('assert');
-var views  = require(__dirname + '/../../app/utils/views.js');
-var sinon  = require('sinon');
-var _      = require('lodash');
-
+var path = require('path')
+var assert = require('assert')
+var views = require(path.join(__dirname, '/../../app/utils/views.js'))
+var sinon = require('sinon')
+var _ = require('lodash')
 
 describe('views helper', function () {
-
   var response = {
-    status: function(){},
-    render: function(){}
-  },
-  status = undefined,
-  render = undefined,
-  testView = {
+    status: function () {},
+    render: function () {}
+  }
+  var status
+  var render
+  var testView = {
     TEST_VIEW: {
-      view: "TEST_VIEW",
+      view: 'TEST_VIEW',
       code: 999
     }
-  };
+  }
 
-  beforeEach(function(){
-    status = sinon.stub(response,"status");
-    render = sinon.stub(response,"render");
-  });
+  beforeEach(function () {
+    status = sinon.stub(response, 'status')
+    render = sinon.stub(response, 'render')
+  })
 
-  afterEach(function(){
-    status.restore();
-    render.restore();
-  });
+  afterEach(function () {
+    status.restore()
+    render.restore()
+  })
 
   it('should call a merged view correctly', function () {
-    _views = views.create(testView);
-    _views.display(response,"TEST_VIEW");
-    assert(status.calledWith(999));
-    assert(render.calledWith("TEST_VIEW",{viewName: "TEST_VIEW"}
-    ));
-  });
+    var _views = views.create(testView)
+    _views.display(response, 'TEST_VIEW')
+    assert(status.calledWith(999))
+    assert(render.calledWith('TEST_VIEW', {viewName: 'TEST_VIEW'}
+    ))
+  })
 
   it('should return a 200 by default', function () {
-    var view = _.cloneDeep(testView);
+    var view = _.cloneDeep(testView)
     delete view.TEST_VIEW.code
-    _views = views.create(view);
-    _views.display(response,"TEST_VIEW");
-
-    assert(status.calledWith(200));
-    assert(render.calledWith("TEST_VIEW",{viewName: "TEST_VIEW"}
-    ));
-  });
+    var _views = views.create(view)
+    _views.display(response, 'TEST_VIEW')
+    assert(status.calledWith(200))
+    assert(render.calledWith('TEST_VIEW', {viewName: 'TEST_VIEW'}
+    ))
+  })
 
   it('should return locals passed in', function () {
-    var view = _.cloneDeep(testView);
-    _views = views.create(view);
-    _views.display(response,"TEST_VIEW", { a: "local"});
-
-    assert(status.calledWith(999));
-    assert(render.calledWith("TEST_VIEW",{viewName: "TEST_VIEW", a: "local"}));
-  });
-
+    var view = _.cloneDeep(testView)
+    var _views = views.create(view)
+    _views.display(response, 'TEST_VIEW', {a: 'local'})
+    assert(status.calledWith(999))
+    assert(render.calledWith('TEST_VIEW', {viewName: 'TEST_VIEW', a: 'local'}))
+  })
 
   it('should rendor error view when view not found', function () {
-    _views = views.create();
-    _views.display(response,"AINT_NO_VIEW_HERE");
-    assert(status.calledWith(500));
-    assert(render.calledWith("error",
-      { message: 'There is a problem, please try again later',
-      viewName: 'error' }
-    ));
-  });
+    var _views = views.create()
+    _views.display(response, 'AINT_NO_VIEW_HERE')
+    assert(status.calledWith(500))
+    assert(render.calledWith('error', { message: 'There is a problem, please try again later', viewName: 'error' }
+    ))
+  })
 
-  var defaultTemplates =  {
+  var defaultTemplates = {
     'ERROR': {
       template: 'error',
       code: 500,
       message: 'There is a problem, please try again later'
     },
-    'NOT_FOUND':{
+    'NOT_FOUND': {
       template: 'error',
       code: 404,
-      message:  "Page cannot be found"
+      message: 'Page cannot be found'
     },
     'HUMANS': {
       template: 'plain_message',
@@ -87,42 +80,33 @@ describe('views helper', function () {
     }
   }
 
-
   _.forEach(defaultTemplates,
-    function(values, name) {
-      it('should be able to render default ' + name + ' page', function () {
-        _views = views.create();
-        _views.display(response,name);
-        assert(status.calledWith(values.code));
+      function (values, name) {
+        it('should be able to render default ' + name + ' page', function () {
+          var _views = views.create()
+          _views.display(response, name)
+          assert(status.calledWith(values.code))
+          assert(render.calledWith(values.template, { message: values.message, viewName: name }
+          ))
+        })
 
-        assert(render.calledWith(values.template,
-          { message: values.message,
-          viewName: name }
-        ));
-      });
+        it('should be able to ovverride the default ' + name + ' message', function () {
+          var _views = views.create()
+          _views.display(response, name, {message: 'lol'})
+          assert(status.calledWith(values.code))
+          assert(render.calledWith(values.template, { message: 'lol', viewName: name }
+          ))
+        })
 
-      it('should be able to ovverride the default ' + name + ' message', function () {
-        _views = views.create();
-        _views.display(response,name,{message : "lol"});
-        assert(status.calledWith(values.code));
-        assert(render.calledWith(values.template,
-          { message: 'lol',
-          viewName: name }
-        ));
-      });
-
-      it('should be able to ovverride the default ' + name + ' template', function () {
-        var overriden = {};
-        overriden[name] = { view: "foo", code: 333 }
-        _views = views.create(overriden);
-        _views.display(response,name,{message : "lol"});
-        assert(status.calledWith(333));
-        assert(render.calledWith("foo",
-          { message: 'lol',
-          viewName: name }
-        ));
-      });
-    }
-  );
-
-});
+        it('should be able to ovverride the default ' + name + ' template', function () {
+          var overriden = {}
+          overriden[name] = { view: 'foo', code: 333 }
+          var _views = views.create(overriden)
+          _views.display(response, name, {message: 'lol'})
+          assert(status.calledWith(333))
+          assert(render.calledWith('foo', { message: 'lol', viewName: name }
+          ))
+        })
+      }
+  )
+})


### PR DESCRIPTION
… errors where they were required

PP-2222 Fixed broken test helper references that were not using camel case

## WHAT
In order to enforce the StandardJS style guide (https://standardjs.com/) the codebase has been run with the 'standard --fix' option which automatically reformats code where it can, to pass linting rules.

Many files had to be hand edited to modify code to be compliant, and as some of our assertion libraries (Chai) don't play nicely with the linter, so on a case by case basis these had to be excluded from linting e.g.

`expect(passedByReference.addressLine2).to.be.undefined // eslint-disable-line`

These are limited to the tests directory, and there is only one case where I've excluded production code from the linter:

from : /app/utils/luhn.js

`default: calc2 = calc2 // eslint-disable-line`

This code is copied from an existing repo, and not our own work, and thought it might be best to leave this in an unmodified state.

The 'npm test' and 'npm lint' script commands have been replaced with ones that use standard.

## HOW 
Run 'npm test'


