### PR TITLE
PP-3436 Run e2e, accept and zap separately in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,12 +3,23 @@
 pipeline {
   agent any
 
+  parameters {
+    booleanParam(defaultValue: true, description: '', name: 'runEndToEndTestsOnPR')
+    booleanParam(defaultValue: true, description: '', name: 'runAcceptTestsOnPR')
+    booleanParam(defaultValue: false, description: '', name: 'runZapTestsOnPR')
+  }
+
   options {
     timestamps()
   }
 
   libraries {
     lib("pay-jenkins-library@master")
+  }
+  environment {
+    RUN_END_TO_END_ON_PR = "${params.runEndToEndTestsOnPR}"
+    RUN_ACCEPT_ON_PR = "${params.runAcceptTestsOnPR}"
+    RUN_ZAP_ON_PR = "${params.runZapTestsOnPR}"
   }
 
   stages {
@@ -26,9 +37,42 @@ pipeline {
         }
       }
     }
-    stage('Test') {
-      steps {
-        runEndToEnd("frontend")
+    stage('Tests') {
+      failFast true
+      parallel {
+        stage('End to End Tests') {
+            when {
+                anyOf {
+                  branch 'master'
+                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
+                }
+            }
+            steps {
+                runE2E("frontend")
+            }
+        }
+        stage('Accept Tests') {
+            when {
+                anyOf {
+                  branch 'master'
+                  environment name: 'RUN_ACCEPT_ON_PR', value: 'true'
+                }
+            }
+            steps {
+                runAccept("frontend")
+            }
+        }
+         stage('ZAP Tests') {
+            when {
+                anyOf {
+                  branch 'master'
+                  environment name: 'RUN_ZAP_ON_PR', value: 'true'
+                }
+            }
+            steps {
+                runZap("frontend")
+            }
+         }
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
# PP-3436 Run e2e, accept and zap separately in parallel

## WHAT
This is a jenkinsfile update which:
- switches to using separate e2e, accept and zap test jobs
- runs each of these jobs in parallel
- switches each of these jobs on its own param for testing on pull requests


