### PR TITLE
PP-3379 Change documentation link in header and footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "node-sass": "4.7.x",
     "nyc": "11.3.x",
     "pact": "1.0.0",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.7/pay-product-page-2.1.7.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.8/pay-product-page-2.1.8.tgz",
     "proxyquire": "~1.8.0",
     "sass-lint": "^1.10.2",
     "sinon": "4.1.x",


### PR DESCRIPTION
Update the version number of the pay-product-page with documentation url
updated to service url, new tar has been published

solo @belindac