### PR TITLE
PP-2932 - Use proper typographic apostrophes not primes

### DIFF
--- a/app/views/charge.html
+++ b/app/views/charge.html
@@ -271,7 +271,7 @@ Enter your card details.
                 data-original-label="{{ i18n.chargeView.email }}">
                 {{ i18n.chargeView.email }}
               </span>
-              <span class="form-hint">We'll send your payment confirmation here</span>
+              <span class="form-hint">We’ll send your payment confirmation here</span>
 
               {{#highlightErrorFields.email}}
                 <p class="error-message" id="error-email">

--- a/app/views/errors/charge_confirm_state_completed.html
+++ b/app/views/errors/charge_confirm_state_completed.html
@@ -12,7 +12,7 @@ Your payment was {{status}}
 <div class="column-two-thirds">
 
 <h1 class="heading-large {{status}}"> Your payment was {{status}} </h1>
-<p class="lede">To make any changes to your payment you'll need to contact the service.</p>
+<p class="lede">To make any changes to your payment you’ll need to contact the service.</p>
 
 
 <a href="{{returnUrl}}" id="return-url" class="lede"> View your payment summary </a>

--- a/app/views/errors/incorrect_state/charge_completed.html
+++ b/app/views/errors/incorrect_state/charge_completed.html
@@ -9,7 +9,7 @@ Your payment was {{status}}
 <main id="content" class="content-wrapper">
 
 <h1 class="page-title {{status}}"> Your payment was {{status}} </h1>
-<p>To make any changes to your payment you'll need to contact the service.</p>
+<p>To make any changes to your payment you’ll need to contact the service.</p>
 
 
 <a href="{{returnUrl}}" id="return-url"> view your payment summary </a>

--- a/app/views/errors/system_error.html
+++ b/app/views/errors/system_error.html
@@ -8,7 +8,7 @@ An error occurred
 
 <main id="content" class="content-wrapper error-pages grid-row">
 <div class="column-two-thirds">
-  <h1 class="heading-large system-error">Sorry, we're experiencing technical problems</h1>
+  <h1 class="heading-large system-error">Sorry, we’re experiencing technical problems</h1>
   {{^returnUrl}}
   <p class="lede">No money has been taken from your account, please try again later.</p>
   {{/returnUrl}}


### PR DESCRIPTION
Thanks to @quis for spotting this.

> “Smart quotes,” the correct quotation marks and apostrophes, are curly
> or sloped. "Dumb quotes," or straight quotes, are a vestigial
> constraint from typewriters when using one key for two different marks
> helped save space on a keyboard. Unfortunately, many improper marks
> make their way onto websites because of dumb defaults in applications
> and CMSs.

– http://smartquotesforsmartpeople.com/

This commit replaces an instance of a straight single quote used as
an apostrophe `'` with the unicode character for a proper typographic
apostrophe `’`.
