### PR TITLE
BAU - bumping product page version with better cookies info page

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "node-sass": "4.7.x",
     "nyc": "11.3.x",
     "pact": "1.0.0",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.1/pay-product-page-2.1.1.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.2/pay-product-page-2.1.2.tgz",
     "proxyquire": "~1.8.0",
     "sass-lint": "^1.10.2",
     "sinon": "4.1.x",


### PR DESCRIPTION
Bumping dependency to include new version of product page with [updated cookies link](https://github.com/alphagov/pay-product-page/pull/35/files)