### PR TITLE
PP-2867 - Disable submit on first click to stop errors

### DIFF
--- a/app/assets/javascripts/modules/form-validation.js
+++ b/app/assets/javascripts/modules/form-validation.js
@@ -33,7 +33,10 @@ var formValidation = function () {
 
       showCardType().checkCardtypeIsAllowed().then(
         function () {
-          if (!validations.hasError) return form.submit()
+          if (!validations.hasError) {
+            $('#submit-card-details').attr('disabled', 'disabled')
+            return form.submit()
+          }
           addValidationsErrors()
         },
         function (error) {
@@ -107,8 +110,7 @@ var formValidation = function () {
         groupHasError = getFormGroup(input).hasClass('error'),
         lastOfgroup = $(input).is('[data-last-of-form-group]'),
         required = $(input).is('[data-required]')
-      if ((lastOfgroup && required) || groupHasError)
-        return checkValidation(input)
+      if ((lastOfgroup && required) || groupHasError) { return checkValidation(input) }
       if (inGroup || blank) return
       checkValidation(input)
     },

--- a/app/assets/javascripts/modules/stop-double-submission.js
+++ b/app/assets/javascripts/modules/stop-double-submission.js
@@ -1,0 +1,22 @@
+(function () {
+  'use strict'
+  var root = this
+  if (typeof root.GOVUK === 'undefined') { root.GOVUK = {} }
+
+  // Stop users double submitting payment charge as causes errors on slow connections
+  var disableAfterSubmit = {
+    init: function () {
+      var $button = $('[data-module="stop-double-submit"]')
+      if ($button.length) {
+        disableAfterSubmit.watch($button)
+      }
+    },
+    watch: function (element) {
+      var $form = element.parents('form')
+      $form.submit(function (e) {
+        element.attr('disabled', 'disabled')
+      })
+    }
+  }
+  root.GOVUK.stopDoubleSubmit = disableAfterSubmit
+}).call(this)

--- a/app/views/confirm.html
+++ b/app/views/confirm.html
@@ -48,7 +48,7 @@ Confirm your details.
     <form id="confirmation" method="POST" action="{{confirmPath}}" class="form">
         <input id="csrf" name="csrfToken" type="hidden" value="{{csrf}}" />
         <input id="chargeId" name="chargeId" type="hidden" value="{{charge.id}}" />
-        <button id="confirm" class="button">Confirm payment</button>
+        <button id="confirm" class="button" data-module="stop-double-submit">Confirm payment</button>
     </form>
     <form id="cancel" name="cancel" method="POST" action="{{post_cancel_action}}" class="form">
         <div>

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -6,6 +6,7 @@
 <script type="text/javascript">
   $(function(){
     GOVUK.stickAtTopWhenScrolling.init();
+    GOVUK.stopDoubleSubmit.init();
     if ($('main').hasClass('charge-new')) {
       $( document ).ready(function() {
         {{#cardsAsStrings}}


### PR DESCRIPTION
If a user double clicks either of the submit buttons on
pay-frontend (the continue button and confirm button)
then they get an error as the server freaks out about a
double charge, so I’ve made a GOV.UK JS Module thing that
stops this it can be applied with `data-module="stop-double-submit"`

The charge page has its own complex validation which hijacks the
submit event so rather than use the component I added in a line
to disable it if a form is validated successfully.

