### PR TITLE
PP-3066: [wip] JS spike to create a adminusers timeout

### DIFF
--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -2,6 +2,7 @@ const views = require('../utils/views.js')
 const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
 const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 const getAdminUsersClient = require('../services/clients/adminusers_client')
+const SERVICE_TIMEOUT = 500;
 
 module.exports = function (req, res, next) {
   'use strict'
@@ -11,7 +12,18 @@ module.exports = function (req, res, next) {
     _views.display(res, 'UNAUTHORISED', withAnalyticsError())
   } else {
     let correlationId = req.headers[CORRELATION_HEADER]
-    return getAdminUsersClient({correlationId: correlationId}).findServiceBy({gatewayAccountId: req.chargeData.gateway_account.gateway_account_id})
+
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve(fetchDefaultService())
+      }, SERVICE_TIMEOUT);
+
+      getAdminUsersClient({
+        correlationId: correlationId
+      }).findServiceBy({
+        gatewayAccountId: req.chargeData.gateway_account.gateway_account_id
+      }).then(c => resolve(c));
+    })
       .then(service => {
         res.locals.service = service
         next()


### PR DESCRIPTION
If adminusers is unreachable payments won't go through the frontend.

A short term fix is to add a timeout that provides a default in lieu of the
adminusers resolving.  A side effect of this is that custom branding will
disappear if adminusers is not responding quickly.

This doesn't work yet (fetching defaults not implemented).