### PR TITLE
PP-2533 Disable temporary accessible-autocomplete

### DIFF
--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,3 +1,3 @@
 window.jQuery = window.$ = require('jquery')
 module.exports.chargeValidation = require('./utils/charge_validation')
-module.exports.accessibleAutocomplete = require('./utils/accessible-autocomplete.js')
+// module.exports.accessibleAutocomplete = require('./utils/accessible-autocomplete.js')


### PR DESCRIPTION
## WHAT
- Not selecting the option value in the target HTML select element. So failing on postcode validation when selecting a country other than United Kingdom (default). This is not working in the example provided by them.
    See: https://alphagov.github.io/accessible-autocomplete/examples/
    	 `Progressive enhancement` example

- Selecting by clicking does not work.

