### PR TITLE
PP-2992 Remove color output from logs in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
   agent any
 
   options {
-    ansiColor('xterm')
     timestamps()
   }
 


### PR DESCRIPTION
## WHAT

- According to https://issues.jenkins-ci.org/browse/JENKINS-11752 the ansicolor plugin exaggerates log files's size by an order of magnitude.
- Currently, the plugin is disabled and we want to remove it from Jenkinsfile


