### PR TITLE
Bumping pay-product-page and adding check for .only in tests

### DIFF
--- a/docker/build_and_test.Dockerfile
+++ b/docker/build_and_test.Dockerfile
@@ -15,4 +15,4 @@ ADD package.json /tmp/package.json
 RUN cd /tmp && npm install
 WORKDIR /app
 
-CMD mkdir -p /app && cp -a /tmp/node_modules /app/ && npm run compile && npm test && npm prune --production
+CMD ./docker/build_and_test.sh

--- a/docker/build_and_test.sh
+++ b/docker/build_and_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+echo ''
+echo ''
+grep -rnw './test' -e 'it.only' && echo '' && echo 'ERROR: it.only() found in tests, Exiting' && exit 1
+grep -rnw './test' -e 'describe.only' && echo '' && echo 'ERROR: describe.only() found in tests, Exiting' && exit 1
+grep -rnw './test' -e 'context.only' && echo '' && echo 'ERROR: context.only() found in tests, Exiting' && exit 1
+
+mkdir -p /app &&\
+cp -a /tmp/node_modules /app/ &&\
+npm run compile &&\
+npm test &&\
+npm prune --production

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "minimist": "1.2.x",
     "moment": "2.18.x",
     "morgan": "1.8.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.10/pay-product-page-2.0.10.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.11/pay-product-page-2.0.11.tgz",
     "q": "1.5.x",
     "randomstring": "^1.1.5",
     "readdir": "0.0.x",


### PR DESCRIPTION
Updated product page with cookie message, this includes it in next build.

Max and I keep leaving in `.only` in unit tests so Max built a thing to check and fail builds if it’s present