### PR TITLE
PP-3673 improve mailcheck accuracy

### DIFF
--- a/app/utils/email_tools.js
+++ b/app/utils/email_tools.js
@@ -29,23 +29,14 @@ const validEmail = email => {
   }
 }
 
-mailcheck.defaultTopLevelDomains.push(
-  'ac.uk',
-  'co.uk',
-  'gov.uk',
-  'judiciary.uk',
-  'ltd.uk',
-  'me.uk',
-  'mod.uk',
-  'net.uk',
-  'nhs.uk',
-  'nic.uk',
-  'org.uk',
-  'parliament.uk',
-  'plc.uk',
-  'police.uk',
-  'sch.uk'
-)
+mailcheck.defaultDomains = ['live.com', 'live.co.uk', 'live.com.au', 'gmail.com', 'gmail.co.uk', 'ymail.com', 'mail.com', 'hotmail.com']
+mailcheck.defaultSecondLevelDomains = ['yahoo', 'outlook', 'hotmail']
+mailcheck.defaultTopLevelDomains = [
+  'com', 'ca', 'co.nz', 'co.uk', 'de', 'fr', 'it', 'ru', 'net', 'org', 'edu', 'gov', 'jp', 'nl', 'kr', 'se', 'eu', 'ie', 'co.il', 'us', 'at', 'be', 'dk', 'hk', 'es', 'gr', 'ch', 'no', 'cz', 'in', 'net', 'net.au', 'info', 'biz', 'mil', 'co.jp', 'sg', 'hu', 'uk', 'ac.uk', 'co.uk', 'gov.uk', 'judiciary.uk', 'ltd.uk', 'me.uk', 'mod.uk', 'net.uk', 'nhs.uk', 'nic.uk', 'org.uk', 'plc.uk', 'police.uk', 'sch.uk', 'ae', 'net.ae', 'pl', 'kw', 'co', 'aero', 'co.in', 'io', 'bz', 'bg', 'sk', 'sx', 'dm', 'bm', 'om', 'me', 'qa', 'coop', 'fm', 'cc', 'mc', 'my', 'vc'
+]
+mailcheck.domainThreshold = 2
+mailcheck.secondLevelThreshold = 2
+mailcheck.topLevelThreshold = 1
 
 module.exports = {
   validEmail,

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -22,6 +22,9 @@
     <form id="card-details" name="cardDetails" method="POST" action="{{ post_card_action }}" class="form">
       <input id="charge-id" name="chargeId" type="hidden" value="{{ id }}"/>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+      {% if (originalEmail) %}
+        <input name="originalemail" type="hidden" value="{{ originalEmail }}"/>
+      {% endif %}
       <div class="form-group{% if highlightErrorFields.cardNo %} error{% endif %} card-no-group" data-validation="cardNo">
         <label id="card-no-lbl" for="card-no" class="form-label-bold">
               <span

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "watch": "chokidar app test *.js --initial -c 'npm run test'",
     "lint": "standard",
     "watch-live-reload": "./node_modules/.bin/grunt watch",
-    "test": "nyc node ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(_test|_tests)'.js",
+    "test": "nyc node ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(_test|_tests|.test)'.js",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"
   },

--- a/test/utils/common-typos.test.js
+++ b/test/utils/common-typos.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const { expect } = require('chai')
+const {commonTypos} = require('../../app/utils/email_tools')
+// const validEmailList = require('./valid-email-list')
+const invalidEmailList = require('./invalid-email-list')
+
+describe('When Mailcheck is given a valid email ', () => {
+  it('it should return empty as there is no problem', () => {
+    expect(commonTypos('test@gmail.com')).to.equal()
+  })
+  invalidEmailList.map(domain => {
+    domain.invalid.map(email => {
+      const corrected = commonTypos(email)
+      it(`${email} is invalid, should be ${corrected.full}`, () => {
+        expect(corrected).to.deep.equal(domain.valid)
+      })
+    })
+  })
+  // I tested with 3000 de-deduped anonymised emails and it works, I don’t want to publish this list to the repo as I guess even domains can give away a persons identity, for example my email is jon@jonheslop.com and even after making it your.name@jonheslop.com it’s pretty obv who that is.
+  // validEmailList.map(email => {
+  //   const corrected = commonTypos(email)
+  //   it(`${email} is invalid, should be ${corrected ? corrected.full : email}`, () => {
+  //     expect(corrected).to.equal()
+  //   })
+  // })
+})

--- a/test/utils/invalid-email-list.js
+++ b/test/utils/invalid-email-list.js
@@ -1,0 +1,54 @@
+'use strict'
+
+module.exports = [
+  {
+    valid: {
+      address: 'your.name',
+      domain: 'hotmail.com',
+      full: 'your.name@hotmail.com'
+    },
+    invalid: [
+      'your.name@hotmaiol.com',
+      'your.name@hotmail.con',
+      'your.name@hotmai.com',
+      'your.name@homtail.com',
+      'your.name@hitmail.com'
+    ]
+  },
+  {
+    valid: {
+      address: 'your.name',
+      domain: 'yahoo.com',
+      full: 'your.name@yahoo.com'
+    },
+    invalid: [
+      'your.name@yahoo.comb',
+      'your.name@yhaoo.com',
+      'your.name@hahoo.com'
+    ]
+  },
+  {
+    valid: {
+      address: 'your.name',
+      domain: 'outlook.com',
+      full: 'your.name@outlook.com'
+    },
+    invalid: [
+      'your.name@outloo.com',
+      'your.name@outlokk.com'
+    ]
+  },
+  {
+    valid: {
+      address: 'your.name',
+      domain: 'gmail.com',
+      full: 'your.name@gmail.com'
+    },
+    invalid: [
+      'your.name@gmil.com',
+      'your.name@gmail.om',
+      'your.name@gmail.con',
+      'your.name@gamil.com'
+    ]
+  }
+]


### PR DESCRIPTION
The previous iteration was too eager to correct people’s perfectly valid emails. I’ve trained it using 10,000 emails that used pay so it’s a lot less trigger happy now, e.g. it knows `.ae` domains are legit. 

Also, before, once invoked if you changed your original input it still preferred the radio buttons, this is no good, as we may have spotted an error but not suggested the right correction, so know if a user ammends the original input, we take that and run that through the validator again.