### PR TITLE
BAU - bump product page version with privacy additions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12348,8 +12348,8 @@
       }
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/2.1.36/pay-product-page-2.1.36.tgz",
-      "integrity": "sha512-xCtVO9igE7rGUtq6xhmgONKz/ASArlQdG6k0zon4eUtNU0sWjEkHW+zKmDagS2auMNrHVhsAZng1NKO/rdxtdA==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/2.1.37/pay-product-page-2.1.37.tgz",
+      "integrity": "sha512-GU+9GTlJ8RZUCRAO3gQjoBobjDz6qR3eUphkw+7LRztdICteAr7TTWeo0Aq9YuUtC+1zdCcXLPpa1ZqZ/ppN7Q==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "node-sass": "4.9.x",
     "nyc": "11.7.x",
     "pact": "4.3.2",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.36/pay-product-page-2.1.36.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.37/pay-product-page-2.1.37.tgz",
     "proxyquire": "~2.0.1",
     "sass-lint": "^1.12.1",
     "sinon": "5.0.x",


### PR DESCRIPTION
There were two bullet points missing from the privacy notice, this adds them

https://github.com/alphagov/pay-product-page/pull/67