### PR TITLE
Added environment variables to permit running locally via pay local tool.

### DIFF
--- a/app/utils/base_client.js
+++ b/app/utils/base_client.js
@@ -7,11 +7,20 @@
  * Leaving for backward compatibility.
  */
 const urlParse = require('url')
-const https = require('https')
 const logger = require('winston')
+const https = setHttpClient()
 
 const customCertificate = require('./custom_certificate')
 const CORRELATION_HEADER_NAME = require('./correlation_header').CORRELATION_HEADER
+
+function setHttpClient () {
+  if (process.env.USE_HTTP_CLIENT === 'true') {
+    logger.warn('USE_HTTP_CLIENT is enabled, base_client will use http.')
+    return require('http')
+  } else {
+    return require('https')
+  }
+}
 
 var agentOptions = {
   keepAlive: true,

--- a/app/utils/base_client.js
+++ b/app/utils/base_client.js
@@ -14,8 +14,8 @@ const customCertificate = require('./custom_certificate')
 const CORRELATION_HEADER_NAME = require('./correlation_header').CORRELATION_HEADER
 
 function setHttpClient () {
-  if (process.env.USE_HTTP_CLIENT === 'true') {
-    logger.warn('USE_HTTP_CLIENT is enabled, base_client will use http.')
+  if (process.env.DISABLE_INTERNAL_HTTPS === 'true') {
+    logger.warn('DISABLE_INTERNAL_HTTPS is enabled, base_client will use http.')
     return require('http')
   } else {
     return require('https')

--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 // Please leave here even though it looks unused - this enables Node.js metrics to be pushed to Hosted Graphite
-require('./app/utils/metrics.js').metrics()
+if (!process.env.DISABLE_APPMETRICS) {
+  require('./app/utils/metrics.js').metrics()
+}
 
 // Node.js core dependencies
 const path = require('path')

--- a/test/test.env
+++ b/test/test.env
@@ -5,4 +5,4 @@ COOKIE_MAX_AGE=5400000
 SESSION_ENCRYPTION_KEY=naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk
 DISABLE_INTERNAL_HTTPS=true
 CSRF_USER_SECRET=123456789012345678
-CARDID_HOST=https://cardid.pymnt.localdomain
+CARDID_HOST=http://cardid.pymnt.localdomain


### PR DESCRIPTION
Added environment variable ```USE_HTTP_CLIENT``` to use http client instead of https for local testing purposes. Added environment variable ```DISABLE_APPMETRICS``` to ignore appmetric import for running locally.


