### PR TITLE
PP-3602 Remove Product smoke test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,18 +97,9 @@ pipeline {
         deployEcs("frontend")
       }
     }
-    stage('Smoke Tests') {
-      failFast true
-      parallel {
-        stage('Card Smoke Test') {
-          when { branch 'master' }
-          steps { runCardSmokeTest() }
-        }
-        stage('Product Smoke Test') {
-          when { branch 'master' }
-          steps { runProductsSmokeTest() }
-        }
-      }
+    stage('Card Smoke Test') {
+      when { branch 'master' }
+      steps { runCardSmokeTest() }
     }
     stage('Complete') {
       failFast true


### PR DESCRIPTION
When converting staging deployments over to use the selenium tests we
decided only to run product smoke test for products and products-ui

solo @belindac