### PR TITLE
PP-2217 Added coverage testing and 85% min threshold on lines/stateme…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.nyc_output
-.idea
 .sass-cache
 .DS_Store
 .start.pid
@@ -24,3 +22,7 @@ public/javascripts/browsered.js
 # floobit, intellij plugin used for remote pairing
 .floo
 .flooignore
+
+# nyc/istanbul
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "npm run lint && npm run grunt-test",
     "lint": "standard",
     "watch-live-reload": "./node_modules/.bin/grunt watch",
-    "grunt-test": "node ./node_modules/.bin/grunt test",
+    "grunt-test": "nyc node ./node_modules/.bin/grunt test",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"
   },
@@ -102,6 +102,7 @@
     "mockserver-client": "^1.0.16",
     "mockserver-grunt": "^1.0.41",
     "nock": "^9.0.13",
+    "nyc": "^11.0.3",
     "portfinder": "^1.0.13",
     "proxyquire": "~1.8.0",
     "sass-lint": "^1.10.2",
@@ -109,6 +110,15 @@
     "standard": "^10.0.2",
     "superagent": "^3.5.2",
     "supertest": "^3.0.0"
+  },
+  "nyc": {
+    "reporter": "text",
+    "check-coverage": true,
+    "per-file": true,
+    "lines": 85,
+    "statements": 85,
+    "functions": 85,
+    "branches": 85
   },
   "snyk": true
 }

--- a/test/unit/template_engine.js
+++ b/test/unit/template_engine.js
@@ -1,0 +1,26 @@
+const path = require('path')
+const TemplateEngine = require(path.join(__dirname, '/../../lib/template-engine.js'))
+
+const chai = require('chai')
+const expect = chai.expect
+
+const dirViews = path.join(__dirname, '/../../app/views')
+const dirVendorViews = path.join(__dirname, '/../../app/views/layouts')
+
+describe('template engine', function () {
+  it('should render a template without errors', function () {
+    const templatePath = path.join(__dirname, '/../../app/views/charge.html')
+    const templateData = JSON.parse(`{"settings": {"views": "${encodeURI(dirViews)}","vendorViews": "${encodeURI(dirVendorViews)}"}}`)
+    TemplateEngine.__express(templatePath, templateData, function (error, output) {
+      expect(error).to.be.null // eslint-disable-line
+      expect(output).to.not.be.null // eslint-disable-line
+    })
+  })
+  it('should return an error for an invalid configuration', function () {
+    const invalidTemplateData = JSON.parse(`{"settings": {"views": "${encodeURI(dirViews)}","vendorViews": "${encodeURI(dirVendorViews)}"}}`)
+    TemplateEngine.__express('', invalidTemplateData, function (error, output) {
+      expect(output).to.be.null // eslint-disable-line
+      expect(error).to.not.be.null // eslint-disable-line
+    })
+  })
+})


### PR DESCRIPTION
…nts/functions/branches

## WHAT
I've added nyc/istanbul code coverage checking to our testing suite, as well as set minimum thresholds for coverage of 85%. We should be able to raise these to 90% in time as test coverage on a few areas outlined in the outputted report.

Unit tests for the template engine were added which previously had only 50% branch coverage, to bring it up to acceptable levels.

## HOW 
Clone and run 'npm run test' which will run all unit tests and output a coverage report.


