### PR TITLE
PP-3996 Version bump of products page to point at new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "node-sass": "4.9.x",
     "nyc": "11.7.x",
     "pact": "4.3.2",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.35/pay-product-page-2.1.35.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.36/pay-product-page-2.1.36.tgz",
     "proxyquire": "~2.0.1",
     "sass-lint": "^1.12.1",
     "sinon": "5.0.x",


### PR DESCRIPTION
## WHAT
Bumps the referenced pay-products page up to the newest version.


