### PR TITLE
PP-3266 refactor middleware

### DIFF
--- a/app/middleware/action_name.js
+++ b/app/middleware/action_name.js
@@ -1,12 +1,10 @@
 'use strict'
 
-var paths = require('./../paths.js')
-var flatPaths = require('./../utils/flattened_paths.js')(paths)
+// local dependencies
+const paths = require('./../paths.js')
+const flatPaths = require('./../utils/flattened_paths.js')(paths)
 
 module.exports = function (req, res, next) {
-  'use strict'
-
-  var method = Object.keys(req.route.methods)[0]
-  req.actionName = flatPaths[req.route.path + '_' + method]
+  req.actionName = flatPaths[`${req.route.path}_${req.method.toLowerCase()}`]
   next()
 }

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -1,21 +1,20 @@
 'use strict'
 
+// npm dependencies
 const logger = require('winston')
 
+// local dependencies
 const views = require('../utils/views.js')
 const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
 const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 const getAdminUsersClient = require('../services/clients/adminusers_client')
 
-module.exports = function (req, res, next) {
-  'use strict'
+module.exports = (req, res, next) => {
   const _views = views.create()
-
   if (!req.chargeId && !req.chargeData) {
     _views.display(res, 'UNAUTHORISED', withAnalyticsError())
   } else {
-    let correlationId = req.headers[CORRELATION_HEADER]
-    return getAdminUsersClient({correlationId: correlationId})
+    return getAdminUsersClient({correlationId: req.headers[CORRELATION_HEADER]})
       .findServiceBy({gatewayAccountId: req.chargeData.gateway_account.gateway_account_id})
       .then(service => {
         res.locals.service = service

--- a/app/middleware/retrieve_charge.js
+++ b/app/middleware/retrieve_charge.js
@@ -1,16 +1,17 @@
-const views = require('../utils/views.js')
+'use strict'
+
+// local dependencies
+const views = require('../utils/views.js').create()
 const Charge = require('../models/charge.js')
 const chargeParam = require('../services/charge_param_retriever.js')
 const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
 const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 
-module.exports = function (req, res, next) {
-  'use strict'
-  const _views = views.create()
+module.exports = (req, res, next) => {
   const chargeId = chargeParam.retrieve(req)
 
   if (!chargeId) {
-    _views.display(res, 'UNAUTHORISED', withAnalyticsError())
+    views.display(res, 'UNAUTHORISED', withAnalyticsError())
   } else {
     req.chargeId = chargeId
     Charge(req.headers[CORRELATION_HEADER]).find(chargeId)
@@ -19,7 +20,7 @@ module.exports = function (req, res, next) {
         next()
       })
       .catch(() => {
-        _views.display(res, 'SYSTEM_ERROR', withAnalyticsError())
+        views.display(res, 'SYSTEM_ERROR', withAnalyticsError())
       })
   }
 }

--- a/test/middleware/action_name_test.js
+++ b/test/middleware/action_name_test.js
@@ -9,8 +9,8 @@ describe('actionName', function () {
   it('should append the viewname to the request', function () {
     var next = sinon.spy()
     var req = {
+      method: 'POST',
       route: {
-        methods: {post: true},
         path: '/card_details/:chargeId'
       }
     }
@@ -22,13 +22,13 @@ describe('actionName', function () {
   it('should not append the viewname to the request if it cannot match', function () {
     var next = sinon.spy()
     var req = {
+      method: 'POST',
       route: {
-        methods: {post: true},
         path: '/invalid'
       }
     }
     actionName(req, {}, next)
-    expect(next.calledOnce).to.be.true // eslint-disable-line 
+    expect(next.calledOnce).to.be.true // eslint-disable-line
     assert.equal(req.actionName, undefined)
   })
 })

--- a/test/middleware/csrf_test.js
+++ b/test/middleware/csrf_test.js
@@ -18,6 +18,7 @@ describe('retrieve param test', function () {
   var render
   var next
   var validGetRequest = {
+    method: 'GET',
     params: {chargeId: 'foo'},
     body: {},
     route: {methods: {get: true}},
@@ -35,11 +36,11 @@ describe('retrieve param test', function () {
   delete noSecret.frontend_state.ch_foo.csrfSecret
 
   var invalidPost = _.cloneDeep(validGetRequest)
-  delete invalidPost.route.methods.get
+  delete invalidPost.method
   var invalidPut = _.cloneDeep(invalidPost)
 
-  invalidPost.route.methods.post = true
-  invalidPut.route.methods.put = true
+  invalidPost.method = 'POST'
+  invalidPut.method = 'PUT'
 
   var validPost = _.cloneDeep(invalidPost)
   validPost.body.csrfToken = helper.csrfToken()


### PR DESCRIPTION
## WHAT
Refactor middleware to:
 - use strict
 - prefer const
 - eliminate unnecessary inner functions and variables
 - to use `exports.<property-name>` over `module.exports.<property-name>`


