### PR TITLE
PP-4135: Enable new relic [DO NOT MERGE]

### DIFF
--- a/newrelic.js
+++ b/newrelic.js
@@ -1,0 +1,53 @@
+'use strict'
+/**
+ * New Relic agent configuration.
+ *
+ * See lib/config/default.js in the agent distribution for a more complete
+ * description of configuration variables and their potential values.
+ */
+exports.config = {
+  /**
+   * Array of application names.
+   */
+  app_name: ['pay-frontend'],
+  /**
+   * Your New Relic license key.
+   */
+  license_key: '',
+  logging: {
+    /**
+     * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+     * issues with the agent, 'info' and higher will impose the least overhead on
+     * production applications.
+     */
+    level: 'info'
+  },
+  /**
+   * When true, all request headers except for those listed in attributes.exclude
+   * will be captured for all traces, unless otherwise specified in a destination's
+   * attributes include/exclude lists.
+   */
+  allow_all_headers: true,
+  attributes: {
+    /**
+     * Prefix of attributes to exclude from all destinations. Allows * as wildcard
+     * at end.
+     *
+     * NOTE: If excluding headers, they must be in camelCase form to be filtered.
+     *
+     * @env NEW_RELIC_ATTRIBUTES_EXCLUDE
+     */
+    exclude: [
+      'request.headers.cookie',
+      'request.headers.authorization',
+      'request.headers.proxyAuthorization',
+      'request.headers.setCookie*',
+      'request.headers.x*',
+      'response.headers.cookie',
+      'response.headers.authorization',
+      'response.headers.proxyAuthorization',
+      'response.headers.setCookie*',
+      'response.headers.x*'
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "memory-cache": "^0.2.0",
     "minimist": "1.2.x",
     "morgan": "1.9.x",
+    "newrelic": "^4.8.0",
     "nunjucks": "^3.1.2",
     "polyfill-array-includes": "^1.0.0",
     "q": "1.5.x",

--- a/start.js
+++ b/start.js
@@ -1,6 +1,7 @@
 (function () {
   'use strict'
 
+  require('newrelic')
   var path = require('path')
   var fs = require('fs')
   var logger = require('winston')


### PR DESCRIPTION
Enable new relic so we can see the frequency of V8 garbage collection. Note:
this should only be enabled in perf or test environments as it's a trial
licence key.

@oswaldquek
