### PR TITLE
PP-3266 refactor return secure and static controllers

### DIFF
--- a/app/controllers/static_controller.js
+++ b/app/controllers/static_controller.js
@@ -1,20 +1,14 @@
-/* jslint node: true */
 'use strict'
-var views = require('../utils/views.js')
-var logger = require('winston')
-var withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
+// npm dependencies
+const logger = require('winston')
 
-module.exports = {
-  privacy: function (req, res) {
-    res.render('static/privacy')
-  },
-  humans: function (req, res) {
-    var _views = views.create()
-    _views.display(res, 'HUMANS', withAnalyticsError())
-  },
-  naxsi_error: function (req, res) {
-    logger.error('NAXSI ERROR:- ' + req.headers['x-naxsi_sig'])
-    var _views = views.create()
-    _views.display(res, 'NAXSI_SYSTEM_ERROR', withAnalyticsError())
-  }
+// local dependencies
+const views = require('../utils/views.js')
+const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
+
+exports.privacy = (req, res) => res.render('static/privacy')
+exports.humans = (req, res) => views.create().display(res, 'HUMANS', withAnalyticsError())
+exports.naxsi_error = (req, res) => {
+  logger.error('NAXSI ERROR:- ' + req.headers['x-naxsi_sig'])
+  views.create().display(res, 'NAXSI_SYSTEM_ERROR', withAnalyticsError())
 }


### PR DESCRIPTION
## WHAT
In the secure, return and static controllers:
- removed unnecessary inner functions in secure controller
- removed unnecessary variables in return controller
- implemented 'prefer-const' style for variable declarations

In the secure controller:
- fixed line 20 (old line 28) where the success path would be executed even if the token destroy failed.
- fixed line 20 (old line 28) where the error would be lost to the ether if token destroy failed.

