### PR TITLE
PP-2766 friendly message for expired sessions

### DIFF
--- a/app/utils/views.js
+++ b/app/utils/views.js
@@ -104,7 +104,7 @@ module.exports = (function () {
 
     UNAUTHORISED: {
       code: 403,
-      view: 'errors/system_error'
+      view: 'errors/incorrect_state/session_expired'
     },
 
     CAPTURE_SUBMITTED: {

--- a/app/views/error.njk
+++ b/app/views/error.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block page_title %}
-  An error occurred
+  An error occurred - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/error_with_return_url.njk
+++ b/app/views/error_with_return_url.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block page_title %}
-  An error occurred
+  An error occurred - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/errors/charge_confirm_state_completed.njk
+++ b/app/views/errors/charge_confirm_state_completed.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block page_title %}
-  Your payment was {{ status }}
+  Your payment was {{ status }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/errors/incorrect_state/auth_3ds_required.njk
+++ b/app/views/errors/incorrect_state/auth_3ds_required.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block page_title %}
-  Your payment is in progress
+  Your payment is in progress - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/errors/incorrect_state/auth_failure.njk
+++ b/app/views/errors/incorrect_state/auth_failure.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block page_title %}
-  There was a problem with your payment
+  There was a problem with your payment - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/errors/incorrect_state/auth_success.njk
+++ b/app/views/errors/incorrect_state/auth_success.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block page_title %}
-Your payment is in progress
+Your payment is in progress - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/errors/incorrect_state/capture_failure.njk
+++ b/app/views/errors/incorrect_state/capture_failure.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block page_title %}
-  Your payment was {{ status }}
+  Your payment was {{ status }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/errors/incorrect_state/capture_waiting.njk
+++ b/app/views/errors/incorrect_state/capture_waiting.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block page_title %}
-  Your payment is in progress
+  Your payment is in progress - GOV.UK Pay
 {% endblock %}
 
 {% block head %}

--- a/app/views/errors/incorrect_state/session_expired.njk
+++ b/app/views/errors/incorrect_state/session_expired.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block page_title %}
-  Your Payment expired
+  Your Payment expired - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
@@ -9,7 +9,9 @@
     <div class="column-two-thirds">
       <h1 class="heading-large session-expired">Your payment session has expired</h1>
       <p class="lede">No money has been taken from your account.</p>
-      <p class="lede"><a href="{{ returnUrl }}" id="return-url"> Go back to try the payment again</a></p>
+      {% if returnUrl %}
+        <p class="lede"><a href="{{ returnUrl }}" id="return-url"> Go back to try the payment again</a></p>
+      {% endif %}
     </div>
   </main>
 {% endblock %}

--- a/app/views/errors/incorrect_state/system_cancelled.njk
+++ b/app/views/errors/incorrect_state/system_cancelled.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block page_title %}
-  Your Payment was cancelled
+  Your Payment was cancelled - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/errors/system_error.njk
+++ b/app/views/errors/system_error.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block page_title %}
-  An error occurred
+  An error occurred - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/static/privacy.njk
+++ b/app/views/static/privacy.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block page_title %}
-  Privacy policy
+  Privacy policy - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/app/views/user_cancelled.njk
+++ b/app/views/user_cancelled.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block page_title %}
-  Your payment has been cancelled
+  Your payment has been cancelled - GOV.UK Pay
 {% endblock %}
 
 {% block content %}

--- a/test/middleware/csrf_test.js
+++ b/test/middleware/csrf_test.js
@@ -58,12 +58,12 @@ describe('retrieve param test', function () {
     expect(next.called).to.not.be.true // eslint-disable-line
     expect(resp.locals.csrf).to.be.undefined // eslint-disable-line
     assert(status.calledWith(403))
-    assert(render.calledWith('errors/system_error', { viewName: 'UNAUTHORISED' }))
+    assert(render.calledWith('errors/incorrect_state/session_expired', { viewName: 'UNAUTHORISED' }))
   }
 
   var assertValidRequest = function (next, resp, status, render) {
     expect(next.called).to.be.true // eslint-disable-line
-    expect(resp.locals.csrf).to.not.be.undefined // eslint-disable-line 
+    expect(resp.locals.csrf).to.not.be.undefined // eslint-disable-line
   }
 
   beforeEach(function () {

--- a/test/middleware/resolve_service_test.js
+++ b/test/middleware/resolve_service_test.js
@@ -67,7 +67,7 @@ describe('resolve service middleware', function () {
     let nextSpy = sinon.spy()
     resolveService(req, res, nextSpy)
     expect(res.status.calledWith(403)).to.be.equal(true)
-    expect(res.render.calledWith('errors/system_error', expectedRenderData)).to.be.equal(true) // eslint-disable-line
+    expect(res.render.calledWith('errors/incorrect_state/session_expired', expectedRenderData)).to.be.equal(true) // eslint-disable-line
   })
 
   it('should log an error if it fails to retrieving service data', function (done) {

--- a/test/middleware/retrieve_charge_test.js
+++ b/test/middleware/retrieve_charge_test.js
@@ -48,7 +48,7 @@ describe('retrieve param test', function () {
   it('should call not found view if charge param does not return an id', function () {
     retrieveCharge({params: {}, body: {}}, response, next)
     assert(status.calledWith(403))
-    assert(render.calledWith('errors/system_error', {viewName: 'UNAUTHORISED', analytics: ANALYTICS_ERROR.analytics}))
+    assert(render.calledWith('errors/incorrect_state/session_expired', {viewName: 'UNAUTHORISED', analytics: ANALYTICS_ERROR.analytics}))
     expect(next.notCalled).to.be.true // eslint-disable-line
   })
 
@@ -84,7 +84,7 @@ describe('retrieve param test', function () {
         expect(status.calledWith(200))
         expect(validRequest.chargeId).to.equal(chargeId)
         expect(validRequest.chargeData).to.deep.equal(chargeData)
-        expect(next.called).to.be.true // eslint-disable-line 
+        expect(next.called).to.be.true // eslint-disable-line
         done()
       } catch (err) { done(err) }
     }, done)


### PR DESCRIPTION
When error 403 "unauthorised" we were using system error, when this sort of error is likely an expired session, we have a template and messaging for that, so I just switched it out.

Also I noticed all the pages on Frontend don’t have “- GOV.UK Pay” on the end of the page title

So I added it to all of them for consistency 