### PR TITLE
PP-3266 refactor utils

### DIFF
--- a/app/utils/accessible-autocomplete.js
+++ b/app/utils/accessible-autocomplete.js
@@ -1,9 +1,0 @@
-var accessibleAutocomplete = require('accessible-autocomplete')
-
-var countryPicker = document.querySelector('#address-country')
-
-if (countryPicker) {
-  accessibleAutocomplete.enhanceSelectElement({
-    selectElement: countryPicker
-  })
-}

--- a/app/utils/analytics.js
+++ b/app/utils/analytics.js
@@ -16,25 +16,14 @@ const ANALYTICS_ERROR = {
   }
 }
 
-module.exports = (function () {
-  'use strict'
-
-  var withAnalytics = function (charge, param) {
-    return _.merge(
-      {
-        analytics: {
-          path: paths.generateRoute(`card.new`, {chargeId: charge.id}),
-          analyticsId: charge.gatewayAccount.analyticsId,
-          type: charge.gatewayAccount.type,
-          paymentProvider: charge.gatewayAccount.paymentProvider,
-          amount: charge.amount
-        }}, param)
-  }
-  var withError = function () {
-    return _.clone(ANALYTICS_ERROR)
-  }
-  return {
-    withAnalyticsError: withError,
-    withAnalytics: withAnalytics
-  }
-}())
+exports.withAnalyticsError = () => lodash.clone(ANALYTICS_ERROR)
+exports.withAnalytics = (charge, param) => {
+  return lodash.merge({
+    analytics: {
+      path: paths.generateRoute(`card.new`, {chargeId: charge.id}),
+      analyticsId: charge.gatewayAccount.analyticsId,
+      type: charge.gatewayAccount.type,
+      paymentProvider: charge.gatewayAccount.paymentProvider,
+      amount: charge.amount
+    }}, param)
+}

--- a/app/utils/analytics.js
+++ b/app/utils/analytics.js
@@ -1,6 +1,12 @@
-var _ = require('lodash')
-var paths = require('../paths.js')
+'use strict'
 
