### PR TITLE
Fix accidentally global functions

### DIFF
--- a/app/assets/javascripts/modules/form-card-type.js
+++ b/app/assets/javascripts/modules/form-card-type.js
@@ -113,7 +113,7 @@ var showCardType = function(){
     if (this.value.length > this.maxLength) {
       this.value = this.value.slice(0, this.maxLength);
     }
-  }
+  },
 
   getSupportedChargeType = function(name){
     var card =  cards.filter('.' + name).first();
@@ -122,6 +122,7 @@ var showCardType = function(){
       credit: card.attr('data-credit')
     };
   },
+
   checkCardtypeIsAllowed = function(){
     var defer = $.Deferred();
       var card = getCardType();


### PR DESCRIPTION
## WHAT
Due to a missing comma, the functions `getSupportedChargeType` and
`checkCardtypeIsAllowed` were global, rather than local to `showCardType`.
This pull request adds the missing comma.

## HOW

  1. Start a local instance of the server using `grunt` (using `master`).
  2. Copy the following HTML to `public/javascripts/test.html`
  3. Go to `localhost:3000/public/javascripts/test.html` in a web browser
  4. Verify that the output is `Test failed`
  5. Merge in the commit from this PR.
  6. Copy the HTML to `public/javascripts/test.html` again.
  7. Refresh your browser.
  8. Verify that the output is now `Test passed`.

```html
<!DOCTYPE html>
<html>
<head>
<title>Test</title>
<script>
window.i18n = {
  "chargeController": {
    "fieldErrors": {
      "fields": {
        "cardNo": { },
      }
    }
  }
};
window.Card = {};
window.Card.allowed = {};
</script>
<script type="text/javascript" src="application.js">
</script>
</head>
<body>
	<main>
		<h1>Test</h1>
	</main>
</body>
<script type="text/javascript">
  showCardType();
  if ("getSupportedChargeType" in window || "checkCardtypeIsAllowed" in window)
    alert("Test failed");
  else
    alert("Test passed");
</script>
</html>
```


