### PR TITLE
We were double loading the fonts but didnt notice because syntax was wrong

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -5,6 +5,10 @@
   {% include "includes/analytics.njk" %}
 {% endblock %}
 
+{% block fontsStylesheets %}
+{# Clear fonts because we want to only load them if not custom branding, see head.njk #}
+{% endblock %}
+
 {% block body_classes %}
   {% if service and service.customBranding and service.customBranding.cssUrl %}custom-branding{% endif %}
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "envfile": "^2.1.1",
     "eslint": "^3.19.0",
     "govuk_frontend_toolkit": "7.2.0",
-    "govuk_template_jinja": "https://github.com/jonheslop/govuk_template/releases/download/v0.22.4/jinja_govuk_template-0.22.3.tgz",
+    "govuk_template_jinja": "https://github.com/jonheslop/govuk_template/releases/download/v0.22.5/jinja_govuk_template-0.22.5.tgz",
     "grunt": "1.0.x",
     "grunt-browserify": "5.2.x",
     "grunt-cli": "1.2.x",


### PR DESCRIPTION
We were double loading the fonts but didnt notice because syntax was wrong on custom [govuk_template](https://github.com/jonheslop/govuk_template/commit/e7488c3af27cc68d847f881ea520164ac3529e4b) fixed on this [release](https://github.com/jonheslop/govuk_template/releases/tag/v0.22.5)
