### PR TITLE
PP-2758 Change “Aland Islands” to “Åland Islands” (note “Å”)

### DIFF
--- a/app/data/countries.json
+++ b/app/data/countries.json
@@ -1172,7 +1172,7 @@
   {
     "entry": {
       "country": "AX",
-      "name": "Aland Islands"
+      "name": "Åland Islands"
     }
   },
   {

--- a/test/services/countries_test.js
+++ b/test/services/countries_test.js
@@ -7,6 +7,6 @@ describe('retrieveCountries', function () {
     let retrievedCountries = countries.retrieveCountries()
 
     expect(retrievedCountries[0].entry.country).to.eql('AF')
-    expect(retrievedCountries[1].entry.country).to.eql('AX')
+    expect(retrievedCountries[1].entry.country).to.eql('AL')
   })
 })


### PR DESCRIPTION
In the country and territories list, change “Aland Islands” to “Åland Islands” (note the “Å”)

See https://territory.register.gov.uk/record/AX