### PR TITLE
PP-2572 Add system error class to error page to be able to easily detect

### DIFF
--- a/app/views/errors/system_error.html
+++ b/app/views/errors/system_error.html
@@ -8,7 +8,7 @@ An error occurred
 
 <main id="content" class="content-wrapper error-pages grid-row">
 <div class="column-two-thirds">
-  <h1 class="heading-large">Sorry, we're experiencing technical problems</h1>
+  <h1 class="heading-large system-error">Sorry, we're experiencing technical problems</h1>
   {{^returnUrl}}
   <p class="lede">No money has been taken from your account, please try again later.</p>
   {{/returnUrl}}


### PR DESCRIPTION
## WHAT
There is no easy way to detect if we're showing the error page when we run our end-to-end tests. To solve this problem a 'system-error' class has been added to the message shown on that page.


