### PR TITLE
PP-2687 Ignore snyk issue

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,6 +1,11 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.7.0
-ignore: {}
+version: v1.7.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'npm:timespan:20170907':
+    - '*':
+        reason: No exposure. Transitive dependency pulled from forever dependency.
+        expires: 2018-01-20T00:00:00.000Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:ms:20170412':

--- a/.snyk
+++ b/.snyk
@@ -5,7 +5,7 @@ ignore:
   'npm:timespan:20170907':
     - '*':
         reason: Transitive dependency pulled in by Forever. Vulnerability does not affect us because it requires a specially-crafted input string and Forever only ever uses input from the system clock. See PP-2687.
-        expires: 2018-01-20T00:00:00.000Z
+        expires: 2017-11-20T00:00:00.000Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   'npm:ms:20170412':

--- a/.snyk
+++ b/.snyk
@@ -4,7 +4,7 @@ version: v1.7.1
 ignore:
   'npm:timespan:20170907':
     - '*':
-        reason: No exposure. Transitive dependency pulled from forever dependency.
+        reason: Transitive dependency pulled in by Forever. Vulnerability does not affect us because it requires a specially-crafted input string and Forever only ever uses input from the system clock. See PP-2687.
         expires: 2018-01-20T00:00:00.000Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:


### PR DESCRIPTION
## WHAT
As specified in the ticket, after investigation we can tell that we have no exposure for the issue found for the dependency 'npm:timespan:20170907'.

We don't want to keep the alert to avoid that another person on support wastes time investigating the issue again. Considering that there's no fix for this issue yet, we decided to ignore the issue for a given period of time and the revisit to check if it applies.
 
In order to ignore the issue the snyk client has to be installed and the ignore the desired dependency by running:

```
snyk ignore --id=npm:timespan:20170907 --expiry='2018-01-20' --reason='No exposure. Transitive dependency pulled from forever dependency.'
```

That will modify the existing .snyk file in the repo to tell Snyk to ignore that issue.

