### PR TITLE
BAU - The email typo thing needs more work

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -17,7 +17,6 @@ const State = require('../models/state.js')
 const paths = require('../paths.js')
 const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
 const {countries} = require('../services/countries.js')
-const {commonTypos} = require('../utils/email_tools.js')
 const {withAnalyticsError, withAnalytics} = require('../utils/analytics.js')
 
 // constants
@@ -30,7 +29,7 @@ const AUTH_3DS_REQUIRED_OUT_VIEW = 'auth_3ds_required_out'
 const AUTH_3DS_REQUIRED_HTML_OUT_VIEW = 'auth_3ds_required_html_out'
 const AUTH_3DS_REQUIRED_IN_VIEW = 'auth_3ds_required_in'
 const CAPTURE_WAITING_VIEW = 'capture_waiting'
-const preserveProperties = ['cardholderName', 'addressLine1', 'addressLine2', 'addressCity', 'addressPostcode', 'addressCountry']
+const preserveProperties = ['cardholderName', 'addressLine1', 'addressLine2', 'addressCity', 'addressPostcode', 'addressCountry', 'email']
 const AUTH_3DS_EPDQ_RESULTS = {
   success: 'AUTHORISED',
   declined: 'DECLINED',
@@ -109,15 +108,7 @@ module.exports = {
       .then(data => {
         cardBrand = data.cardBrand
         if (!req.body['email-typo-sugestion']) {
-          if (data.validation.hasError || commonTypos(req.body.email)) {
-            if (commonTypos(req.body.email)) {
-              data.validation.hasError = true
-              data.validation.errorFields.push({
-                cssKey: 'email-typo',
-                value: i18n.__('chargeController.fieldErrors.fields.email.typo')
-              })
-              data.validation.typos = commonTypos(req.body.email)
-            }
+          if (data.validation.hasError) {
             charge.countries = countries
             appendChargeForNewView(charge, req, charge.id)
             _.merge(data.validation, withAnalytics(charge, charge), _.pick(req.body, preserveProperties))

--- a/app/utils/email_tools.js
+++ b/app/utils/email_tools.js
@@ -29,29 +29,25 @@ const validEmail = email => {
   }
 }
 
-const commonTypos = email => {
-  mailcheck.defaultTopLevelDomains.push(
-    'ac.uk',
-    'co.uk',
-    'gov.uk',
-    'judiciary.uk',
-    'ltd.uk',
-    'me.uk',
-    'mod.uk',
-    'net.uk',
-    'nhs.uk',
-    'nic.uk',
-    'org.uk',
-    'parliament.uk',
-    'plc.uk',
-    'police.uk',
-    'sch.uk')
-  return mailcheck.run({
-    email
-  })
-}
+mailcheck.defaultTopLevelDomains.push(
+  'ac.uk',
+  'co.uk',
+  'gov.uk',
+  'judiciary.uk',
+  'ltd.uk',
+  'me.uk',
+  'mod.uk',
+  'net.uk',
+  'nhs.uk',
+  'nic.uk',
+  'org.uk',
+  'parliament.uk',
+  'plc.uk',
+  'police.uk',
+  'sch.uk'
+)
 
 module.exports = {
   validEmail,
-  commonTypos
+  commonTypos: email => mailcheck.run({email})
 }

--- a/test/integration/charge_validation_ft_tests.js
+++ b/test/integration/charge_validation_ft_tests.js
@@ -113,39 +113,4 @@ describe('checks for PAN-like numbers', () => {
         done()
       })
   })
-
-  it('shows an error when an email contains what could be a typo', function (done) {
-    const chargeId = '23144323'
-    const formWithAllFieldsContainingTooManyDigits = {
-      'returnUrl': RETURN_URL,
-      'cardUrl': connectorAuthUrl,
-      'chargeId': chargeId,
-      'cardNo': '4242424242424242',
-      'cvc': '234',
-      'expiryMonth': '11',
-      'expiryYear': '99',
-      'cardholderName': 'A Name',
-      'addressLine1': 'Whip Ma Whop Ma Avenue',
-      'addressLine2': '1line two',
-      'addressPostcode': 'Y1 1YN',
-      'addressCity': 'Townfordshire',
-      'email': 'willy@wonka.con',
-      'addressCountry': 'US'
-    }
-    const cookieValue = cookie.create(chargeId, {})
-
-    defaultCardID('4242424242424242')
-    defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
-    defaultAdminusersResponseForGetService(gatewayAccountId)
-
-    postChargeRequest(app, cookieValue, formWithAllFieldsContainingTooManyDigits, chargeId)
-      .expect(200)
-      .end((err, res) => {
-        if (err) return done(err)
-        const $ = cheerio.load(res.text)
-        const typoErrorText = 'There might be a mistake in the last part of your email address. Select your email address.'
-        expect($('#email-typo-lbl').text()).to.contains(typoErrorText)
-        done()
-      })
-  })
 })


### PR DESCRIPTION
It’s overly sensitive and is flagging more false positives than actual
errors, need to roll back and work out how to make it less trigger
happy.

On the plus side, we were noticing it dropping the persons  email from
the form on error, this was not because of mailcheck but due do a
erroeous deletion during a rebase of the Node 8 upgrade. So that’s one
'bug' fixed :D

