### PR TITLE
Bumping pay-product-page version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "winston": "2.3.x",
     "appmetrics": "1.1.2",
     "appmetrics-statsd": "1.0.1",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.3/pay-product-page-2.0.3.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.4/pay-product-page-2.0.4.tgz",
     "snyk": "^1.36.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We have a new release of pay product page with updated contact us copy