+// npm dependencies
+const lodash = require('lodash')
+
+// local dependencies
+const paths = require('../paths.js')
+
+// constants
 const ANALYTICS_ERROR = {
   analytics: {
     analyticsId: 'Service unavailable',

--- a/app/utils/cardid_client.js
+++ b/app/utils/cardid_client.js
@@ -1,21 +1,17 @@
-var baseClient = require('./base_client')
+'use strict'
 
-var cardUrl = process.env.CARDID_HOST + '/v1/api/card'
+// local dependencies
+const baseClient = require('./base_client')
 
-/*
- * @module cardIdClient
+// constants
+const CARD_URL = process.env.CARDID_HOST + '/v1/api/card'
+
+/**
+ *
+ * @param args
+ * @param callBack
+ *
+ * @returns {Request}
  */
-module.exports = {
-  /**
-   *
-   * @param args
-   * @param callBack
-   *
-   * @returns {NodeRestClient}
-   */
-  post: function (args, callBack) {
-    return baseClient.post(cardUrl, args, callBack)
-  },
-
-  CARD_URL: cardUrl
-}
+exports.post = (args, callBack) => baseClient.post(CARD_URL, args, callBack)
+exports.CARD_URL = CARD_URL

--- a/app/utils/charge_utils.js
+++ b/app/utils/charge_utils.js
@@ -1,9 +1,7 @@
-module.exports = {
-  hashOutCardNumber: function (cardNumber) {
-    'use strict'
+'use strict'
 
-    var hashedSize = cardNumber.length - 4
-    var lastFour = cardNumber.substring(hashedSize)
-    return new Array(hashedSize + 1).join('*') + lastFour
-  }
+exports.hashOutCardNumber = cardNumber => {
+  const hashedSize = cardNumber.length - 4
+  const lastFour = cardNumber.substring(hashedSize)
+  return new Array(hashedSize + 1).join('*') + lastFour
 }

--- a/app/utils/correlation_header.js
+++ b/app/utils/correlation_header.js
@@ -1,1 +1,3 @@
+'use strict'
+
 exports.CORRELATION_HEADER = 'x-request-id'

--- a/app/utils/custom_certificate.js
+++ b/app/utils/custom_certificate.js
@@ -9,31 +9,24 @@ const logger = require('winston')
 // constants
 const CERTS_PATH = process.env.CERTS_PATH || path.join(__dirname, '/../../certs')
 exports.getCertOptions = (certsPath) => {
-    try {
-      if (!fs.lstatSync(certsPath).isDirectory()) {
-        logger.error('Provided CERTS_PATH is not a directory', {
-          certsPath: certsPath
-        })
-        return
-      }
-    } catch (e) {
-      logger.error('Provided CERTS_PATH could not be read', {
-        certsPath: certsPath
-      })
-      return
+  certsPath = certsPath || CERTS_PATH
+  try {
+    if (fs.lstatSync(certsPath).isDirectory()) {
+      // Read everything from the certificates directories
+      // Get everything that isn't a directory (e.g. files, symlinks)
+      // Read it (assume it is a certificate)
+      // Add it to the agentOptions list of CAs
+      const ca = []
+      fs.readdirSync(certsPath)
+        .map(certPath => path.join(certsPath, certPath))
+        .filter(fullCertPath => !fs.lstatSync(fullCertPath).isDirectory())
+        .map(fullCertPath => fs.readFileSync(fullCertPath))
+        .forEach(caCont => ca.push(caCont))
+      return ca
+    } else {
+      logger.error('Provided CERTS_PATH is not a directory', {certsPath})
     }
-
-    var ca = []
-    // Read everything from the certificates directories
-    // Get everything that isn't a directory (e.g. files, symlinks)
-    // Read it (assume it is a certificate)
-    // Add it to the agentOptions list of CAs
-    fs.readdirSync(certsPath)
-      .map(certPath => path.join(certsPath, certPath))
-      .filter(fullCertPath => !fs.lstatSync(fullCertPath).isDirectory())
-      .map(fullCertPath => fs.readFileSync(fullCertPath))
-      .forEach(caCont => ca.push(caCont))
-
-    return ca
+  } catch (e) {
+    logger.error('Provided CERTS_PATH could not be read', {certsPath})
   }
 }

--- a/app/utils/custom_certificate.js
+++ b/app/utils/custom_certificate.js
@@ -1,12 +1,14 @@
-var path = require('path')
-var fs = require('fs')
+'use strict'
+// core dependencies
+const path = require('path')
+const fs = require('fs')
 
-var logger = require('winston')
+// npm dependencies
+const logger = require('winston')
 
-module.exports = {
-  getCertOptions: function () {
-    var certsPath = process.env.CERTS_PATH || path.join(__dirname, '/../../certs')
-
+// constants
+const CERTS_PATH = process.env.CERTS_PATH || path.join(__dirname, '/../../certs')
+exports.getCertOptions = (certsPath) => {
     try {
       if (!fs.lstatSync(certsPath).isDirectory()) {
         logger.error('Provided CERTS_PATH is not a directory', {

--- a/app/utils/email_tools.js
+++ b/app/utils/email_tools.js
@@ -1,40 +1,27 @@
+'use strict'
+
 /* Uses Regexes from the rfc822-validate library.
    We use rfc822-validate in our email validation
    so this follows that standard. */
 
-var emailTools = function (email) {
-  'use strict'
+const sQtext = '[^\\x0d\\x22\\x5c\\x80-\\xff]'
+const sDtext = '[^\\x0d\\x5b-\\x5d\\x80-\\xff]'
+const sAtom = '[^\\x00-\\x20\\x22\\x28\\x29\\x2c\\x2e\\x3a-\\x3c\\x3e\\x40\\x5b-\\x5d\\x7f-\\xff]+'
+const sQuotedPair = '\\x5c[\\x00-\\x7f]'
+const sDomainLiteral = '\\x5b(' + sDtext + '|' + sQuotedPair + ')*\\x5d'
+const sQuotedString = '\\x22(' + sQtext + '|' + sQuotedPair + ')*\\x22'
+const sSubDomain = '(' + sAtom + '|' + sDomainLiteral + ')'
+const sWord = '(' + sAtom + '|' + sQuotedString + ')'
+const sDomain = sSubDomain + '(\\x2e' + sSubDomain + ')*'
+const sLocalPart = sWord + '(\\x2e' + sWord + ')*'
+const sAddrSpec = '(' + sLocalPart + ')' + '\\x40' + '(' + sDomain + ')' // complete RFC822 email address spec
+const sValidEmail = '^' + sAddrSpec + '$' // as whole string
+const reValidEmail = new RegExp(sValidEmail)
 
-  var init = (function () {
-    var sQtext = '[^\\x0d\\x22\\x5c\\x80-\\xff]'
-    var sDtext = '[^\\x0d\\x5b-\\x5d\\x80-\\xff]'
-    var sAtom = '[^\\x00-\\x20\\x22\\x28\\x29\\x2c\\x2e\\x3a-\\x3c\\x3e\\x40\\x5b-\\x5d\\x7f-\\xff]+'
-    var sQuotedPair = '\\x5c[\\x00-\\x7f]'
-    var sDomainLiteral = '\\x5b(' + sDtext + '|' + sQuotedPair + ')*\\x5d'
-    var sQuotedString = '\\x22(' + sQtext + '|' + sQuotedPair + ')*\\x22'
-    var sDomainRef = sAtom
-    var sSubDomain = '(' + sDomainRef + '|' + sDomainLiteral + ')'
-    var sWord = '(' + sAtom + '|' + sQuotedString + ')'
-    var sDomain = sSubDomain + '(\\x2e' + sSubDomain + ')*'
-    var sLocalPart = sWord + '(\\x2e' + sWord + ')*'
-    var sAddrSpec = '(' + sLocalPart + ')' + '\\x40' + '(' + sDomain + ')' // complete RFC822 email address spec
-    var sValidEmail = '^' + sAddrSpec + '$' // as whole string
-
-    var reValidEmail = new RegExp(sValidEmail)
-
-    var f = function (email) {
-      return reValidEmail.exec(email)
-    }
-
-    return f
-  }())
-
-  var match = init(email)
-
+module.exports = email => {
+  const match = reValidEmail.exec(email)
   return {
-    'local-part': (match !== null) ? match[1] : false,
-    'domain': (match !== null) ? match[7] : false
+    'local-part': match !== null ? match[1] : false,
+    'domain': match !== null ? match[7] : false
   }
 }
-
-module.exports = emailTools

--- a/app/utils/flattened_paths.js
+++ b/app/utils/flattened_paths.js
@@ -1,24 +1,20 @@
+'use strict'
 // this is to get a one dimensional array of the routes,
 // so we can infer the pathname from the req route path
 
-  module.exports = function (paths) {
-    'use strict'
-
-    var flattenObject = function (paths) {
-      var flattenedPaths = {}
-      for (var controllerName in paths) {
-        if (paths.hasOwnProperty(controllerName)) {
-          var controller = paths[controllerName]
-          if (typeof controller !== 'object') continue
-          for (var actionName in controller) {
-            if (controller.hasOwnProperty(actionName)) {
-              var action = controller[actionName]
-              flattenedPaths[action.path + '_' + action.action] = `${controllerName}.${actionName}`
-            }
-          }
+module.exports = paths => {
+  const flattenedPaths = {}
+  for (const controllerName in paths) {
+    if (paths.hasOwnProperty(controllerName)) {
+      const controller = paths[controllerName]
+      if (typeof controller !== 'object') continue
+      for (const actionName in controller) {
+        if (controller.hasOwnProperty(actionName)) {
+          const action = controller[actionName]
+          flattenedPaths[`${action.path}_${action.action}`] = `${controllerName}.${actionName}`
         }
       }
-      return flattenedPaths
     }
-    return flattenObject(paths)
   }
+  return flattenedPaths
+}

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -1,36 +1,37 @@
-/* jslint node: true */
 'use strict'
-var logger = require('winston')
-module.exports = {
 
-  authChargePost: function (url) {
-    logger.debug('Calling connector to authorize a charge (post card details) -', {
-      service: 'connector',
-      method: 'POST',
-      url: url
-    })
-  },
-  failedChargePost: function (status, url) {
-    logger.warn('Calling connector to authorize a charge (post card details) failed -', {
-      service: 'connector',
-      method: 'POST',
-      status: status,
-      url: url
-    })
-  },
+// npm dependencies
+const logger = require('winston')
 
-  failedChargePostException: function (err) {
-    logger.error('Calling connector to authorize a charge (post card details) threw exception -', {
-      service: 'connector',
-      method: 'POST',
-      error: err
-    })
-  },
-  failedChargePatch: function (err) {
-    logger.warn('Calling connector to patch a charge failed -', {
-      service: 'connector',
-      method: 'POST',
-      err: err
-    })
-  }
+exports.authChargePost = url => {
+  logger.debug('Calling connector to authorize a charge (post card details) -', {
+    service: 'connector',
+    method: 'POST',
+    url: url
+  })
+}
+
+exports.failedChargePost = (status, url) => {
+  logger.warn('Calling connector to authorize a charge (post card details) failed -', {
+    service: 'connector',
+    method: 'POST',
+    status: status,
+    url: url
+  })
+}
+
+exports.failedChargePostException = err => {
+  logger.error('Calling connector to authorize a charge (post card details) threw exception -', {
+    service: 'connector',
+    method: 'POST',
+    error: err
+  })
+}
+
+exports.failedChargePatch = err => {
+  logger.warn('Calling connector to patch a charge failed -', {
+    service: 'connector',
+    method: 'POST',
+    err: err
+  })
 }

--- a/app/utils/luhn.js
+++ b/app/utils/luhn.js
@@ -1,47 +1,36 @@
+'use strict'
 // COPIED OVER FROM NODE_LUHN
 // https://github.com/JamesEggers1/node-luhn/issues/12
-'use strict'
-module.exports = (function () {
-  function validate (cardNumber) {
-    var trimmed = String(cardNumber).replace(/[\s]/g, '')
-    var length = trimmed.length
-    var odd = false
-    var total = 0
-    var calc
-    var calc2
+exports.validate = cardNumber => {
+  const trimmed = String(cardNumber).replace(/[\s]/g, '')
+  const length = trimmed.length
+  let odd = false
+  let total = 0
+  let calc
+  let calc2
 
-    if (length === 0) {
-      return true
-    }
+  if (length === 0) return true
+  if (!/^[0-9]+$/.test(trimmed)) return false
 
-    if (!/^[0-9]+$/.test(trimmed)) {
-      return false
-    }
+  for (let i = length; i > 0; i--) {
+    calc = parseInt(trimmed.charAt(i - 1))
+    if (!odd) {
+      total += calc
+    } else {
+      calc2 = calc * 2
 
-    for (var i = length; i > 0; i--) {
-      calc = parseInt(trimmed.charAt(i - 1))
-      if (!odd) {
-        total += calc
-      } else {
-        calc2 = calc * 2
-
-        switch (calc2) {
-          case 10: calc2 = 1; break
-          case 12: calc2 = 3; break
-          case 14: calc2 = 5; break
-          case 16: calc2 = 7; break
-          case 18: calc2 = 9; break
-          default: calc2 = calc2 // eslint-disable-line
-        }
-        total += calc2
+      switch (calc2) {
+        case 10: calc2 = 1; break
+        case 12: calc2 = 3; break
+        case 14: calc2 = 5; break
+        case 16: calc2 = 7; break
+        case 18: calc2 = 9; break
+        default: break
       }
-      odd = !odd
+      total += calc2
     }
-
-    return ((total % 10) === 0)
+    odd = !odd
   }
 
-  return {
-    validate: validate
-  }
-}())
+  return (total % 10) === 0
+}

--- a/app/utils/metrics.js
+++ b/app/utils/metrics.js
@@ -1,19 +1,13 @@
-/* jslint node: true */
 'use strict'
-var appmetrics = require('appmetrics')
-var metricsHost = process.env.METRICS_HOST || 'localhost'
-var metricsPort = process.env.METRICS_PORT || 8125
-var metricsPrefix = 'frontend.'
 
-function initialiseMonitoring () {
+const appmetrics = require('appmetrics')
+const metricsHost = process.env.METRICS_HOST || 'localhost'
+const metricsPort = process.env.METRICS_PORT || 8125
+const metricsPrefix = 'frontend.'
+
+exports.metrics = () => {
   appmetrics.configure({'mqtt': 'off'})
-  var appmetricsStatsd = require('appmetrics-statsd')
+  const appmetricsStatsd = require('appmetrics-statsd')
 
   return appmetricsStatsd.StatsD(null, metricsHost, metricsPort, metricsPrefix)
 }
-
-module.exports = (function () {
-  return {
-    metrics: initialiseMonitoring
-  }
-}())

--- a/app/utils/no_cache.js
+++ b/app/utils/no_cache.js
@@ -1,6 +1,6 @@
-module.exports = function (res) {
-  'use strict'
+'use strict'
 
+module.exports = res => {
   res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate')
   res.header('Expires', '-1')
   res.header('Pragma', 'no-cache')

--- a/app/utils/random.js
+++ b/app/utils/random.js
@@ -1,33 +1,21 @@
 'use strict'
 
-function randomInt (min, max) {
-  return Math.floor(Math.random() * (max - min + 1)) + min
-}
+exports.key = length => {
+  const buf = []
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789'
+  for (let i = 0; i < length; ++i) {
+    buf.push(chars[exports.randomInt(0, chars.length - 1)])
+  }
 
-function randomUuid () {
+  return buf.join('')
+}
+exports.randomUuid = () => {
   // See:
   // http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
-  return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+  return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, c => {
     const r = Math.random() * 16 | 0
     const v = c === 'x' ? r : (r & 0x3 | 0x8)
     return v.toString(16)
   })
 }
-
-function key (length) {
-  let buf = []
-  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789'
-  const charlen = chars.length
-
-  for (let i = 0; i < length; ++i) {
-    buf.push(chars[randomInt(0, charlen - 1)])
-  }
-
-  return buf.join('')
-}
-
-module.exports = {
-  randomInt: randomInt,
-  randomUuid: randomUuid,
-  key: key
-}
+exports.randomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -1,34 +1,32 @@
+'use strict'
+
+// npm dependencies
 const logger = require('winston')
 
-module.exports = {
-  logRequestStart: context => {
-    logger.debug(`Calling ${context.service}  ${context.description}-`, {
-      service: context.service,
-      method: context.method,
-      url: context.url
-    })
-  },
-
-  logRequestEnd: context => {
-    let duration = new Date() - context.startTime
-    logger.info(`[${context.correlationId}] - ${context.method} to ${context.url} ended - elapsed time: ${duration} ms`)
-  },
-
-  logRequestFailure: (context, response) => {
-    logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed -`, {
-      service: context.service,
-      method: context.method,
-      url: context.url,
-      status: response.statusCode
-    })
-  },
-
-  logRequestError: (context, error) => {
-    logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception -`, {
-      service: context.service,
-      method: context.method,
-      url: context.url,
-      error: error
-    })
-  }
+exports.logRequestStart = context => {
+  logger.debug(`Calling ${context.service}  ${context.description}-`, {
+    service: context.service,
+    method: context.method,
+    url: context.url
+  })
+}
+exports.logRequestEnd = context => {
+  const duration = new Date() - context.startTime
+  logger.info(`[${context.correlationId}] - ${context.method} to ${context.url} ended - elapsed time: ${duration} ms`)
+}
+exports.logRequestFailure = (context, response) => {
+  logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed -`, {
+    service: context.service,
+    method: context.method,
+    url: context.url,
+    status: response.statusCode
+  })
+}
+exports.logRequestError = (context, error) => {
+  logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception -`, {
+    service: context.service,
+    method: context.method,
+    url: context.url,
+    error: error
+  })
 }

--- a/app/utils/session.js
+++ b/app/utils/session.js
@@ -1,16 +1,7 @@
 'use strict'
 
-var cookie = require('../utils/cookies')
+// local dependencies
+const cookie = require('../utils/cookies')
 
-module.exports = (function () {
-  var createChargeIdSessionKey = function (chargeId) {
-    return 'ch_' + chargeId
-  }
-  var retrieve = function (req, chargeId) {
-    return cookie.getSessionVariable(req, createChargeIdSessionKey(chargeId))
-  }
-  return {
-    retrieve: retrieve,
-    createChargeIdSessionKey: createChargeIdSessionKey
-  }
-}())
+exports.createChargeIdSessionKey = chargeId => 'ch_' + chargeId
+exports.retrieve = (req, chargeId) => cookie.getSessionVariable(req, exports.createChargeIdSessionKey(chargeId))

--- a/test/integration/util_cookies_ft_tests.js
+++ b/test/integration/util_cookies_ft_tests.js
@@ -1,18 +1,33 @@
-var assert = require('assert')
-var cookies = require('../../app/utils/cookies.js')
+'use strict'
+
+// npm dependencies
+const {expect} = require('chai')
+const proxyquire = require('proxyquire').noPreserveCache()
 
 describe('frontend cookie', function () {
+  let initialEnvironmentVariables
+  before(() => {
+    initialEnvironmentVariables = Object.assign({}, process.env)
+  })
+
+  afterEach(() => {
+    for (const envVar in process.env) {
+      process.env[envVar] = initialEnvironmentVariables[envVar]
+    }
+  })
   it('should have secure proxy off in unsecured environment', function () {
     process.env.SECURE_COOKIE_OFF = 'true'
-    assert.equal('frontend_state', cookies.getSessionCookieName())
-    assert.equal(true, cookies.namedCookie('name', 'key').proxy)
-    assert.deepEqual({httpOnly: true, secureProxy: false, maxAge: 5400000}, cookies.namedCookie('name', 'key').cookie)
+    const cookies = proxyquire('../../app/utils/cookies.js', {})
+    expect(cookies.getSessionCookieName()).to.equal('frontend_state')
+    expect(cookies.namedCookie('name', 'key').proxy).to.equal(true)
+    expect(cookies.namedCookie('name', 'key').cookie).to.deep.equal({httpOnly: true, secureProxy: false, maxAge: 5400000})
   })
 
   it('should have secure proxy on in a secured https environment', function () {
     process.env.SECURE_COOKIE_OFF = 'false'
-    assert.equal('frontend_state', cookies.getSessionCookieName())
-    assert.equal(true, cookies.namedCookie('name', 'key').proxy)
-    assert.deepEqual({httpOnly: true, secureProxy: true, maxAge: 5400000}, cookies.namedCookie('name', 'key').cookie)
+    const cookies = proxyquire('../../app/utils/cookies.js', {})
+    expect(cookies.getSessionCookieName()).to.equal('frontend_state')
+    expect(cookies.namedCookie('name', 'key').proxy).to.equal(true)
+    expect(cookies.namedCookie('name', 'key').cookie).to.deep.equal({httpOnly: true, secureProxy: true, maxAge: 5400000})
   })
 })

--- a/test/unit/custom_certificate_tests.js
+++ b/test/unit/custom_certificate_tests.js
@@ -1,18 +1,18 @@
-var path = require('path')
-var assert = require('assert')
-var customCertificate = require(path.join(__dirname, '/../../app/utils/custom_certificate.js'))
+'use strict'
 
-describe('custom certificate', function () {
-  beforeEach(function () {
-    process.env.CERTS_PATH = path.join(__dirname, '/../test_helpers/certs')
-  })
+// core dependencies
+const path = require('path')
 
-  afterEach(function () {
-    process.env.CERTS_PATH = undefined
-  })
+// npm dependencies
+const {expect} = require('chai')
+const customCertificate = require('../../app/utils/custom_certificate.js')
 
-  it('should set secure options', function () {
-    let ca = customCertificate.getCertOptions()
-    assert.equal(1, ca.length)
+// constants
+const CERTS_PATH = path.join(__dirname, '/../test_helpers/certs')
+
+describe('custom certificate', () => {
+  it('should set secure options', () => {
+    const ca = customCertificate.getCertOptions(CERTS_PATH)
+    expect(ca.length).to.equal(1)
   })
 })


### PR DESCRIPTION
## WHAT
Refactoring  utils in frontend:
- to remove unnecessary inner functions and variables
- to remove unnecessary IIFEs
- to extract calls to `process.env` to constants
- to use `exports.<property-name>` over `module.exports.<property-name>`