### PR TITLE
Update to use latest release of the product page

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "minimist": "1.2.x",
     "moment": "2.18.x",
     "morgan": "1.8.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.7/pay-product-page-2.0.7.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.8/pay-product-page-2.0.8.tgz",
     "q": "1.5.x",
     "randomstring": "^1.1.5",
     "readdir": "0.0.x",


### PR DESCRIPTION
Update to use version 2.0.8 of the product page, which has various additions and changes to the features page and the roadmap (including updates to reflect the quarterly cadence)