### PR TITLE
PP-3351 Pinned hoek sub-dependency at non vunerable version 4.2.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1335,9 +1335,9 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
         },
         "hoek": {
-          "version": "2.16.3",
+          "version": "4.2.1",
           "from": "hoek@2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz"
         },
         "http-signature": {
           "version": "1.1.1",


### PR DESCRIPTION
## WHAT
Bumps the version of hoek in the shrinkwrap for the fsevents sub dependency to 4.2.1, over the 2.x version it is pinned at by fsevents.

This fixes a prototype pollution attack vulnerability outlined by Snyk.


