### PR TITLE
PP-3066 graceful fail on adminusers error

### DIFF
--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -1,3 +1,7 @@
+'use strict'
+
+const logger = require('winston')
+
 const views = require('../utils/views.js')
 const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
 const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
@@ -11,13 +15,15 @@ module.exports = function (req, res, next) {
     _views.display(res, 'UNAUTHORISED', withAnalyticsError())
   } else {
     let correlationId = req.headers[CORRELATION_HEADER]
-    return getAdminUsersClient({correlationId: correlationId}).findServiceBy({gatewayAccountId: req.chargeData.gateway_account.gateway_account_id})
+    return getAdminUsersClient({correlationId: correlationId})
+      .findServiceBy({gatewayAccountId: req.chargeData.gateway_account.gateway_account_id})
       .then(service => {
         res.locals.service = service
         next()
       })
       .catch(() => {
-        _views.display(res, 'SYSTEM_ERROR', withAnalyticsError())
+        logger.error(`Failed to retrieve service information for service: ${req.chargeData.gateway_account.serviceName}`)
+        next()
       })
   }
 }

--- a/app/utils/views.js
+++ b/app/utils/views.js
@@ -198,32 +198,24 @@ module.exports = (function () {
 
     ENTERING_CARD_DETAILS: systemError,
 
-    display: function (res, resName, locals) {
-      var action = _.result(this, resName)
+    display: function (res, viewName, options) {
+      var action = _.result(this, viewName)
       var status
-      locals = locals || {}
-      locals.viewName = resName
+      options = options || {}
+      options.viewName = viewName
       if (!action) {
-        logger.error('VIEW ' + resName + ' NOT FOUND')
-        locals = {viewName: 'error'}
+        logger.error('VIEW ' + viewName + ' NOT FOUND')
+        options = {viewName: 'error'}
         action = this.ERROR
       }
-      locals = (action.locals) ? _.merge({}, action.locals, locals) : locals
+      options = (action.locals) ? _.merge({}, action.locals, options) : options
 
-      if (_.get(res.locals, 'service.hasCustomBranding', false)) {
-        locals.customBranding = _.get(res.locals, 'service.customBranding')
-      }
-
-      if (_.get(res.locals, 'service.hasMerchantDetails', false)) {
-        locals.merchantDetails = _.get(res.locals, 'service.merchantDetails')
-      }
-
-      if (_.get(locals, 'analytics.path')) {
-        locals.analytics.path = locals.analytics.path + _.get(action, 'analyticsPage', '')
+      if (_.get(options, 'analytics.path')) {
+        options.analytics.path = options.analytics.path + _.get(action, 'analyticsPage', '')
       }
       status = (action.code) ? action.code : 200
       res.status(status)
-      res.render(action.view, locals)
+      res.render(action.view, options)
     }
   }
 

--- a/app/views/includes/custom.njk
+++ b/app/views/includes/custom.njk
@@ -1,5 +1,5 @@
 <div class="header-logo header-logo--custom">
   <a href="{{ homepageUrl|default('https://www.gov.uk') }}" title="" id="logo" class="content">
-    <img src="{{ customBranding.imageUrl }}" class="custom-branding-image" alt="">
+    <img src="{{ service.customBranding.imageUrl }}" class="custom-branding-image" alt="">
   </a>
 </div>

--- a/app/views/includes/head.njk
+++ b/app/views/includes/head.njk
@@ -1,6 +1,6 @@
 <link href="{{ css_path }}" media="screen" rel="stylesheet" type="text/css" />
-{% if customBranding %}
-  <link href="{{ customBranding.cssUrl }}" media="screen" rel="stylesheet" type="text/css" />
+{% if service and service.customBranding and service.customBranding.cssUrl  %}
+  <link href="{{ service.customBranding.cssUrl }}" media="screen" rel="stylesheet" type="text/css" />
 {% else %}
   <!--[if IE 8]><link href="{{ asset_path }}stylesheets/fonts-ie8.css?0.22.3" media="all" rel="stylesheet" /><![endif]-->
   <!--[if gte IE 9]><!--><link href="{{ asset_path }}stylesheets/fonts.css?0.22.3" media="all" rel="stylesheet" /><!--<![endif]-->

--- a/app/views/includes/merchant_details.njk
+++ b/app/views/includes/merchant_details.njk
@@ -1,8 +1,8 @@
-{% if merchantDetails %}
+{% if service and service.merchantDetails %}
   <ul class="merchant-details">
-    <li class="merchant-details-line-1">Service provided by {{ merchantDetails.name }}</li>
-    <li class="merchant-details-line-2">{{ merchantDetails.addressLine1 }},
-      {% if merchantDetails.addressLine2 %} {{ merchantDetails.addressLine2 }}, {% endif %}
-      {{ merchantDetails.city }} {{ merchantDetails.postcode }} {{ merchantDetails.countryName }}</li>
+    <li class="merchant-details-line-1">Service provided by {{ service.merchantDetails.name }}</li>
+    <li class="merchant-details-line-2">{{ service.merchantDetails.addressLine1 }},
+      {% if service.merchantDetails.addressLine2 %} {{ service.merchantDetails.addressLine2 }}, {% endif %}
+      {{ service.merchantDetails.city }} {{ service.merchantDetails.postcode }} {{ service.merchantDetails.countryName }}</li>
   </ul>
 {% endif %}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -6,11 +6,11 @@
 {% endblock %}
 
 {% block body_classes %}
-  {% if customBranding %}custom-branding{% endif %}
+  {% if service and service.customBranding and service.customBranding.cssUrl %}custom-branding{% endif %}
 {% endblock %}
 
 {% block inside_header %}
-  {% if customBranding %}
+  {% if service and service.customBranding and service.customBranding.imageUrl %}
     {% include "includes/custom.njk" %}
   {% endif %}
 {% endblock %}

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -5,9 +5,12 @@ var cheerio = require('cheerio')
 var should = require('chai').should() // eslint-disable-line
 
 const customBrandingData = {
-  customBranding: {
-    cssUrl: 'css url',
-    imageUrl: 'image url'
+  service: {
+    hasCustomBranding: true,
+    customBranding: {
+      cssUrl: 'css url',
+      imageUrl: 'image url'
+    }
   }
 }
 

--- a/test/utils/views_test.js
+++ b/test/utils/views_test.js
@@ -8,22 +8,6 @@ var _ = require('lodash')
 
 describe('views helper', function () {
   const service = serviceFixtures.validServiceResponse().getPlain()
-  const expectedDefaultCustomBranding = {
-    customBranding: {
-      cssUrl: service.custom_branding.css_url,
-      imageUrl: service.custom_branding.image_url
-    }
-  }
-  const expectedDefaultMerchantDetails = {
-    merchantDetails: {
-      name: 'Give Me Your Money',
-      addressLine1: 'Clive House',
-      addressLine2: '10 Downing Street',
-      city: 'London',
-      postcode: 'AW1H 9UX',
-      countryName: 'United Kingdom'
-    }
-  }
 
   var response = {
     status: function () {},
@@ -54,7 +38,7 @@ describe('views helper', function () {
     var _views = views.create(testView)
     _views.display(response, 'TEST_VIEW')
     assert(status.calledWith(999))
-    assert(render.calledWith('TEST_VIEW', _.merge({viewName: 'TEST_VIEW'}, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
+    assert(render.calledWith('TEST_VIEW', {viewName: 'TEST_VIEW'}))
   })
 
   it('should return a 200 by default', function () {
@@ -63,7 +47,7 @@ describe('views helper', function () {
     var _views = views.create(view)
     _views.display(response, 'TEST_VIEW')
     assert(status.calledWith(200))
-    assert(render.calledWith('TEST_VIEW', _.merge({viewName: 'TEST_VIEW'}, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
+    assert(render.calledWith('TEST_VIEW', {viewName: 'TEST_VIEW'}))
   })
 
   it('should return locals passed in', function () {
@@ -71,17 +55,17 @@ describe('views helper', function () {
     var _views = views.create(view)
     _views.display(response, 'TEST_VIEW', {a: 'local'})
     assert(status.calledWith(999))
-    assert(render.calledWith('TEST_VIEW', _.merge({viewName: 'TEST_VIEW', a: 'local'}, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
+    assert(render.calledWith('TEST_VIEW', {viewName: 'TEST_VIEW', a: 'local'}))
   })
 
   it('should rendor error view when view not found', function () {
     var _views = views.create()
     _views.display(response, 'AINT_NO_VIEW_HERE')
     assert(status.calledWith(500))
-    assert(render.calledWith('error', _.merge({
+    assert(render.calledWith('error', {
       message: 'There is a problem, please try again later',
       viewName: 'error'
-    }, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
+    }))
   })
 
   var defaultTemplates = {
@@ -108,20 +92,20 @@ describe('views helper', function () {
         var _views = views.create()
         _views.display(response, name)
         assert(status.calledWith(values.code))
-        assert(render.calledWith(values.template, _.merge({
+        assert(render.calledWith(values.template, {
           message: values.message,
           viewName: name
-        }, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
+        }))
       })
 
       it('should be able to ovverride the default ' + name + ' message', function () {
         var _views = views.create()
         _views.display(response, name, {message: 'lol'})
         assert(status.calledWith(values.code))
-        assert(render.calledWith(values.template, _.merge({
+        assert(render.calledWith(values.template, {
           message: 'lol',
           viewName: name
-        }, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
+        }))
       })
 
       it('should be able to ovverride the default ' + name + ' template', function () {
@@ -130,7 +114,7 @@ describe('views helper', function () {
         var _views = views.create(overriden)
         _views.display(response, name, {message: 'lol'})
         assert(status.calledWith(333))
-        assert(render.calledWith('foo', _.merge({message: 'lol', viewName: name}, expectedDefaultCustomBranding, expectedDefaultMerchantDetails)))
+        assert(render.calledWith('foo', {message: 'lol', viewName: name}))
       })
     }
   )


### PR DESCRIPTION
- Altered `middleware/resolve_service` so to only log an error if call to adminusers fails
- Updated `utils/views.js` and views depending on `service` to use `res.locals` rather than set explicit property


