### PR TITLE
PP-3240 - Used <th> so that screen readers labels the field when it reads it out

### DIFF
--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -10,35 +10,35 @@
 
     <table class="confirm-details">
       <tr>
-        <td>Card number:</td>
+        <th>Card number:</th>
         <td id="card-number" class="details">{{ charge.cardDetails.cardNumber }}</td>
       </tr>
       <tr>
-        <td>Card brand:</td>
+        <th>Card brand:</th>
         <td id="card-brand" class="details">{{ charge.cardDetails.cardBrand }}</td>
       </tr>
       <tr>
-        <td>Expiry date:</td>
+        <th>Expiry date:</th>
         <td id="expiry-date" class="details">{{ charge.cardDetails.expiryDate }}</td>
       </tr>
       <tr>
-        <td>Name on card:</td>
+        <th>Name on card:</th>
         <td id="cardholder-name" class="details">{{ charge.cardDetails.cardholderName }}</td>
       </tr>
       <tr>
-        <td>Billing address:</td>
+        <th>Billing address:</th>
         <td id="address" class="details">{{ charge.cardDetails.billingAddress }}</td>
       </tr>
       <tr>
-        <td>Payment for:</td>
+        <th>Payment for:</th>
         <td id="payment-description" class="details">{{ charge.description }}</td>
       </tr>
       <tr>
-        <td>Total amount:</td>
+        <th>Total amount:</th>
         <td id="amount" class="details">£{{ charge.amount }}</td>
       </tr>
       <tr>
-        <td>Confirmation email:</td>
+        <th>Confirmation email:</th>
         <td id="email" class="details">{{ charge.email }}</td>
       </tr>
     </table>


### PR DESCRIPTION
This change makes the table more accessible to screenreaders.

for example the row.

```html
      <tr>
        <th>Card brand:</th>
        <td>Visa</td>
      </tr>
```

When the screenreader focuses on the table it jumps though the `td` but says "Card brand, Visa"

Whereas before it would say "Visa", this makes it clear what the value being read represents