### PR TITLE
BAU Minor Refactoring

### DIFF
--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,3 +1,3 @@
 window.jQuery = window.$ = require('jquery')
-module.exports.chargeValidation = require('./utils/charge_validation')
-// module.exports.accessibleAutocomplete = require('./utils/accessible-autocomplete.js')
+exports.chargeValidation = require('./utils/charge_validation')
+

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,3 +1,2 @@
 window.jQuery = window.$ = require('jquery')
 exports.chargeValidation = require('./utils/charge_validation')
-

--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -16,7 +16,7 @@ let CANCELABLE_STATES = [
   StateModel.AUTH_3DS_READY
 ]
 
-module.exports.return = function (req, res) {
+exports.return = function (req, res) {
   'use strict'
 
   let correlationId = req.headers[CORRELATION_HEADER] || ''

--- a/app/controllers/secure_controller.js
+++ b/app/controllers/secure_controller.js
@@ -9,7 +9,7 @@ var CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_H
 var withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 var stateService = require('../services/state_service.js')
 
-module.exports.new = function (req, res) {
+exports.new = function (req, res) {
   'use strict'
 
   var chargeTokenId = req.params.chargeTokenId || req.body.chargeTokenId

--- a/app/middleware/action_name.js
+++ b/app/middleware/action_name.js
@@ -1,6 +1,7 @@
-var path = require('path')
-var paths = require(path.join(__dirname, '/../paths.js'))
-var flatPaths = require(path.join(__dirname, '/../utils/flattened_paths.js'))(paths)
+'use strict'
+
+var paths = require('./../paths.js')
+var flatPaths = require('./../utils/flattened_paths.js')(paths)
 
 module.exports = function (req, res, next) {
   'use strict'

--- a/app/paths.js
+++ b/app/paths.js
@@ -1,6 +1,7 @@
+'use strict'
+
 var _ = require('lodash')
-var path = require('path')
-var generateRoute = require(path.join(__dirname, '/utils/generate_route.js'))
+var generateRoute = require('./utils/generate_route.js')
 
 if (process.env.CONNECTOR_HOST === undefined) throw new Error('CONNECTOR_HOST environment variable is not defined')
 // please structure each route as follows

--- a/app/router.js
+++ b/app/router.js
@@ -1,17 +1,18 @@
+'use strict'
+
 var i18n = require('i18n')
-var path = require('path')
 
 var charge = require('./controllers/charge_controller.js')
 var secure = require('./controllers/secure_controller.js')
 var statik = require('./controllers/static_controller.js')
 var returnCont = require('./controllers/return_controller.js')
 
-var paths = require(path.join(__dirname, '/paths.js'))
-var {csrfCheck, csrfTokenGeneration} = require(path.join(__dirname, '/middleware/csrf.js'))
-var actionName = require(path.join(__dirname, '/middleware/action_name.js'))
-var stateEnforcer = require(path.join(__dirname, '/middleware/state_enforcer.js'))
-var retrieveCharge = require(path.join(__dirname, '/middleware/retrieve_charge.js'))
-const resolveService = require(path.join(__dirname, '/middleware/resolve_service.js'))
+var paths = require('./paths.js')
+var {csrfCheck, csrfTokenGeneration} = require('./middleware/csrf.js')
+var actionName = require('./middleware/action_name.js')
+var stateEnforcer = require('./middleware/state_enforcer.js')
+var retrieveCharge = require('./middleware/retrieve_charge.js')
+const resolveService = require('./middleware/resolve_service.js')
 
 exports.paths = paths
 

--- a/app/router.js
+++ b/app/router.js
@@ -13,9 +13,9 @@ var stateEnforcer = require(path.join(__dirname, '/middleware/state_enforcer.js'
 var retrieveCharge = require(path.join(__dirname, '/middleware/retrieve_charge.js'))
 const resolveService = require(path.join(__dirname, '/middleware/resolve_service.js'))
 
-module.exports.paths = paths
+exports.paths = paths
 
-module.exports.bind = function (app) {
+exports.bind = function (app) {
   'use strict'
 
   app.get('/healthcheck', function (req, res) {

--- a/app/utils/base_client.js
+++ b/app/utils/base_client.js
@@ -1,3 +1,5 @@
+'use strict'
+
 /**
  * @Deprecated
  *
@@ -6,11 +8,10 @@
  */
 const urlParse = require('url')
 const https = require('https')
-const path = require('path')
 const logger = require('winston')
 
-const customCertificate = require(path.join(__dirname, '/custom_certificate'))
-const CORRELATION_HEADER_NAME = require(path.join(__dirname, '/correlation_header')).CORRELATION_HEADER
+const customCertificate = require('./custom_certificate')
+const CORRELATION_HEADER_NAME = require('./correlation_header').CORRELATION_HEADER
 
 var agentOptions = {
   keepAlive: true,

--- a/app/utils/base_client2.js
+++ b/app/utils/base_client2.js
@@ -1,4 +1,5 @@
-const path = require('path')
+'use strict'
+
 const https = require('https')
 const httpAgent = require('http').globalAgent
 const urlParse = require('url').parse
@@ -6,7 +7,7 @@ const _ = require('lodash')
 const logger = require('winston')
 const request = require('requestretry')
 const customCertificate = require('./custom_certificate')
-const CORRELATION_HEADER_NAME = require(path.join(__dirname, '/correlation_header')).CORRELATION_HEADER
+const CORRELATION_HEADER_NAME = require('./correlation_header').CORRELATION_HEADER
 
 const agentOptions = {
   keepAlive: true,

--- a/app/utils/correlation_header.js
+++ b/app/utils/correlation_header.js
@@ -1,1 +1,1 @@
-module.exports.CORRELATION_HEADER = 'x-request-id'
+exports.CORRELATION_HEADER = 'x-request-id'

--- a/test/fixtures/pact_interaction_builder.js
+++ b/test/fixtures/pact_interaction_builder.js
@@ -91,4 +91,4 @@ class PactInteractionBuilder {
   }
 }
 
-module.exports.PactInteractionBuilder = PactInteractionBuilder
+exports.PactInteractionBuilder = PactInteractionBuilder


### PR DESCRIPTION
# BAU Minor Refactoring

## What
* 7e62443 - Usage of `module.exports.<property-name>` removed in favour of `exports.<property-name>`. 
*  56235c0 - Usage of `require(path.join(__dirname, '<file-path>'))` removed in favour of `require('<file-path>')`

## Why
* The variable `exports`, when a module is instantiated is a shorthand reference to the `exports` property of the module. i.e. `exports = module.exports = {}`
* `require()` in Node.js handles relative file loading by default so using `path.join(__dirname, '<file-path>') is unnecessary.

## More detailed why
* It's generally considered better practice to:
    * use `exports.<property-name>` when assigning a property to be exported
    * use `module.exports = <Object | Function>` when exporting a single export.
* Using `require(path.join(__dirname, '<file-path>'))` in JetBrains IDEs breaks automatic updates to file paths when moving files, meaning a developer has to manually update each instance of a file being imported into another module. This is exceptionally annoying, especially if you are attempting any sort of refactoring.

