### PR TITLE
PP-3119 Bumped pay-product-page release from 2.0.18 to 2.0.19 which includes status page link fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "node-sass": "4.7.x",
     "nyc": "11.3.x",
     "pact": "1.0.0",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.18/pay-product-page-2.0.18.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.0.19/pay-product-page-2.0.19.tgz",
     "proxyquire": "~1.8.0",
     "sass-lint": "^1.10.2",
     "sinon": "4.1.x",


### PR DESCRIPTION
## WHAT
Bumps the release number for the pay-product-page being referenced from 2.0.18 to 2.0.19. The new release updates the footer link and main page link to the new statuspage.io page which was recently created.


