### PR TITLE
PP-3022 - Wrapping input/selects in their label element causes accessibility issues

### DIFF
--- a/app/views/charge.html
+++ b/app/views/charge.html
@@ -34,15 +34,15 @@ Enter your card details.
                     {{highlightErrorFields.cardNo}}
                 </p>
               {{/highlightErrorFields.cardNo}}
-              <input id="card-no"
-                type="tel"
-                name="cardNo"
-                maxlength="26"
-                class="form-control-1-2"
-                autocomplete="cc-number"
-                val=""
-              />
           </label>
+          <input id="card-no"
+            type="tel"
+            name="cardNo"
+            maxlength="26"
+            class="form-control-1-2"
+            autocomplete="cc-number"
+            val=""
+          />
           <ul class="accepted-cards field-empty">
             {{#allowedCards}}
             <li
@@ -73,27 +73,27 @@ Enter your card details.
             {{ i18n.chargeView.expiry }}
           </label>
           <p class="form-hint-bold form-hint">For example, 10/20</p>
-              {{#highlightErrorFields.expiryMonth}}
-                <p class="error-message" id="error-expiry-date">
-                    {{highlightErrorFields.expiryMonth}}
-                </p>
-              {{/highlightErrorFields.expiryMonth}}
-              <div class="date-container">
-                <label class="form-hint" for="expiry-month"> Month </label>
-                <input id="expiry-month" type="number" name="expiryMonth"
-                class="form-control"
-                min="1" max="12" minlength="1" maxlength="2"  autocomplete="cc-exp-month"/>
-                <p class="seperator"> / </p>
-              </div>
-              <div class="date-container">
-                <div class="form-hint"> Year </div>
-                <input id="expiry-year" type="number" name="expiryYear" minlength="2" maxlength="4"
-                class="form-control"
-                autocomplete="cc-exp-year"
-                data-last-of-form-group
-                data-required
-                />
-              </div>
+          {{#highlightErrorFields.expiryMonth}}
+            <p class="error-message" id="error-expiry-date">
+                {{highlightErrorFields.expiryMonth}}
+            </p>
+          {{/highlightErrorFields.expiryMonth}}
+          <div class="date-container">
+            <label class="form-hint" for="expiry-month"> Month </label>
+            <input id="expiry-month" type="number" name="expiryMonth"
+            class="form-control"
+            min="1" max="12" minlength="1" maxlength="2"  autocomplete="cc-exp-month"/>
+            <p class="seperator"> / </p>
+          </div>
+          <div class="date-container">
+            <div class="form-hint"> Year </div>
+            <input id="expiry-year" type="number" name="expiryYear" minlength="2" maxlength="4"
+            class="form-control"
+            autocomplete="cc-exp-year"
+            data-last-of-form-group
+            data-required
+            />
+          </div>
       </div>
       <div class="form-group{{#highlightErrorFields.cardholderName}} error{{/highlightErrorFields.cardholderName}}"
       data-validation="cardholderName">
@@ -109,14 +109,14 @@ Enter your card details.
                     {{highlightErrorFields.cardholderName}}
                   </p>
               {{/highlightErrorFields.cardholderName}}
-              <input id="cardholder-name"
-                      type="text"
-                      name="cardholderName"
-                      maxlength="200"
-                      class="form-control-1-2 form-control"
-                      value="{{ cardholderName }}"
-                      autocomplete="cc-name" />
           </label>
+          <input id="cardholder-name"
+                  type="text"
+                  name="cardholderName"
+                  maxlength="200"
+                  class="form-control-1-2 form-control"
+                  value="{{ cardholderName }}"
+                  autocomplete="cc-name" />
       </div>
       <div class="form-group{{#highlightErrorFields.cvc}} error{{/highlightErrorFields.cvc}} cvc" data-validation="cvc">
           <label id="cvc-lbl" for="cvc" class="form-label-bold">
@@ -142,19 +142,19 @@ Enter your card details.
                         {{highlightErrorFields.cvc}}
                   </p>
               {{/highlightErrorFields.cvc}}
-              <input id="cvc"
-                type="number"
-                value=""
-                name="cvc"
-                class="form-control-1-8 cvc"
-                maxlength="4"
-                autocomplete="cc-csc" />
-              <img src="/images/security-code.png" class="generic-cvc" alt="Please enter either a 3 or 4 digit card security code"/>
-              <span class="either hidden">
-                or
-              </span>
-              <img src="/images/amex-security-code.png" class="amex-cvc hidden" alt="Please enter either a 3 or 4 digit card security code" />
           </label>
+          <input id="cvc"
+            type="number"
+            value=""
+            name="cvc"
+            class="form-control-1-8 cvc"
+            maxlength="4"
+            autocomplete="cc-csc" />
+          <img src="/images/security-code.png" class="generic-cvc" alt="Please enter either a 3 or 4 digit card security code"/>
+          <span class="either hidden">
+            or
+          </span>
+          <img src="/images/amex-security-code.png" class="amex-cvc hidden" alt="Please enter either a 3 or 4 digit card security code" />
       </div>
       <div class="form-group pull-bottom{{#highlightErrorFields.addressCountry}} error{{/highlightErrorFields.addressCountry}}" data-validation="addressCountry">
           <h2 class="push-top">Billing address</h2>
@@ -172,18 +172,16 @@ Enter your card details.
                   {{highlightErrorFields.addressCountry}}
               </p>
               {{/highlightErrorFields.addressCountry}}
-              <span class="ui-front form-label-bold">
-                  <select name="addressCountry" class="form-control form-control-2-3" id="address-country"  autocomplete="billing country-name">
-                      {{#countries}}
-                      <option
-                          value="{{ entry.country }}"
-                          data-aliases="{{ entry.aliases }}"
-                          data-weighting="{{ entry.weighting }}"
-                          {{#entry.selected }} selected="selected" {{/entry.selected }}>{{ entry.name }}</option>
-                      {{/countries}}
-                  </select>
-              </span>
           </label>
+          <select name="addressCountry" class="form-control form-control-2-3" id="address-country" autocomplete="billing country-name">
+              {{#countries}}
+              <option
+                  value="{{ entry.country }}"
+                  data-aliases="{{ entry.aliases }}"
+                  data-weighting="{{ entry.weighting }}"
+                  {{#entry.selected }} selected="selected" {{/entry.selected }}>{{ entry.name }}</option>
+              {{/countries}}
+          </select>
       </div>
       <div class="form-group address{{#highlightErrorFields.addressLine1}} error{{/highlightErrorFields.addressLine1}}"
           data-validation="addressLine1">
@@ -231,14 +229,14 @@ Enter your card details.
                     {{highlightErrorFields.addressCity}}
                 </p>
               {{/highlightErrorFields.addressCity}}
-              <input id="address-city"
-                  type="text"
-                  name="addressCity"
-                  maxlength="100"
-                  class="form-control-1-4"
-                  value="{{ addressCity }}"
-                  autocomplete="billing address-level2" />
           </label>
+          <input id="address-city"
+              type="text"
+              name="addressCity"
+              maxlength="100"
+              class="form-control-1-4"
+              value="{{ addressCity }}"
+              autocomplete="billing address-level2" />
       </div>
       <div class="form-group{{#highlightErrorFields.addressPostcode}} error{{/highlightErrorFields.addressPostcode}}" data-validation="addressPostcode">
           <label id="address-postcode-lbl" for="address-postcode" class="form-label-bold">
@@ -254,14 +252,14 @@ Enter your card details.
                     {{highlightErrorFields.addressPostcode}}
                 </p>
               {{/highlightErrorFields.addressPostcode}}
-              <input id="address-postcode"
-                  type="text"
-                  name="addressPostcode"
-                  maxlength="10"
-                  class="form-control-1-8"
-                  value = "{{ addressPostcode }}"
-                  autocomplete="billing postal-code" />
           </label>
+          <input id="address-postcode"
+              type="text"
+              name="addressPostcode"
+              maxlength="10"
+              class="form-control-1-8"
+              value = "{{ addressPostcode }}"
+              autocomplete="billing postal-code" />
       </div>
       <div class="form-group{{#highlightErrorFields.email}} error{{/highlightErrorFields.email}}" data-validation="email" data-confirmation="true">
           <label id="email-lbl" for="email" class="form-label-bold">
@@ -278,14 +276,14 @@ Enter your card details.
                     {{highlightErrorFields.email}}
                 </p>
               {{/highlightErrorFields.email}}
-              <input id="email"
-                  type="email"
-                  name="email"
-                  maxlength="254"
-                  class="form-control-1-2"
-                  value = "{{ email }}"
-                  autocomplete="email" />
           </label>
+          <input id="email"
+              type="email"
+              name="email"
+              maxlength="254"
+              class="form-control-1-2"
+              value = "{{ email }}"
+              autocomplete="email" />
       </div>
       <div>
           <input id="submit-card-details" type="submit" class="button" value="Continue" name="submitCardDetails" />


### PR DESCRIPTION
Whilst it’s valid to wrap `input` or `select` within a `label` it causes issues for
screen reader uses on PC. The when focusing the label element it will read out
everything within the label and so will read the entire select box, in our case
this is a list of 200+ countries which means users probably wont listen to the
end and find that its a combo box that can be accessed.

So I've moved the inputs/selects outside of the labels across the whole page.


