### PR TITLE
PP-2798 Order territories alphabetically

### DIFF
--- a/app/services/countries.js
+++ b/app/services/countries.js
@@ -22,4 +22,4 @@ countries.forEach((country, i) => {
 })
 
 countries = lodash.compact(countries)
-countries = lodash.sortBy(countries, country => country.entry.name.toLowerCase()).reverse()
+countries = lodash.sortBy(countries, country => country.entry.name.toLowerCase())

--- a/locales/en.json
+++ b/locales/en.json
@@ -86,7 +86,7 @@
     "building": "Building number or name and street",
     "city": "Town or city",
     "postcode": "Postcode",
-    "country": "Country",
+    "country": "Country or territory",
     "email": "Email",
     "cvcTip": "The last 3 digits on the back of the card",
     "amexcvcTip": "The last 4 digits after the card number on the front",

--- a/test/services/countries_test.js
+++ b/test/services/countries_test.js
@@ -1,0 +1,12 @@
+const path = require('path')
+const expect = require('chai').expect
+const countries = require(path.join(__dirname, '/../../app/services/countries.js'))
+
+describe('retrieveCountries', function () {
+  it('should list of countries ordered', function () {
+    let retrievedCountries = countries.retrieveCountries()
+
+    expect(retrievedCountries[0].entry.country).to.eql('AF')
+    expect(retrievedCountries[1].entry.country).to.eql('AX')
+  })
+})


### PR DESCRIPTION
## WHAT
- Order alphabetically. Somehow the order was reversed and we can't find reasons why.

-  User 'Country or territory' in favour of just 'Country' as label in Enter card details.

