### PR TITLE
PP-3020 Fix failing e2e

### DIFF
--- a/test/nightwatch/tests/charge_validation_form_group.js
+++ b/test/nightwatch/tests/charge_validation_form_group.js
@@ -30,7 +30,7 @@ module.exports = {
   'error label gets replaced when in error state and you fix it without leaving the form group': function (browser) {
     var cardDetails = browser.page.payment_new()
     cardDetails
-      .setValue('@expiryYear', '17')
+      .setValue('@expiryYear', '21')
       .click('@addressLine1')
     cardDetails.expect.element('@expiryLabel').text.to.contain('Enter a valid expiry date').before(100)
     cardDetails


### PR DESCRIPTION
- Update card expiry date for test data. It was set for
`11/17` and today is `12/17`

- Updated to 11/21



