### PR TITLE
PP-2367 - Added JS to switch how many digits are allowed in CVC depending on card type

### DIFF
--- a/app/assets/javascripts/modules/form-card-type.js
+++ b/app/assets/javascripts/modules/form-card-type.js
@@ -11,6 +11,7 @@ var showCardType = function(){
   validations       = module.chargeValidation(i18n.chargeController.fieldErrors,console,window.Card);
   var cardValidation    = validations.creditCardType,
   cardTypes         = validations.allowedCards,
+  cvcInput          = form.find('#cvc'),
   amexCvcTip        = form.find('.amex-cvc'),
   genericCvcTip     = form.find('.generic-cvc');
 
@@ -18,6 +19,9 @@ var showCardType = function(){
     cardInput
       .on('blur',unselectIfNotAvailable)
       .on('keyup',showCardType);
+
+    cvcInput
+      .on('input', cvcTrim)
   },
 
   unselectIfNotAvailable = function(){
@@ -36,9 +40,11 @@ var showCardType = function(){
     checkAllowed(cardType);
     checkNumeric($(this).val(), number);
     cvcHighlight(); // to reset
+    cvcLength();
     if (cardType.length !== 1) return;
     cvcHighlight(cardType[0].type);
     selectCard(cardType[0].type);
+    cvcLength(cardType[0].type);
   },
 
   getCardType = function(){
@@ -93,6 +99,21 @@ var showCardType = function(){
     amexCvcTip.toggleClass('hidden',!isAmex);
     genericCvcTip.toggleClass('hidden',isAmex);
   },
+
+  cvcLength = function(type){
+    var isAmex = type === 'american-express';
+    if (isAmex) {
+      cvcInput.attr('maxlength', 4)
+    } else {
+      cvcInput.attr('maxlength', 3)
+    }
+  },
+
+  cvcTrim = function(){
+    if (this.value.length > this.maxLength) {
+      this.value = this.value.slice(0, this.maxLength);
+    }
+  }
 
   getSupportedChargeType = function(name){
     var card =  cards.filter('.' + name).first();

--- a/app/views/charge.html
+++ b/app/views/charge.html
@@ -147,6 +147,7 @@ Enter your card details.
                 value=""
                 name="cvc"
                 class="form-control-1-8 cvc"
+                maxlength="4"
                 autocomplete="cc-csc" />
               <img src="/images/security-code.png" class="generic-cvc" alt="Please enter either a 3 or 4 digit card security code"/>
               <span class="either hidden">


### PR DESCRIPTION
Added in a couple of functions to set how the length of number allowed in the CVC/CVV input depending on which card type is detected. 

`input[type="number"]` is not compatible with the `maxlength` atrribute so I wrote a function to polyfill this. For older browsers that ignore `input[type="number"]` and fallback to `input[type="text"]` the `maxlength` property will work as expected
