### PR TITLE
Bumping version to correct incorrect case

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "minimist": "1.2.x",
     "moment": "2.18.x",
     "morgan": "1.8.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.14/pay-product-page-2.0.14.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.15/pay-product-page-2.0.15.tgz",
     "q": "1.5.x",
     "randomstring": "^1.1.5",
     "readdir": "0.0.x",


### PR DESCRIPTION
Minor copy tweaks

Updated pay-product-page version to include:
Case fix for "Get Started" to "Get started" — https://github.com/alphagov/pay-product-page/commit/ae9600e886ec1b287c9d0b274faa177aad43a46e

Add `&nbsp;`’s to stop GOV.UK Pay splitting across two lines — https://github.com/alphagov/pay-product-page/commit/18871fa985d372e914034f646589f255a09ce8bb