### PR TITLE
PP-2688 Add merchant details

### DIFF
--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -16,7 +16,6 @@ class Service {
    * @returns {Object} service - internal representation of the service object
    **/
   constructor (serviceData) {
-    console.log(serviceData.merchant_details.address_country)
     this.externalId = serviceData.external_id
     this.name = serviceData.name
     this.gatewayAccountIds = serviceData.gateway_account_ids

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -39,7 +39,20 @@ class Service {
    * @returns {boolean} if the service got a non-GOV.UK branding
    */
   hasCustomBranding () {
-    return !_.isEmtpy(this.customBranding)
+    return !_.isEmpty(this.customBranding)
+  }
+
+  /**
+   * @method hasMerchantDetails
+   *
+   * All services must have merchant details defined for all gateway accounts
+   * This will be kept as backward compatibility until merchant details are
+   * enforced.
+   *
+   * @returns {boolean} if the service got merchant details specified
+   */
+  hasMerchantDetails () {
+    return !_.isEmpty(this.merchantDetails)
   }
 }
 

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -1,5 +1,6 @@
 'use strict'
 const _ = require('lodash')
+const countries = require('../services/countries')
 
 /**
  @class Service
@@ -12,12 +13,10 @@ class Service {
   /**
    * Create an instance of Service
    * @param {Object} serviceData - raw 'service' object from server
-   * @param {string} serviceData.external_id - The external ID of the service
-   * @param {string} serviceData.name - The name of the service
-   * @param {string[]} serviceData.gateway_account_ids - list of gateway account id's that belong to this service
-   * @property {string} customBranding -  custom (non-GOV.UK) styling for the service.
+   * @returns {Object} service - internal representation of the service object
    **/
   constructor (serviceData) {
+    console.log(serviceData.merchant_details.address_country)
     this.externalId = serviceData.external_id
     this.name = serviceData.name
     this.gatewayAccountIds = serviceData.gateway_account_ids
@@ -26,22 +25,14 @@ class Service {
         cssUrl: serviceData.custom_branding.css_url,
         imageUrl: serviceData.custom_branding.image_url
       } : undefined
-  }
-
-  /**
-   * @method toJson
-   * @returns {Object} An 'adminusers' compatible representation of the service
-   */
-  toJson () {
-    return {
-      external_id: this.externalId,
-      name: this.name,
-      gateway_account_ids: this.gatewayAccountIds,
-      custom_branding: this.customBranding ? {
-        css_url: this.customBranding.cssUrl,
-        image_url: this.customBranding.imageUrl
-      } : undefined
-    }
+    this.merchantDetails = serviceData.merchant_details ? {
+      name: serviceData.merchant_details.name,
+      addressLine1: serviceData.merchant_details.address_line1,
+      addressLine2: serviceData.merchant_details.address_line2,
+      city: serviceData.merchant_details.address_city,
+      postcode: serviceData.merchant_details.address_postcode,
+      countryName: countries.translateAlpha2(serviceData.merchant_details.address_country)
+    } : undefined
   }
 
   /**

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -15,38 +15,6 @@ module.exports = function (clientOptions = {}) {
 
   /**
    *
-   * @param serviceExternalId
-   * @returns {*|promise}
-   */
-  const getServiceById = (serviceExternalId) => {
-    const params = {
-      correlationId: correlationId
-    }
-    const url = `${servicesResource}/${serviceExternalId}`
-    const defer = q.defer()
-    const startTime = new Date()
-    const context = {
-      url: url,
-      defer: defer,
-      startTime: startTime,
-      correlationId: correlationId,
-      method: 'GET',
-      description: 'get a service',
-      service: SERVICE_NAME
-    }
-
-    const callbackToPromiseConverter = createCallbackToPromiseConverter(context, responseBodyToServiceTransformer)
-
-    requestLogger.logRequestStart(context)
-
-    baseClient.get(url, params, callbackToPromiseConverter)
-      .on('error', callbackToPromiseConverter)
-
-    return defer.promise
-  }
-
-  /**
-   *
    * @param findOptions - for now only `findOptions.gatewayAccountId` property is supported
    */
   const findServiceBy = (findOptions) => {
@@ -81,7 +49,6 @@ module.exports = function (clientOptions = {}) {
   }
 
   return {
-    getServiceById: getServiceById,
     findServiceBy: findServiceBy
   }
 }

--- a/app/utils/views.js
+++ b/app/utils/views.js
@@ -214,6 +214,10 @@ module.exports = (function () {
         locals.customBranding = _.get(res.locals, 'service.customBranding')
       }
 
+      if (_.get(res.locals, 'service.hasMerchantDetails', false)) {
+        locals.merchantDetails = _.get(res.locals, 'service.merchantDetails')
+      }
+
       if (_.get(locals, 'analytics.path')) {
         locals.analytics.path = locals.analytics.path + _.get(action, 'analyticsPage', '')
       }

--- a/app/views/includes/merchant_details.html
+++ b/app/views/includes/merchant_details.html
@@ -1,0 +1,8 @@
+{{#service.merchantDetails?}}
+<div class="footer-meta">
+    <div class="footer-meta-inner">
+        <p>Service provided by {{name}} Service</p>
+        <p>{{addressLine1}}, {{#addressLine2}}{{addressLine2}},{{/addressLine2}} {{city}} {{postcode}} {{countryName}}</p>
+    </div>
+</div>
+{{/service.merchantDetails}}

--- a/app/views/includes/merchant_details.html
+++ b/app/views/includes/merchant_details.html
@@ -1,8 +1,7 @@
-{{#service.merchantDetails?}}
-<div class="footer-meta">
-    <div class="footer-meta-inner">
-        <p>Service provided by {{name}} Service</p>
-        <p>{{addressLine1}}, {{#addressLine2}}{{addressLine2}},{{/addressLine2}} {{city}} {{postcode}} {{countryName}}</p>
-    </div>
-</div>
-{{/service.merchantDetails}}
+{{#merchantDetails}}
+<ul>
+    <li class="merchant-details-line-1">Service provided by {{merchantDetails.name}} Service</li>
+    <li class="merchant-details-line-2">{{merchantDetails.addressLine1}}, {{#merchantDetails.addressLine2}}{{merchantDetails.addressLine2}},{{/merchantDetails.addressLine2}} {{merchantDetails.city}}
+        {{merchantDetails.postcode}} {{merchantDetails.countryName}}</li>
+</ul>
+{{/merchantDetails}}

--- a/app/views/includes/privacy_policy.html
+++ b/app/views/includes/privacy_policy.html
@@ -1,0 +1,3 @@
+<ul>
+    <li><a href="/privacy">Privacy policy</a></li>
+</ul>

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -33,6 +33,11 @@
 {{$bodyEnd}}
 {{>includes/scripts}}
 {{/bodyEnd}}
+
+{{$footerTop}}
+{{>includes/merchant_details}}
+{{$footerTop}}
+
 {{$footerSupportLinks}}
 <ul><li><a href="/privacy">Privacy policy</a></li></ul>
 {{/footerSupportLinks}}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -34,12 +34,9 @@
 {{>includes/scripts}}
 {{/bodyEnd}}
 
-{{$footerTop}}
-{{>includes/merchant_details}}
-{{$footerTop}}
-
 {{$footerSupportLinks}}
-<ul><li><a href="/privacy">Privacy policy</a></li></ul>
+{{>includes/merchant_details}}
+{{>includes/privacy_policy}}
 {{/footerSupportLinks}}
 
 {{/govuk_template}}

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -11,7 +11,8 @@ let random = require('../../app/utils/random')
 module.exports = {
   validServiceResponse: (serviceData = {}) => {
     let defaultCustomBranding = {css_url: 'css url', image_url: 'image url'}
-    let defaultMerchantDetais = { name: 'Give Me Your Money',
+    let defaultMerchantDetais = {
+      name: 'Give Me Your Money',
       address_line1: 'Clive House',
       address_line2: '10 Downing Street',
       address_city: 'London',

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -9,14 +9,21 @@ const pactServices = pactBase({array: ['service_ids']})
 let random = require('../../app/utils/random')
 
 module.exports = {
-
   validServiceResponse: (serviceData = {}) => {
     let defaultCustomBranding = {css_url: 'css url', image_url: 'image url'}
+    let defaultMerchantDetais = { name: 'Give Me Your Money',
+      address_line1: 'Clive House',
+      address_line2: '10 Downing Street',
+      address_city: 'London',
+      address_postcode: 'AW1H 9UX',
+      address_country: 'GB'
+    }
     let data = {
       external_id: serviceData.external_id || random.randomUuid(),
       name: serviceData.name || 'service name',
       gateway_account_ids: serviceData.gateway_account_ids || [random.randomInt()],
-      custom_branding: serviceData.custom_branding || defaultCustomBranding
+      custom_branding: serviceData.custom_branding || defaultCustomBranding,
+      merchant_details: serviceData.merchant_details || defaultMerchantDetais
     }
 
     return {

--- a/test/models/service_test.js
+++ b/test/models/service_test.js
@@ -1,0 +1,29 @@
+const path = require('path')
+const assert = require('assert')
+const Service = require(path.join(__dirname, '/../../app/models/Service.class'))
+
+describe('Service model from service raw data', function () {
+  let serviceModel
+
+  before('Create Service from raw data', function () {
+    let data = {
+      external_id: '1234',
+      name: 'service name',
+      gateway_account_ids: [1],
+      custom_branding: {css_url: 'css url', image_url: 'image url'},
+      merchant_details: {
+        name: 'Give Me Your Money',
+        address_line1: 'Clive House',
+        address_line2: '10 Downing Street',
+        address_city: 'London',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
+      }
+    }
+    serviceModel = new Service(data)
+  })
+
+  it('should contain expected merchant details country name', function () {
+    assert.equal(serviceModel.merchantDetails.countryName, 'United Kingdom')
+  })
+})

--- a/test/models/service_test.js
+++ b/test/models/service_test.js
@@ -1,11 +1,9 @@
 const path = require('path')
-const assert = require('assert')
+const expect = require('chai').expect
 const Service = require(path.join(__dirname, '/../../app/models/Service.class'))
 
 describe('Service model from service raw data', function () {
-  let serviceModel
-
-  before('Create Service from raw data', function () {
+  it('should contain expected merchant details country name', function () {
     let data = {
       external_id: '1234',
       name: 'service name',
@@ -20,10 +18,22 @@ describe('Service model from service raw data', function () {
         address_country: 'GB'
       }
     }
-    serviceModel = new Service(data)
+
+    let serviceModel = new Service(data)
+
+    expect(serviceModel.merchantDetails.countryName).to.equal('United Kingdom')
   })
 
-  it('should contain expected merchant details country name', function () {
-    assert.equal(serviceModel.merchantDetails.countryName, 'United Kingdom')
+  it('should return merchant details as undefined when not in raw data', function () {
+    let data = {
+      external_id: '1234',
+      name: 'service name',
+      gateway_account_ids: [1],
+      custom_branding: {css_url: 'css url', image_url: 'image url'}
+    }
+
+    let serviceModel = new Service(data)
+
+    expect(serviceModel.merchantDetails).to.equal(undefined)
   })
 })

--- a/test/services/countries_test.js
+++ b/test/services/countries_test.js
@@ -2,11 +2,15 @@ const path = require('path')
 const expect = require('chai').expect
 const countries = require(path.join(__dirname, '/../../app/services/countries.js'))
 
-describe('retrieveCountries', function () {
+describe('countries', function () {
   it('should list of countries ordered', function () {
     let retrievedCountries = countries.retrieveCountries()
 
     expect(retrievedCountries[0].entry.country).to.eql('AF')
     expect(retrievedCountries[1].entry.country).to.eql('AL')
+  })
+
+  it('should translate country code to name', function () {
+    expect(countries.translateAlpha2('GB')).to.eql('United Kingdom')
   })
 })

--- a/test/unit/clients/adminusers_client_find_service_tests.js
+++ b/test/unit/clients/adminusers_client_find_service_tests.js
@@ -57,14 +57,6 @@ describe('adminusers client - services API', function () {
       afterEach((done) => {
         adminUsersMock.finalize().then(() => done())
       })
-
-      it('should return service successfully', function (done) {
-        adminusersClient.getServiceById(serviceExternalId).should.be.fulfilled.then(service => {
-          expect(service.externalId).to.be.equal(serviceExternalId)
-          expect(service.customBranding.cssUrl).to.be.equal(getServiceResponse.getPlain().custom_branding.css_url)
-          expect(service.customBranding.imageUrl).to.be.equal(getServiceResponse.getPlain().custom_branding.image_url)
-        }).should.notify(done)
-      })
     })
 
     context('GET service - not found', function () {
@@ -82,10 +74,6 @@ describe('adminusers client - services API', function () {
 
       afterEach((done) => {
         adminUsersMock.finalize().then(() => done())
-      })
-
-      it('should error 404', function (done) {
-        adminusersClient.getServiceById(serviceExternalId).should.be.rejected.should.notify(done)
       })
     })
   })

--- a/test/utils/views_test.js
+++ b/test/utils/views_test.js
@@ -14,6 +14,16 @@ describe('views helper', function () {
       imageUrl: service.custom_branding.image_url
     }
   }
+  const expectedDefaultMerchantDetails = {
+    merchantDetails: {
+      name: 'Give Me Your Money',
+      addressLine1: 'Clive House',
+      addressLine2: '10 Downing Street',
+      city: 'London',
+      postcode: 'AW1H 9UX',
+      countryName: 'United Kingdom'
+    }
+  }
 
   var response = {
     status: function () {},
@@ -44,7 +54,7 @@ describe('views helper', function () {
     var _views = views.create(testView)
     _views.display(response, 'TEST_VIEW')
     assert(status.calledWith(999))
-    assert(render.calledWith('TEST_VIEW', _.merge({viewName: 'TEST_VIEW'}, expectedDefaultCustomBranding)))
+    assert(render.calledWith('TEST_VIEW', _.merge({viewName: 'TEST_VIEW'}, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
   })
 
   it('should return a 200 by default', function () {
@@ -53,7 +63,7 @@ describe('views helper', function () {
     var _views = views.create(view)
     _views.display(response, 'TEST_VIEW')
     assert(status.calledWith(200))
-    assert(render.calledWith('TEST_VIEW', _.merge({viewName: 'TEST_VIEW'}, expectedDefaultCustomBranding)))
+    assert(render.calledWith('TEST_VIEW', _.merge({viewName: 'TEST_VIEW'}, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
   })
 
   it('should return locals passed in', function () {
@@ -61,7 +71,7 @@ describe('views helper', function () {
     var _views = views.create(view)
     _views.display(response, 'TEST_VIEW', {a: 'local'})
     assert(status.calledWith(999))
-    assert(render.calledWith('TEST_VIEW', _.merge({viewName: 'TEST_VIEW', a: 'local'}, expectedDefaultCustomBranding)))
+    assert(render.calledWith('TEST_VIEW', _.merge({viewName: 'TEST_VIEW', a: 'local'}, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
   })
 
   it('should rendor error view when view not found', function () {
@@ -71,7 +81,7 @@ describe('views helper', function () {
     assert(render.calledWith('error', _.merge({
       message: 'There is a problem, please try again later',
       viewName: 'error'
-    }, expectedDefaultCustomBranding)))
+    }, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
   })
 
   var defaultTemplates = {
@@ -101,7 +111,7 @@ describe('views helper', function () {
         assert(render.calledWith(values.template, _.merge({
           message: values.message,
           viewName: name
-        }, expectedDefaultCustomBranding)))
+        }, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
       })
 
       it('should be able to ovverride the default ' + name + ' message', function () {
@@ -111,7 +121,7 @@ describe('views helper', function () {
         assert(render.calledWith(values.template, _.merge({
           message: 'lol',
           viewName: name
-        }, expectedDefaultCustomBranding)))
+        }, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
       })
 
       it('should be able to ovverride the default ' + name + ' template', function () {
@@ -120,7 +130,7 @@ describe('views helper', function () {
         var _views = views.create(overriden)
         _views.display(response, name, {message: 'lol'})
         assert(status.calledWith(333))
-        assert(render.calledWith('foo', _.merge({message: 'lol', viewName: name}, expectedDefaultCustomBranding)))
+        assert(render.calledWith('foo', _.merge({message: 'lol', viewName: name}, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
       })
     }
   )


### PR DESCRIPTION
## WHAT
- Add merchant details above privacy info in footer area.
- Extract privacy info into a separated template.
- Add merchant details to Service object class **when available.** Added _isEmpty_ method to check whether merchant details exist so it is backward compatible (current services do not include merchant details, a test account might not have them but live account must have merchant details available).

