### PR TITLE
Fix base client test

### DIFF
--- a/app/utils/base_client.js
+++ b/app/utils/base_client.js
@@ -38,7 +38,9 @@ var _request = function request (methodName, url, args, callback) {
   let headers = {}
 
   headers['Content-Type'] = 'application/json'
-  headers[CORRELATION_HEADER_NAME] = args.correlationId
+  if (args.correlationId) {
+    headers[CORRELATION_HEADER_NAME] = args.correlationId
+  }
 
   const httpsOptions = {
     hostname: parsedUrl.hostname,


### PR DESCRIPTION
Had been failing with:

```
   1) base client should always set request content-type header to application/json:
      Error: "value" required in setHeader("x-request-id", value)
```

not sure why this started failing now, but seems reasonable to only attempt to
set the header if a value has been specified to the client