### PR TITLE
Add all .uk second-level domains to mailcheck.js default TLDs

### DIFF
--- a/app/utils/email_tools.js
+++ b/app/utils/email_tools.js
@@ -30,7 +30,22 @@ const validEmail = email => {
 }
 
 const commonTypos = email => {
-  mailcheck.defaultTopLevelDomains.push('gov.uk', 'org.uk')
+  mailcheck.defaultTopLevelDomains.push(
+    'ac.uk',
+    'co.uk',
+    'gov.uk',
+    'judiciary.uk',
+    'ltd.uk',
+    'me.uk',
+    'mod.uk',
+    'net.uk',
+    'nhs.uk',
+    'nic.uk',
+    'org.uk',
+    'parliament.uk',
+    'plc.uk',
+    'police.uk',
+    'sch.uk')
   return mailcheck.run({
     email
   })


### PR DESCRIPTION
Unfortunately, mailcheck.js doesn’t know about some .uk second-level domains, which means it makes some erroneous suggestions:

- .ac.uk — suggests .co.uk
- .me.uk — suggests .me.uk
- .mod.uk — suggests .gov.uk
- .net.uk — suggests .net

Fix this by just adding all the active .uk second-level domains (see https://en.wikipedia.org/wiki/.uk#Active for a hopefully accurate list) to the mailcheck.js default top level domains list.