### PR TITLE
PP-3225 - Simplifying and removing jQuery from function

### DIFF
--- a/app/assets/javascripts/modules/form-input-confirm.js
+++ b/app/assets/javascripts/modules/form-input-confirm.js
@@ -1,48 +1,43 @@
-"use strict";
-var confirmInput = function() {
-  var $inputs = $('[data-confirmation]'),
-      makeConfirmation,
-      addFor,
-      update;
+'use strict'
 
-  makeConfirmation = function(id) {
-    var confirmation = [
-          '<div class="form-group panel panel-border-wide input-confirm">',
-              '<p class="form-hint">',
-                  'An email will be sent to: <span class="email"></span>',
-              '</p>',
-          '</div>'
-        ].join(''),
-        $elm;
+module.exports = () => {
+  const inputs = document.querySelectorAll('[data-confirmation]')
 
-    $elm = $(confirmation);
-    $elm.attr('id', id);
-    return $elm;
-  };
+  inputs.forEach(input => {
+    input.addEventListener('input', update, false)
+  })
 
-  addFor = function ($input, $confirmation) {
-    var $formGroup = $input.closest('.form-group');
+  const addFor = (input, confirmation) => {
+    const formGroup = input.closest('.form-group')
 
-    $confirmation.insertAfter($formGroup);
-  };
+    formGroup.after(confirmation)
+  }
 
-  update = function (e) {
-    var $input = $(e.target),
-        value = $input.val(),
-        confirmationId = $input.attr('id') + '-confirmation',
-        $confirmation = $('#' + confirmationId);
+  function update (e) {
+    const input = e.target
+    const value = input.value
+    const confirmationId = `${input.id}-confirmation`
+    let confirmation = document.getElementById(confirmationId)
+    const confirmationLabel = input.dataset.confirmationLabel
+    const confirmationPrepend = input.dataset.confirmationPrepend
 
-    if ($confirmation.length === 0) {
-      $confirmation = makeConfirmation(confirmationId);
-      addFor($input, $confirmation);
+    if (!confirmation) {
+      const confirmationInner = `
+      <div id="${confirmationId}" class="form-group panel panel-border-wide input-confirm">
+        <p class="form-hint">
+          ${confirmationLabel}<span class="input-confirmation"></span>
+        </p>
+      </div>`
+      confirmation = document.createElement('div')
+      confirmation.innerHTML = confirmationInner
+      addFor(input, confirmation)
     }
 
     if (value === '') {
-      $confirmation.remove();
+      confirmation.remove()
     } else {
-      $confirmation.find('.email').text(value);
+      const confirmationText = document.querySelectorAll(`#${confirmationId} .input-confirmation`)
+      confirmationText[0].innerText = confirmationPrepend + value
     }
-  };
-
-  $inputs.on('input', update);
-};
+  }
+}

--- a/app/assets/sass/helpers/_panels.scss
+++ b/app/assets/sass/helpers/_panels.scss
@@ -96,7 +96,7 @@
     display: block;
   }
 
-  .email {
+  .input-confirmation {
     @include core-24;
     color: $text-colour;
   }

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,3 +1,7 @@
+const inputConfim = require('./assets/javascripts/modules/form-input-confirm')
+
 window.jQuery = window.$ = require('jquery')
 module.exports.chargeValidation = require('./utils/charge_validation')
 // module.exports.accessibleAutocomplete = require('./utils/accessible-autocomplete.js')
+
+inputConfim()

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -261,7 +261,7 @@
                value="{{ addressPostcode }}"
                autocomplete="billing postal-code"/>
       </div>
-      <div class="form-group{% if highlightErrorFields.email %} error{% endif %}" data-validation="email" data-confirmation="true">
+      <div class="form-group{% if highlightErrorFields.email %} error{% endif %}" data-validation="email">
         <label id="email-lbl" for="email" class="form-label-bold">
               <span
                   class="email-label"
@@ -283,7 +283,9 @@
                maxlength="254"
                class="form-control-1-2"
                value="{{ email }}"
-               autocomplete="email"/>
+               autocomplete="email"
+               data-confirmation="true"
+               data-confirmation-label="An email will be sent to: "/>
       </div>
       <div>
         <input id="submit-card-details" type="submit" class="button" value="Continue" name="submitCardDetails"/>

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -18,7 +18,6 @@
         {% endif %}
         formValidation();
         showCardType().init();
-        confirmInput();
       });
     } else if ($('main').hasClass('confirm-page')) {
       $( document ).ready(function() {


### PR DESCRIPTION
We’d like to reuse this input confirm function on pay-products-ui
and over there we dont use jQuery and write nodeJS that gets converted
by Browserify. So to keep things consistent I'm making it the same in
both places.


