### PR TITLE
Pp 3453 handle epdq 3ds response

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -206,8 +206,14 @@ module.exports = {
     const charge = normalise.charge(req.chargeData, req.chargeId)
     views.display(res, AUTH_3DS_REQUIRED_IN_VIEW, {
       threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
-      paResponse: _.get(req, 'body.PaRes'),
-      providerStatus: _.get(req, 'query.status')
+      paResponse: _.get(req, 'body.PaRes')
+    })
+  },
+  auth3dsRequiredInEpdq: (req, res) => {
+    const charge = normalise.charge(req.chargeData, req.chargeId)
+    views.display(res, AUTH_3DS_REQUIRED_IN_VIEW, {
+      threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
+      providerStatus: _.get(req, 'query.status', 'success')
     })
   },
   confirm: (req, res) => {

--- a/app/paths.js
+++ b/app/paths.js
@@ -11,7 +11,7 @@ if (process.env.CONNECTOR_HOST === undefined) throw new Error('CONNECTOR_HOST en
 // the action while not used directly here is used so we can match to the named
 // routes when we have duplicate paths on different actions
 
-var paths = {
+const paths = {
   card: {
     new: {
       path: '/card_details/:chargeId',

--- a/app/paths.js
+++ b/app/paths.js
@@ -33,6 +33,10 @@ const paths = {
       path: '/card_details/:chargeId/3ds_required_in',
       action: 'post'
     },
+    auth3dsRequiredInEpdq: {
+      path: '/card_details/:chargeId/3ds_required_in/epdq',
+      action: 'post'
+    },
     auth3dsRequiredOut: {
       path: '/card_details/:chargeId/3ds_required_out',
       action: 'get'

--- a/app/router.js
+++ b/app/router.js
@@ -1,17 +1,17 @@
 'use strict'
 
-var i18n = require('i18n')
+const i18n = require('i18n')
 
-var charge = require('./controllers/charge_controller.js')
-var secure = require('./controllers/secure_controller.js')
-var statik = require('./controllers/static_controller.js')
-var returnCont = require('./controllers/return_controller.js')
+const charge = require('./controllers/charge_controller.js')
+const secure = require('./controllers/secure_controller.js')
+const statik = require('./controllers/static_controller.js')
+const returnCont = require('./controllers/return_controller.js')
 
-var paths = require('./paths.js')
-var {csrfCheck, csrfTokenGeneration} = require('./middleware/csrf.js')
-var actionName = require('./middleware/action_name.js')
-var stateEnforcer = require('./middleware/state_enforcer.js')
-var retrieveCharge = require('./middleware/retrieve_charge.js')
+const paths = require('./paths.js')
+const {csrfCheck, csrfTokenGeneration} = require('./middleware/csrf.js')
+const actionName = require('./middleware/action_name.js')
+const stateEnforcer = require('./middleware/state_enforcer.js')
+const retrieveCharge = require('./middleware/retrieve_charge.js')
 const resolveService = require('./middleware/resolve_service.js')
 
 exports.paths = paths
@@ -20,15 +20,15 @@ exports.bind = function (app) {
   'use strict'
 
   app.get('/healthcheck', function (req, res) {
-    var data = {'ping': {'healthy': true}}
+    const data = {'ping': {'healthy': true}}
     res.writeHead(200, {'Content-Type': 'application/json'})
     res.end(JSON.stringify(data))
   })
 
   // charges
-  var card = paths.card
+  const card = paths.card
 
-  var middlewareStack = [
+  const middlewareStack = [
     function (req, res, next) {
       i18n.setLocale('en')
       next()

--- a/app/router.js
+++ b/app/router.js
@@ -45,6 +45,8 @@ exports.bind = function (app) {
   app.get(card.authWaiting.path, middlewareStack, charge.authWaiting)
   app.get(card.auth3dsRequired.path, middlewareStack, charge.auth3dsRequired)
   app.get(card.auth3dsRequiredOut.path, middlewareStack, charge.auth3dsRequiredOut)
+  app.post(card.auth3dsRequiredInEpdq.path, [csrfTokenGeneration, retrieveCharge], charge.auth3dsRequiredInEpdq)
+  app.get(card.auth3dsRequiredInEpdq.path, [csrfTokenGeneration, retrieveCharge], charge.auth3dsRequiredInEpdq)
   app.post(card.auth3dsRequiredIn.path, [csrfTokenGeneration, retrieveCharge], charge.auth3dsRequiredIn)
   app.get(card.auth3dsRequiredIn.path, [csrfTokenGeneration, retrieveCharge], charge.auth3dsRequiredIn)
   app.post(card.auth3dsHandler.path, middlewareStack, charge.auth3dsHandler)

--- a/app/router.js
+++ b/app/router.js
@@ -46,6 +46,7 @@ exports.bind = function (app) {
   app.get(card.auth3dsRequired.path, middlewareStack, charge.auth3dsRequired)
   app.get(card.auth3dsRequiredOut.path, middlewareStack, charge.auth3dsRequiredOut)
   app.post(card.auth3dsRequiredIn.path, [csrfTokenGeneration, retrieveCharge], charge.auth3dsRequiredIn)
+  app.get(card.auth3dsRequiredIn.path, [csrfTokenGeneration, retrieveCharge], charge.auth3dsRequiredIn)
   app.post(card.auth3dsHandler.path, middlewareStack, charge.auth3dsHandler)
   app.get(card.captureWaiting.path, middlewareStack, charge.captureWaiting)
   app.post(card.create.path, middlewareStack, charge.create)

--- a/app/views/auth_3ds_required_in.njk
+++ b/app/views/auth_3ds_required_in.njk
@@ -1,18 +1,23 @@
 <!DOCTYPE html>
 <html>
 {% block head %}
-  {% include "includes/iframe_head.njk" %}
+    {% include "includes/iframe_head.njk" %}
 {% endblock %}
 <body OnLoad="OnLoadEvent();">
 <noscript>
-  <p class="lede">The card details have been approved by the bank.</p>
+    <p class="lede">The card details have been approved by the bank.</p>
 </noscript>
 <form name="three_ds_required" method="post" action="{{ threeDsHandlerUrl }}" target="_top">
-  <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
-  <input type="hidden" name="PaRes" value="{{ paResponse }}"/>
-  <noscript>
-    <button id="confirm" class="button">Continue</button>
-  </noscript>
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+    {% if paResponse %}
+        <input type="hidden" name="PaRes" value="{{ paResponse }}"/>
+    {% endif %}
+    {% if providerStatus %}
+        <input type="hidden" name="providerStatus" value="{{ providerStatus }}"/>
+    {% endif %}
+    <noscript>
+        <button id="confirm" class="button">Continue</button>
+    </noscript>
 </form>
 
 <script>


### PR DESCRIPTION
## WHAT
- When receiving a response from the payment gateway, it will
send the user back inside the iframe. To get out from the iframe
we use a form with a target `_top` and at the same time we pass
any data we get from the payment provider as form fields to the
charge_controller. Because some of this data is specific to each
payment gateway, we will set it only if available. After setting this
data as hidden fields we then submit the form and send this data
to connector
- Added both POST and GET to the same path for EPDQ as they
use GET as a fall back when JS is deactivated. This callback url to us
will contain the EPDQ auth status as query param
- The status received from EPDQ is not reliable as this is
resubmitted as a hidden field, however we verify this status in connector
against EPDQ before updating the charge

## HOW 
- Updated auth_3ds template to hide/display data for EPDQ or
WorldPay
- Updated routes for handling EPDQ 3DS


