### PR TITLE
PP-3579 - more robust setup

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -15,7 +15,7 @@ const retrieveCharge = require('./middleware/retrieve_charge.js')
 const resolveService = require('./middleware/resolve_service.js')
 const abTest = require('./utils/ab_test.js')
 
-const AB_TEST_THRESHOLD = parseInt(process.env.AB_TEST_THRESHOLD, 10) || 100
+const AB_TEST_THRESHOLD = process.env.AB_TEST_THRESHOLD
 
 exports.paths = paths
 

--- a/app/utils/ab_test.js
+++ b/app/utils/ab_test.js
@@ -47,7 +47,7 @@ exports._getOrSetSession = req => {
 }
 
 exports.switch = opts => {
-  const threshold = Math.floor(opts.threshold || 90)
+  const threshold = Math.floor(parseInt(opts.threshold, 10) || 100)
   const defaultVariant = opts.defaultVariant
   const testingVariant = opts.testingVariant
 


### PR DESCRIPTION
## A Slack conversation…

A question for `pay-frontend` `ab_test.js:50` there is this line `const threshold = Math.floor(opts.threshold || 90)` and it looks like is returning 90 if no `threshold` is passed, also Math.floor seems like is not needed because you get in Integer anyway `const threshold = Math.floor(opts.threshold || 90)`

Toby Lorne [16:27]
defensive programming :open_mouth:

George Racu [16:27]
I think the Math.floor is not necessary
and also the threshold of 90 shouldn’t be 100?

Toby Lorne [16:28]
yeah so there are a couple of layers here
the environment variable passed in is specific to one single ab test
but the Math.floor bit is for all ab tests
so we could have a long running ab test that doesn’t take an environment variable etc

George Racu [16:29]
and the 90 shouldn’t be 100?

Toby Lorne [16:30]
arguably the code should be

```Math.floor(parseInt(opts.threshold, 10) || 100)```

in the ab test file (edited)

George Racu [16:30]
:thumbsup_parrot:

Toby Lorne [16:30]
i nominate you jon :slightly_smiling_face: