### PR TITLE
BAU - bump product page version to publish Till’s copy changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "node-sass": "4.7.x",
     "nyc": "11.3.x",
     "pact": "1.0.0",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.5/pay-product-page-2.1.5.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.6/pay-product-page-2.1.6.tgz",
     "proxyquire": "~1.8.0",
     "sass-lint": "^1.10.2",
     "sinon": "4.1.x",


### PR DESCRIPTION
Bump product page to this release https://github.com/alphagov/pay-product-page/releases/tag/2.1.6

To include these changes
https://github.com/alphagov/pay-product-page/commit/f6921c8a6ff1b2f3227b1b70f77892d894771248
https://github.com/alphagov/pay-product-page/commit/74603ce8922e056845f3f99cd56b542a25be0a58