### PR TITLE
PP-2688 Merchant details CSS changes

### DIFF
--- a/app/assets/sass/pages/card-details.scss
+++ b/app/assets/sass/pages/card-details.scss
@@ -59,3 +59,11 @@
   cursor: pointer;
   font-size: 19px;
 }
+
+#footer .footer-meta .footer-meta-inner {
+  .merchant-details,
+  .merchant-details-line-1,
+  .merchant-details-line-2 {
+    display: block;
+  }
+}

--- a/app/views/includes/merchant_details.html
+++ b/app/views/includes/merchant_details.html
@@ -1,5 +1,5 @@
 {{#merchantDetails}}
-<ul>
+<ul class="merchant-details">
     <li class="merchant-details-line-1">Service provided by {{merchantDetails.name}}</li>
     <li class="merchant-details-line-2">{{merchantDetails.addressLine1}}, {{#merchantDetails.addressLine2}}{{merchantDetails.addressLine2}},{{/merchantDetails.addressLine2}} {{merchantDetails.city}}
         {{merchantDetails.postcode}} {{merchantDetails.countryName}}</li>


### PR DESCRIPTION
## WHAT

Use `display: block` to display the merchant details name and address on two lines when `address line 2` is not provided.

with @jonheslop 