### PR TITLE
Use typographic apostrophe in email field hint

### DIFF
--- a/app/views/charge.html
+++ b/app/views/charge.html
@@ -271,7 +271,7 @@ Enter your card details.
                 data-original-label="{{ i18n.chargeView.email }}">
                 {{ i18n.chargeView.email }}
               </span>
-              <span class="form-hint">We'll send your payment confirmation here</span>
+              <span class="form-hint">We’ll send your payment confirmation here</span>
 
               {{#highlightErrorFields.email}}
                 <p class="error-message" id="error-email">


### PR DESCRIPTION
> “Smart quotes,” the correct quotation marks and apostrophes, are curly or sloped. "Dumb quotes," or straight quotes, are a vestigial constraint from typewriters when using one key for two different marks helped save space on a keyboard. Unfortunately, many improper marks make their way onto websites because of dumb defaults in applications and CMSs.

– http://smartquotesforsmartpeople.com/

This commit replaces an instance of a straight single quote used as an apostrophe (') with the unicode character for a proper typographic apostrophe (’).

I haven’t looked for other occurrences of this happening on this page or in this repo.