### PR TITLE
bumping product page version to include minor updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "node-sass": "4.7.x",
     "nyc": "11.3.x",
     "pact": "1.0.0",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.2/pay-product-page-2.1.2.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.5/pay-product-page-2.1.5.tgz",
     "proxyquire": "~1.8.0",
     "sass-lint": "^1.10.2",
     "sinon": "4.1.x",


### PR DESCRIPTION
bumping product page version to include minor updates

[0c82a9c](https://github.com/alphagov/pay-product-page/commit/0c82a9c211113ffca80b2c2d0c22897a9bac4d52) - Fixing broken roadmap link
[5ee03e0](https://github.com/alphagov/pay-product-page/commit/5ee03e0d0afc2ea34f8798202dde523319dc21a5) - PP-2651 - adding guidance on how long an integration takes
[fa8f923](https://github.com/alphagov/pay-product-page/commit/fa8f923dfb0e4c14f55cdb84b5253b224d9f7d43) - Use ‘to’ not hyphens for date ranges