### PR TITLE
PP-3304 add service to charge session cookie

### DIFF
--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -6,16 +6,22 @@ const logger = require('winston')
 // local dependencies
 const views = require('../utils/views.js')
 const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
+const session = require('../utils/session.js')
+const {setSessionVariable} = require('../utils/cookies')
 const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 const getAdminUsersClient = require('../services/clients/adminusers_client')
 
 module.exports = (req, res, next) => {
-  if (!req.chargeId && !req.chargeData) {
-    views.display(res, 'UNAUTHORISED', withAnalyticsError())
+  if (!req.chargeId && !req.chargeData) return views.display(res, 'UNAUTHORISED', withAnalyticsError())
+  const chargeSession = session.retrieve(req, req.chargeId) || {}
+  if (chargeSession.service) {
+    res.locals.service = chargeSession.service
+    next()
   } else {
     return getAdminUsersClient({correlationId: req.headers[CORRELATION_HEADER]})
       .findServiceBy({gatewayAccountId: req.chargeData.gateway_account.gateway_account_id})
       .then(service => {
+        setSessionVariable(req, session.createChargeIdSessionKey(req.chargeId), {service})
         res.locals.service = service
         next()
       })

--- a/app/router.js
+++ b/app/router.js
@@ -37,8 +37,8 @@ exports.bind = function (app) {
     csrfTokenGeneration,
     actionName,
     retrieveCharge,
-    stateEnforcer,
-    resolveService
+    resolveService,
+    stateEnforcer
   ]
 
   app.get(card.new.path, middlewareStack, charge.new)

--- a/app/utils/cookies.js
+++ b/app/utils/cookies.js
@@ -26,9 +26,8 @@ module.exports = {
  * @param {string} cookieName
  */
 function setValueOnCookie (req, key, value, cookieName) {
-  if (typeof req[cookieName] === 'object') {
-    req[cookieName][key] = value
-  }
+  if (typeof req[cookieName] !== 'object') return
+  req[cookieName][key] = Object.assign(req[cookieName][key] || {}, value)
 }
 
 /**

--- a/app/utils/cookies.js
+++ b/app/utils/cookies.js
@@ -27,7 +27,11 @@ module.exports = {
  */
 function setValueOnCookie (req, key, value, cookieName) {
   if (typeof req[cookieName] !== 'object') return
-  req[cookieName][key] = Object.assign(req[cookieName][key] || {}, value)
+  if (typeof value === 'object') {
+    req[cookieName][key] = Object.assign(req[cookieName][key] || {}, value)
+  } else {
+    req[cookieName][key] = value
+  }
 }
 
 /**

--- a/test/unit/cookies_test.js
+++ b/test/unit/cookies_test.js
@@ -145,6 +145,19 @@ describe('setting value on session', function () {
     expect(req.frontend_state.foo).to.equal('bar')
   })
 
+  it('should set object on frontend_state and add to it not replace it', function () {
+    let cookies = getCookiesUtil()
+    let req = {
+      frontend_state: {
+      }
+    }
+
+    cookies.setSessionVariable(req, 'foo', {a: 'f'})
+    cookies.setSessionVariable(req, 'foo', {b: 'o'})
+
+    expect(req.frontend_state.foo).to.deep.equal({a: 'f', b: 'o'})
+  })
+
   it('should set value on frontend_state_2 if SESSION_ENCRYPTION_KEY_2 set', function () {
     let originalKey = process.env.SESSION_ENCRYPTION_KEY
     process.env.SESSION_ENCRYPTION_KEY = ''


### PR DESCRIPTION
with @maxcbc

Custom branding is configured by the service, to keep things
consistant we should show custom branding on error pages too.

Updated resolve_service:
- use cookie to store service info
- use cookie service info if available
- resolve_service middleware should be available to error pages
