### PR TITLE
PP-3451 handling epdq auth 3ds out view

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -17,6 +17,7 @@ const CONFIRM_VIEW = 'confirm'
 const AUTH_WAITING_VIEW = 'auth_waiting'
 const AUTH_3DS_REQUIRED_VIEW = 'auth_3ds_required'
 const AUTH_3DS_REQUIRED_OUT_VIEW = 'auth_3ds_required_out'
+const AUTH_3DS_REQUIRED_HTML_OUT_VIEW = 'auth_3ds_required_html_out'
 const AUTH_3DS_REQUIRED_IN_VIEW = 'auth_3ds_required_in'
 const CAPTURE_WAITING_VIEW = 'capture_waiting'
 const preserveProperties = ['cardholderName', 'addressLine1', 'addressLine2', 'addressCity', 'addressPostcode', 'addressCountry']
@@ -175,11 +176,23 @@ module.exports = {
   },
   auth3dsRequiredOut: (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)
-    views.display(res, AUTH_3DS_REQUIRED_OUT_VIEW, {
-      issuerUrl: _.get(charge, 'auth3dsData.issuerUrl'),
-      paRequest: _.get(charge, 'auth3dsData.paRequest'),
-      threeDSReturnUrl: `${req.protocol}://${req.hostname}${paths.generateRoute('external.card.auth3dsRequiredIn', {chargeId: charge.id})}`
-    })
+    const issuerUrl = _.get(charge, 'auth3dsData.issuerUrl')
+    const paRequest = _.get(charge, 'auth3dsData.paRequest')
+    const htmlOut = _.get(charge, 'auth3dsData.htmlOut')
+
+    if (issuerUrl && paRequest) {
+      views.display(res, AUTH_3DS_REQUIRED_OUT_VIEW, {
+        issuerUrl: issuerUrl,
+        paRequest: paRequest,
+        threeDSReturnUrl: `${req.protocol}://${req.hostname}${paths.generateRoute('external.card.auth3dsRequiredIn', {chargeId: charge.id})}`
+      })
+    } else if (htmlOut) {
+      views.display(res, AUTH_3DS_REQUIRED_HTML_OUT_VIEW, {
+        htmlOut: Buffer.from(htmlOut, 'base64').toString('utf8')
+      })
+    } else {
+      views.display(res, 'ERROR', withAnalytics(charge))
+    }
   },
   auth3dsRequiredIn: (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -85,7 +85,8 @@ module.exports = (function () {
   var _normaliseAuth3dsData = function (auth3dsData) {
     return {
       paRequest: auth3dsData.paRequest,
-      issuerUrl: auth3dsData.issuerUrl
+      issuerUrl: auth3dsData.issuerUrl,
+      htmlOut: auth3dsData.htmlOut
     }
   }
 

--- a/app/utils/views.js
+++ b/app/utils/views.js
@@ -48,6 +48,10 @@ module.exports = {
     view: 'auth_3ds_required_out',
     analyticsPage: '/3ds_required'
   },
+  auth_3ds_required_html_out: {
+    view: 'auth_3ds_required_html_out',
+    analyticsPage: '/3ds_required'
+  },
   auth_waiting: {
     view: 'auth_waiting',
     analyticsPage: '/auth_waiting'

--- a/app/views/auth_3ds_required_html_out.njk
+++ b/app/views/auth_3ds_required_html_out.njk
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+{% block head %}
+  {% include "includes/iframe_head.njk" %}
+{% endblock %}
+<body>
+  {{ htmlOut|safe }}
+</body>
+</html>

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -93,7 +93,7 @@ function rawSuccessfulGetChargeDebitCardOnly (status, returnUrl, chargeId, gatew
   return charge
 }
 
-function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId) {
+function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}) {
   var charge = {
     'amount': 2345,
     'description': 'Payment Description',
@@ -177,8 +177,9 @@ function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId) 
   }
   if (status === 'AUTHORISATION 3DS REQUIRED') {
     charge.auth_3ds_data = {
-      'paRequest': 'aPaRequest',
-      'issuerUrl': 'http://issuerUrl.com'
+      'paRequest': auth3dsData.paRequest,
+      'issuerUrl': auth3dsData.issuerUrl,
+      'htmlOut': auth3dsData.htmlOut
     }
   }
   return charge

--- a/test/utils/normalise_test.js
+++ b/test/utils/normalise_test.js
@@ -15,7 +15,8 @@ var unNormalisedCharge = {
   email: 'bobbybobby@bobby.bob',
   auth_3ds_data: {
     paRequest: 'paRequest',
-    issuerUrl: 'issuerUrl'
+    issuerUrl: 'issuerUrl',
+    htmlOut: 'html'
   },
   gateway_account: {
     analytics_id: 'bla-1234',
@@ -43,7 +44,8 @@ var normalisedCharge = {
   email: 'bobbybobby@bobby.bob',
   auth3dsData: {
     paRequest: 'paRequest',
-    issuerUrl: 'issuerUrl'
+    issuerUrl: 'issuerUrl',
+    htmlOut: 'html'
   },
   gatewayAccount: {
     analyticsId: 'bla-1234',
@@ -94,7 +96,7 @@ describe('normalise', function () {
       var passedByReference = {addressLine2: 'foo'}
       normalise.addressLines(passedByReference)
       expect(passedByReference).to.deep.equal({addressLine1: 'foo'})
-      expect(passedByReference.addressLine2).to.be.undefined // eslint-disable-line 
+      expect(passedByReference.addressLine2).to.be.undefined // eslint-disable-line
     })
 
     it('should do nothing if there is addressLine1', function () {


### PR DESCRIPTION
## WHAT
Displays different iframe contents based on the availability of `issuerUrl` and `paRequest` (for Worldpay) or `htmlOut` (in case of `epdq`).
Using `utf8` decoding of html as of now (need to verify with eqdq on this)

with @chrisgrimble

