### PR TITLE
PP-3395 Cache service in memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "humps": "^2.0.1",
     "i18n": "0.8.x",
     "lodash": "4.17.x",
+    "memory-cache": "^0.2.0",
     "minimist": "1.2.x",
     "morgan": "1.9.x",
     "nunjucks": "^3.0.1",

--- a/test/middleware/resolve_service_test.js
+++ b/test/middleware/resolve_service_test.js
@@ -72,7 +72,7 @@ describe('resolve service middleware', function () {
   })
 
   it('should log an error if it fails to retrieving service data', function (done) {
-    const gatewayAccountId = '1'
+    const gatewayAccountId = Math.random()
     const resolveService = resolveServiceMiddleware(q.reject())
     let chargeData = {}
     _.set(chargeData, 'gateway_account.gateway_account_id', gatewayAccountId)


### PR DESCRIPTION
# PP-3395 Cache service in memory
- use `memory-cache` to store service in cache rather than in cookie