### PR TITLE
PP-3132 - Set GA to use navigator.sendBeacon for better accuracy

### DIFF
--- a/app/views/includes/analytics.njk
+++ b/app/views/includes/analytics.njk
@@ -6,6 +6,7 @@
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', '{{analyticsTrackingId}}', 'auto');
     ga('set', 'anonymizeIp', true);
+    ga('set', 'transport', 'beacon');
     ga('send', 'pageview', {
     {% if analytics.path %}
       'page':'{{analytics.path}}',


### PR DESCRIPTION
This will one day be the default when more browsers support it,
but we are setting it now as it may help increase the accuracy
of successful payment journey counts.

We don’t have a content security policy [yet](https://payments-platform.atlassian.net/browse/PP-3131)! But when we do we'll need to add GA to the policy:

```
script-src 'self' *.google-analytics.com;
connect-src 'self' *.google-analytics.com;
img-src 'self' *.google-analytics.com;
```

Example of Notify’s
```
Content-Security-Policy:default-src 'self' 'unsafe-inline';script-src 'self' *.google-analytics.com 'unsafe-inline' 'unsafe-eval' data:;connect-src 'self' *.google-analytics.com;object-src 'self';font-src 'self' data:;img-src 'self' *.google-analytics.com *.notifications.service.gov.uk static-logos.notifications.service.gov.uk data:;frame-src www.youtube.com;
```