### PR TITLE
PP-4090 - Switch to allow ZAP to disable JS validation

### DIFF
--- a/app/assets/javascripts/modules/form-validation.js
+++ b/app/assets/javascripts/modules/form-validation.js
@@ -32,6 +32,11 @@ var formValidation = function () {
   }
 
   var checkFormSubmission = function (e) {
+    // ZAP tests need to be able to post bad form fields to be able to try all the pen test stuff so this allows us to do that
+    var zapDisabler = document.getElementById('disable-for-zap')
+    if (zapDisabler !== null) {
+      return
+    }
     e.preventDefault()
     var validations = allValidations()
     if (countryAutocomplete.value === '') {


### PR DESCRIPTION
ZAP tests need to be able to submit a malformed post so that it can run
a bunch of pen tests on the post. But to do that, it needs to get
around our client-side validation JS. Before they could use jQuery to
kill all the eventListeners but we can’t do that without jQuery.

So I’ve put a breaker in the function that will supress the validation
if an element with the id `disable-for-zap` is present.

Then when the page is loaded in the ZAP test it will insert the element
before it does the submit and will be able to do the pen test.