### PR TITLE
PP-3848 - Add cookie banner text

### DIFF
--- a/app/views/includes/cookie-message.njk
+++ b/app/views/includes/cookie-message.njk
@@ -1,0 +1,1 @@
+<p>GOV.UK Pay uses cookies to make the site simpler. <a href="https://www.payments.service.gov.uk/cookies/">Find out more about cookies</a></p>

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -25,6 +25,10 @@
 
 {% block header_class %}with-proposition{% endblock %}
 
+{% block cookie_message %}
+  {% include "includes/cookie-message.njk" %}
+{% endblock %}
+
 {% block body_end %}
   {% include "includes/scripts.njk" %}
 {% endblock %}


### PR DESCRIPTION
For some reason Frontend was missing the cookie banner text so it showed the banner but it was blank.