### PR TITLE
PP-3991 - Minifying JS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -133,6 +133,14 @@ module.exports = function (grunt) {
     }
   }
 
+  const uglify = {
+    my_target: {
+      files: {
+        'public/javascripts/application.min.js': ['public/javascripts/application.js']
+      }
+    }
+  }
+
   const compress = {
     main: {
       options: {
@@ -142,7 +150,8 @@ module.exports = function (grunt) {
         {expand: true, src: ['public/images/*.jpg'], ext: '.jpg.gz'},
         {expand: true, src: ['public/images/*.gif'], ext: '.gif.gz'},
         {expand: true, src: ['public/images/*.png'], ext: '.png.gz'},
-        {expand: true, src: ['public/javascripts/*.js'], ext: '.js.gz'},
+        { expand: true, src: ['public/javascripts/*.js'], ext: '.js.gz' },
+        { expand: true, src: ['public/javascripts/*.min.js'], ext: '.min.js.gz' },
         {expand: true, src: ['public/stylesheets/*.css'], ext: '.css.gz'}
       ]
     }
@@ -163,6 +172,7 @@ module.exports = function (grunt) {
     browserify: browserify,
     concat: concat,
     rewrite: rewrite,
+    uglify: uglify,
     compress: compress
   });
 
@@ -176,11 +186,9 @@ module.exports = function (grunt) {
     'grunt-concurrent',
     'grunt-browserify',
     'grunt-contrib-concat',
-    'grunt-rewrite'
-
-  ].forEach(function (task) {
-    grunt.loadNpmTasks(task)
-  })
+    'grunt-rewrite',
+    'grunt-contrib-uglify'
+  ].forEach(task => grunt.loadNpmTasks(task))
 
   grunt.registerTask('generate-assets', [
     'clean',
@@ -189,6 +197,7 @@ module.exports = function (grunt) {
     'browserify',
     'concat',
     'rewrite',
+    'uglify',
     'compress'
   ])
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6124,6 +6124,18 @@
         "file-sync-cmp": "^0.1.0"
       }
     },
+    "grunt-contrib-uglify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-3.4.0.tgz",
+      "integrity": "sha512-UXsTpeP0pytpTYlmll3RDndsRXfdwmrf1tI/AtD/PrArQAzGmKMvj83aVt3D8egWlE6KqPjsJBLCCvfC52LI/A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "maxmin": "^2.1.0",
+        "uglify-js": "~3.4.0",
+        "uri-path": "^1.0.0"
+      }
+    },
     "grunt-contrib-watch": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.1.tgz",
@@ -6361,6 +6373,15 @@
         "each-async": "^1.0.0",
         "node-sass": "^4.7.2",
         "object-assign": "^4.0.1"
+      }
+    },
+    "gzip-size": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+      "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+      "dev": true,
+      "requires": {
+        "duplexer": "^0.1.1"
       }
     },
     "har-schema": {
@@ -7738,6 +7759,29 @@
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
+    },
+    "maxmin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-2.1.0.tgz",
+      "integrity": "sha1-TTsiCQPZXu5+t6x/qGTnLcCaMWY=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "figures": "^1.0.1",
+        "gzip-size": "^3.0.0",
+        "pretty-bytes": "^3.0.0"
+      },
+      "dependencies": {
+        "pretty-bytes": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+          "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        }
+      }
     },
     "md5.js": {
       "version": "1.3.4",
@@ -15623,6 +15667,30 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.6.tgz",
+      "integrity": "sha512-O1D7L6WcOzS1qW2ehopEm4cWm5yA6bQBozlks8jO8ODxYCy4zv+bR/la4Lwp01tpkYGNonnpXvUpYtrvSu8Yzg==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.16.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+          "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "uid-safe": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
@@ -15879,6 +15947,12 @@
       "requires": {
         "upper-case": "^1.1.1"
       }
+    },
+    "uri-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz",
+      "integrity": "sha1-l0fwGDWJM8Md4PzP2C0TjmcmLjI=",
+      "dev": true
     },
     "urix": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "grunt-contrib-compress": "1.4.x",
     "grunt-contrib-concat": "1.0.x",
     "grunt-contrib-copy": "1.0.x",
+    "grunt-contrib-uglify": "^3.4.0",
     "grunt-contrib-watch": "1.0.x",
     "grunt-nodemon": "0.4.x",
     "grunt-rewrite": "1.0.x",

--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ const session = require('./app/utils/session')
 
 // Global constants
 const CSS_PATH = staticify.getVersionedPath('/stylesheets/application.css')
-const JAVASCRIPT_PATH = staticify.getVersionedPath('/javascripts/application.js')
+const JAVASCRIPT_PATH = staticify.getVersionedPath('/javascripts/application.min.js')
 const PORT = process.env.PORT || 3000
 const {NODE_ENV} = process.env
 const argv = require('minimist')(process.argv.slice(2))
@@ -121,7 +121,7 @@ function initialiseTemplateEngine (app) {
   // Version static assets on production for better caching
   // if it's not production we want to re-evaluate the assets on each file change
   nunjucksEnvironment.addGlobal('css_path', NODE_ENV === 'production' ? CSS_PATH : staticify.getVersionedPath('/stylesheets/application.css'))
-  nunjucksEnvironment.addGlobal('js_path', NODE_ENV === 'production' ? JAVASCRIPT_PATH : staticify.getVersionedPath('/javascripts/application.js'))
+  nunjucksEnvironment.addGlobal('js_path', NODE_ENV === 'production' ? JAVASCRIPT_PATH : staticify.getVersionedPath('/javascripts/application.min.js'))
   // Initialise internationalisation
   fs.readFile('./locales/en.json', 'utf8', (err, data) => {
     if (err) {


### PR DESCRIPTION
Whilst looking at how our performance was improved by switching to GOV.UK Frontend, I noticed how huge our JS because it’s not minified/uglified.

So I’ve added a grunt task to do so and it comes out 3x smaller.

I still think it’s bundling an awful lot of stuff it can’t possibly need, so I'm going to do some further investigation but this is a quick win.