### PR TITLE
PP-2303 Enabled livereload in grunt config. Created npm script command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,8 @@ module.exports = function (grunt) {
       files: ['app/assets/**/*'],
       tasks: ['generate-assets'],
       options: {
-        spawn: false
+        spawn: false,
+        livereload: true
       }
     },
     forBrowsifier: {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
     "test": "npm run lint && npm run grunt-test",
     "lint": "standard",
+    "watch-live-reload": "./node_modules/.bin/grunt watch",
     "grunt-test": "node ./node_modules/.bin/grunt test",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"


### PR DESCRIPTION
## WHAT
@jonheslop needed the ability to perform live editing of the frontend application without resorting to performing browser refreshes or node instance restarts. I looked into doing this via Browsersync which ended up in a variety of dead ends with proxied websites and cookie issues, but it turns out our Grunt configuration already supports 'livereload' which is enabled with a config switch and assumes you have the 'livereload' browser plugin enabled.

## HOW 
Run the entire application up using 'msl -a up', and then ensure the frontend application is running locally via a 'msl run' command in the repo directory. In another terminal window run the 'npm run watch-live-reload' which runs a Grunt watch task.

You will then need to ensure you have the 'livereload' browser plugin (I tested using Chrome) running while viewing the site. You can then see things working by making a change to a .sass file which will cause a re-compilation and then the browser should automatically show changes without having to perform any browser actions.

