### PR TITLE
PP-3092 Use req.hostname for 3ds IN url 

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -178,7 +178,7 @@ module.exports = {
     views.display(res, AUTH_3DS_REQUIRED_OUT_VIEW, {
       issuerUrl: _.get(charge, 'auth3dsData.issuerUrl'),
       paRequest: _.get(charge, 'auth3dsData.paRequest'),
-      termUrl: paths.generateRoute('external.card.auth3dsRequiredIn', {chargeId: charge.id})
+      threeDSReturnUrl: `${req.protocol}://${req.hostname}${paths.generateRoute('external.card.auth3dsRequiredIn', {chargeId: charge.id})}`
     })
   },
   auth3dsRequiredIn: (req, res) => {

--- a/app/paths.js
+++ b/app/paths.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var _ = require('lodash')
 var generateRoute = require('./utils/generate_route.js')
 
 if (process.env.CONNECTOR_HOST === undefined) throw new Error('CONNECTOR_HOST environment variable is not defined')
@@ -130,15 +129,15 @@ var paths = {
   }
 }
 
-var extendedPaths = _.extend({}, paths, {
-  external: {
-    card: {
-      auth3dsRequiredIn: {
-        path: process.env.FRONTEND_URL + paths.card.auth3dsRequiredIn.path,
-        action: 'post'
-      }
+paths.external = {
+  card: {
+    auth3dsRequiredIn: {
+      path: paths.card.auth3dsRequiredIn.path,
+      action: 'post'
     }
   }
-})
+}
 
-module.exports = _.extend({}, extendedPaths, {generateRoute: generateRoute(extendedPaths)})
+paths.generateRoute = generateRoute(paths)
+
+module.exports = paths

--- a/app/views/auth_3ds_required_out.njk
+++ b/app/views/auth_3ds_required_out.njk
@@ -9,7 +9,7 @@
 </noscript>
 <form name="three_ds_required" method="post" action="{{ issuerUrl }}">
   <input type="hidden" name="PaReq" value="{{ paRequest }}"/>
-  <input type="hidden" name="TermUrl" value="{{ termUrl }}"/>
+  <input type="hidden" name="TermUrl" value="{{ threeDSReturnUrl }}"/>
   <noscript>
     <button id="confirm" class="button">Continue</button>
   </noscript>


### PR DESCRIPTION
 # PP-3092 Use req.hostname for 3ds IN url
- We were using a env-var for the hostname in the 3ds in url, this switches to using req.protocol followed by req.hostname