### PR TITLE
PP-2712 Upgrade serve-favicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "readdir": "0.0.x",
     "requestretry": "^1.12.0",
     "rfc822-validate": "1.0.x",
-    "serve-favicon": "2.4.3",
+    "serve-favicon": "2.4.5",
     "staticify": "0.0.8",
     "string": "3.3.x",
     "throng": "4.0.x",


### PR DESCRIPTION
Snyk is reporting a vulnerability in `fresh`
included through `serve-favicon`
https://snyk.io/vuln/npm:fresh:20170908

Upgrading to 2.4.5 fixes this.