### PR TITLE
PP-4137 - remove link from service name

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -33,7 +33,7 @@
     {{ govukHeader({
       homepageUrl: 'https://www.gov.uk',
       serviceName: gatewayAccount.serviceName,
-      serviceUrl: '/'
+      serviceUrl: '#'
     }) }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
The new design system nunjucks macros require a link for the service name, I dropped in `/` without thinking about it.

Putting in `#` as thats less confusing for the user, although still not great.

We should either raise a PR with the design system to allow for a service name without a link.

OR come up with a way to determine what link we should put in there, but we’d have to communicate this with our partners