### PR TITLE
PP-2572 Add cancel pages discriminators to ease testing

### DIFF
--- a/app/views/errors/incorrect_state/system_cancelled.html
+++ b/app/views/errors/incorrect_state/system_cancelled.html
@@ -9,7 +9,7 @@ Your Payment was cancelled
 <main id="content" class="content-wrapper error-pages grid-row">
   <div class="column-two-thirds">
 
-	<h1 class="heading-large">Payment cancelled</h1>
+	<h1 class="heading-large system-cancel">Payment cancelled</h1>
 	<p class="lede">Your payment has been cancelled by the government service. This may have happened for a number of reasons.</p>
 	<p class="lede"><a href="{{returnUrl}}" id="return-url">Go back to try the payment again</a></p>
 </div>

--- a/app/views/user_cancelled.html
+++ b/app/views/user_cancelled.html
@@ -7,7 +7,7 @@ Your payment has been cancelled
 
 <main id="content" class="content-wrapper error-pages grid-row">
     <div class="column-two-thirds">
-        <h1 class="heading-large"> Your payment has been cancelled </h1>
+        <h1 class="heading-large user-cancel"> Your payment has been cancelled </h1>
         <p class="lede">No money has been taken from your account</p>
         <a id="return-url" href="{{returnUrl}}" class="lede">Go back to the service</a>
         <p>You can try to pay again</p>


### PR DESCRIPTION
## WHAT

- Add css classes `user-cancel` and `system-cancel` to User cancelled and System cancelled pages respectively.

- This is to ease testing not relying in text displayed to the users (approach not recommended).

