### PR TITLE
2.0.12 release tarball was corrupt generated a new clean one

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "minimist": "1.2.x",
     "moment": "2.18.x",
     "morgan": "1.8.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.12/pay-product-page-2.0.12.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.13/pay-product-page-2.0.13.tgz",
     "q": "1.5.x",
     "randomstring": "^1.1.5",
     "readdir": "0.0.x",


### PR DESCRIPTION
pay-product-page 2.0.12 was corrupt so I just made a new clean on and marked it 2.0.13
