### PR TITLE
PP-2453 Make `customBranding` to expect/store JSON.

### DIFF
--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -21,7 +21,11 @@ class Service {
     this.externalId = serviceData.external_id
     this.name = serviceData.name
     this.gatewayAccountIds = serviceData.gateway_account_ids
-    this.customBranding = serviceData.custom_branding
+    this.customBranding =
+      serviceData.custom_branding ? {
+        cssUrl: serviceData.custom_branding.css_url,
+        imageUrl: serviceData.custom_branding.image_url
+      } : undefined
   }
 
   /**
@@ -33,7 +37,10 @@ class Service {
       external_id: this.externalId,
       name: this.name,
       gateway_account_ids: this.gatewayAccountIds,
-      custom_branding: this.custom_branding
+      custom_branding: this.customBranding ? {
+        css_url: this.customBranding.cssUrl,
+        image_url: this.customBranding.imageUrl
+      } : undefined
     }
   }
 

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -11,11 +11,12 @@ let random = require('../../app/utils/random')
 module.exports = {
 
   validServiceResponse: (serviceData = {}) => {
+    let defaultCustomBranding = {css_url: 'css url', image_url: 'image url'}
     let data = {
       external_id: serviceData.external_id || random.randomUuid(),
       name: serviceData.name || 'service name',
       gateway_account_ids: serviceData.gateway_account_ids || [random.randomInt()],
-      custom_branding: serviceData.custom_branding || 'custom branding'
+      custom_branding: serviceData.custom_branding || defaultCustomBranding
     }
 
     return {

--- a/test/unit/clients/adminusers_client_find_service_tests.js
+++ b/test/unit/clients/adminusers_client_find_service_tests.js
@@ -61,6 +61,8 @@ describe('adminusers client - services API', function () {
       it('should return service successfully', function (done) {
         adminusersClient.getServiceById(serviceExternalId).should.be.fulfilled.then(service => {
           expect(service.externalId).to.be.equal(serviceExternalId)
+          expect(service.customBranding.cssUrl).to.be.equal(getServiceResponse.getPlain().custom_branding.css_url)
+          expect(service.customBranding.imageUrl).to.be.equal(getServiceResponse.getPlain().custom_branding.image_url)
         }).should.notify(done)
       })
     })


### PR DESCRIPTION
For now, we are expecting/forcing to use only the following properties (`image_url` and `css_url`).

This is as per discussion with @jonheslop, where its better to have multiple attributes, than having everything loaded in one CSS. This allows us to expand to more customisations (e.g. two images) in future.

