### PR TITLE
PP-3091 Modify pay-frontend to support ECS based deployments

### DIFF
--- a/app/utils/custom_certificate.js
+++ b/app/utils/custom_certificate.js
@@ -22,11 +22,15 @@ module.exports = {
     }
 
     var ca = []
-    fs.readdirSync(certsPath).forEach(
-      certPath => ca.push(
-        fs.readFileSync(path.join(certsPath, certPath))
-      )
-    )
+    // Read everything from the certificates directories
+    // Get everything that isn't a directory (e.g. files, symlinks)
+    // Read it (assume it is a certificate)
+    // Add it to the agentOptions list of CAs
+    fs.readdirSync(certsPath)
+      .map(certPath => path.join(certsPath, certPath))
+      .filter(fullCertPath => !fs.lstatSync(fullCertPath).isDirectory())
+      .map(fullCertPath => fs.readFileSync(fullCertPath))
+      .forEach(caCont => ca.push(caCont))
 
     return ca
   }

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+AWS_REGION=${ECS_AWS_REGION} chamber exec ${ECS_SERVICE} -- npm start


### PR DESCRIPTION
## WHAT
Adds NPM start script to allow the execution of the application using the Chamber binary to fetch secrets and add as environment variables. This allows the application to be used via ECS and our associated secrets management pattern.

In addition, changes to the certificate management code have been made to be tolerant of sub directories in the existing certificate directory which may be present when volume mounting.

