### PR TITLE
PP-4097 reconfigure app to use i18n dynamically

### DIFF
--- a/app/middleware/resolve_language.js
+++ b/app/middleware/resolve_language.js
@@ -1,0 +1,9 @@
+'use strict'
+
+// local dependencies
+const i18n = require('i18n')
+
+module.exports = function (req, res, next) {
+  res.locals.translationStrings = JSON.stringify(i18n.getCatalog('en'))
+  next()
+}

--- a/app/router.js
+++ b/app/router.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const i18n = require('i18n')
-
 const charge = require('./controllers/charge_controller.js')
 const secure = require('./controllers/secure_controller.js')
 const statik = require('./controllers/static_controller.js')
@@ -13,6 +11,7 @@ const actionName = require('./middleware/action_name.js')
 const stateEnforcer = require('./middleware/state_enforcer.js')
 const retrieveCharge = require('./middleware/retrieve_charge.js')
 const resolveService = require('./middleware/resolve_service.js')
+const resolveLanguage = require('./middleware/resolve_language.js')
 
 // Import AB test when we need to use it
 // const abTest = require('./utils/ab_test.js')
@@ -33,10 +32,7 @@ exports.bind = function (app) {
   const card = paths.card
 
   const middlewareStack = [
-    function (req, res, next) {
-      i18n.setLocale('en')
-      next()
-    },
+    resolveLanguage,
     csrfCheck,
     csrfTokenGeneration,
     actionName,

--- a/app/utils/charge_validation.js
+++ b/app/utils/charge_validation.js
@@ -43,7 +43,8 @@ module.exports = (translations, logger, Card) => {
         const customValidation = fieldValidations[name] ? fieldValidations[name].bind(fieldValidations)(value, body) : true
         if (value && customValidation === true) return
         const translation = translations.fields[name]
-        const problem = value || isOptional ? translation[customValidation] : `Enter a valid ${translation.name}`
+        const messageTemplate = translations.generic
+        const problem = value || isOptional ? translation[customValidation] : messageTemplate.replace('%s', translation.name)
         // Push to Error Fields
         const customError = CUSTOM_ERRORS[name] || {}
         const cssKey = customError.cssKey || changeCase.paramCase(name)

--- a/app/views/auth_3ds_required.njk
+++ b/app/views/auth_3ds_required.njk
@@ -1,12 +1,12 @@
 {% extends "layout.njk" %}
 
-{% block pageTitle %}{{ i18n.commonHeadings.inProgress }}{% endblock %}
+{% block pageTitle %}{{ __("commonHeadings.inProgress") }}{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l form-title">{{ i18n.commonHeadings.inProgress }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.authorisation.extraSteps }}</p>
+    <h1 class="govuk-heading-l form-title">{{ __("commonHeadings.inProgress") }}</h1>
+    <p class="govuk-body-l lede">{{ __("authorisation.extraSteps") }}</p>
     <iframe class="iframe-3ds" src="3ds_required_out">
     </iframe>
   </div>

--- a/app/views/auth_3ds_required_in.njk
+++ b/app/views/auth_3ds_required_in.njk
@@ -5,7 +5,7 @@
 {% endblock %}
 <body OnLoad="OnLoadEvent();">
 <noscript>
-    <p class="govuk-body-l lede">{{ i18n.authorisation.approved }}</p>
+    <p class="govuk-body-l lede">{{ __("authorisation.approved") }}</p>
 </noscript>
 <form name="three_ds_required" method="post" action="{{ threeDsHandlerUrl }}" target="_top">
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
@@ -19,7 +19,7 @@
         <input type="hidden" name="MD" value="{{ md }}"/>
     {% endif %}
     <noscript>
-        <button id="confirm" class="govuk-button">{{ i18n.commonButtons.continueButton}}</button>
+        <button id="confirm" class="govuk-button">{{ __("commonButtons.continueButton") }}</button>
     </noscript>
 </form>
 

--- a/app/views/auth_3ds_required_out.njk
+++ b/app/views/auth_3ds_required_out.njk
@@ -5,14 +5,14 @@
 {% endblock %}
 <body OnLoad="OnLoadEvent();">
 <noscript>
-  <p class="govuk-body-l lede">{{ i18n.authorisation.approvalNeeded }}</p>
+  <p class="govuk-body-l lede">{{ __("authorisation.approvalNeeded") }}</p>
 </noscript>
 <form name="three_ds_required" method="post" action="{{ issuerUrl }}">
   <input type="hidden" name="PaReq" value="{{ paRequest }}"/>
   <input type="hidden" name="MD" value="{{ md }}"/>
   <input type="hidden" name="TermUrl" value="{{ threeDSReturnUrl }}"/>
   <noscript>
-    <button id="confirm" class="govuk-button">{{ i18n.commonButtons.continueButton }}</button>
+    <button id="confirm" class="govuk-button">{{ __("commonButtons.continueButton") }}</button>
   </noscript>
 </form>
 

--- a/app/views/auth_waiting.njk
+++ b/app/views/auth_waiting.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.authorisation.processingPayment }}
+  {{ __("authorisation.processingPayment") }}
 {% endblock %}
 
 {% block head %}
@@ -30,10 +30,10 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l form-title">{{ i18n.authorisation.checkingDetails }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.authorisation.checkingDetailsDescription }}</p>
+    <h1 class="govuk-heading-l form-title">{{ __("authorisation.checkingDetails") }}</h1>
+    <p class="govuk-body-l lede">{{ __("authorisation.checkingDetailsDescription") }}</p>
     <div id="spinner">
-      <img src="/images/spinner.gif" alt="{{ i18n.authorisation.spinnerAltText }}"/>
+      <img src="/images/spinner.gif" alt="{{ __("authorisation.spinnerAltText") }}"/>
     </div>
   </div>
 </div>

--- a/app/views/capture_waiting.njk
+++ b/app/views/capture_waiting.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.authorisation.processingPayment }}
+  {{ __("authorisation.processingPayment") }}
 {% endblock %}
 
 {% block head %}
@@ -30,10 +30,10 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l form-title">{{ i18n.authorisation.processing }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.authorisation.processingPayment }}</p>
+    <h1 class="govuk-heading-l form-title">{{ __("authorisation.processing") }}</h1>
+    <p class="govuk-body-l lede">{{ __("authorisation.processingPayment") }}</p>
     <div id="spinner">
-      <img src="/images/spinner.gif" alt="{{ i18n.authorisation.spinnerAltText }}"/>
+      <img src="/images/spinner.gif" alt="{{ __("authorisation.spinnerAltText") }}"/>
     </div>
   </div>
 </div>

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.cardDetails.title }}
+  {{ __("cardDetails.title") }}
 {% endblock %}
 
 {% set mainClasses = "charge-new" %}
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div id="error-summary" class="govuk-error-summary hidden" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
-        {{ i18n.fieldErrors.summary }}
+        {{ __("fieldErrors.summary") }}
       </h2>
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
@@ -23,7 +23,7 @@
         </ul>
       </div>
     </div>
-    <h1 class="govuk-heading-l">{{ i18n.cardDetails.title }}</h1>
+    <h1 class="govuk-heading-l">{{ __("cardDetails.title") }}</h1>
 
     <form id="card-details" name="cardDetails" method="POST" action="{{ post_card_action }}">
       <input id="charge-id" name="chargeId" type="hidden" value="{{ id }}"/>
@@ -37,8 +37,8 @@
               <span
                   class="card-no-label"
                   data-label-replace="cardNo"
-                  data-original-label="{{ i18n.cardDetails.cardNo }}">
-              {{ i18n.cardDetails.cardNo }}
+                  data-original-label="{{ __("cardDetails.cardNo") }}">
+                {{ __("cardDetails.cardNo") }}
               </span>
           {% if highlightErrorFields.cardNo %}
             <p class="govuk-error-message" id="error-card-no">
@@ -72,10 +72,10 @@
         </ul>
         <p class="govuk-body-s accepted-cards-hint withdrawal-text">
           {% if withdrawalText === 'debit_credit' %}
-            {{ i18n.cardDetails.withdrawalText.debit_credit }}
+            {{ __("cardDetails.withdrawalText").debit_credit }}
           {% endif %}
           {% if withdrawalText === 'debit' %}
-            {{ i18n.cardDetails.withdrawalText.debit }}
+            {{ __("cardDetails.withdrawalText").debit }}
           {% endif %}
         </p>
       </div>
@@ -83,19 +83,19 @@
         <label class="govuk-label govuk-label--s" id="expiry-date-lbl" for="expiry-month">
           <span class="expiry-date-label"
             data-label-replace="expiryMonth"
-            data-original-label="{{ i18n.cardDetails.expiry }}">
-            {{ i18n.cardDetails.expiry }}
+            data-original-label="{{ __("cardDetails.expiry") }}">
+            {{ __("cardDetails.expiry") }}
           </span>
         </label>
         <span class="govuk-hint govuk-!-margin-bottom-2">
-          {{ i18n.cardDetails.expiryHint }}</span>
+          {{ __("cardDetails.expiryHint") }}</span>
         {% if highlightErrorFields.expiryMonth %}
           <p class="error-message" id="error-expiry-date">
             {{ highlightErrorFields.expiryMonth }}
           </p>
         {% endif %}
         <div class="govuk-date-input__item govuk-date-input__item--month govuk-date-input__item--with-separator">
-            <label class="govuk-label govuk-date-input__label" for="expiry-month">{{ i18n.cardDetails.expiryMonth }}</label>
+            <label class="govuk-label govuk-date-input__label" for="expiry-month">{{ __("cardDetails.expiryMonth") }}</label>
             <input
               id="expiry-month"
               type="number"
@@ -109,7 +109,7 @@
               autocomplete="cc-exp-month"/>
         </div>
         <div class="govuk-date-input__item govuk-date-input__item--year">
-            <label for="expiry-year" class="govuk-label govuk-date-input__label">{{ i18n.cardDetails.expiryYear }}</label>
+            <label for="expiry-year" class="govuk-label govuk-date-input__label">{{ __("cardDetails.expiryYear") }}</label>
             <input
               id="expiry-year"
               type="number"
@@ -128,9 +128,9 @@
         <label id="cardholder-name-lbl" for="cardholder-name" class="govuk-label govuk-label--s">
               <span
                   data-label-replace="cardholderName"
-                  data-original-label="{{ i18n.cardDetails.cardholderName }}"
+                  data-original-label="{{ __("cardDetails.cardholderName") }}"
                   class="card-holder-name-label">
-              {{ i18n.cardDetails.cardholderName }}
+                {{ __("cardDetails.cardholderName") }}
               </span>
           {% if highlightErrorFields.cardholderName %}
             <p class="govuk-error-message" id="error-cardholder-name">
@@ -151,18 +151,18 @@
           <span
             class="cvc-label"
             data-label-replace="cvc"
-            data-original-label="{{ i18n.cardDetails.cvc }}">
-          {{ i18n.cardDetails.cvc }}
+            data-original-label="{{ __("cardDetails.cvc") }}">
+            {{ __("cardDetails.cvc") }}
           </span>
           <span class="govuk-hint govuk-!-margin-bottom-2">
             <span class="generic-cvc">
-              {{ i18n.cardDetails.cvcTip }}
+              {{ __("cardDetails.cvcTip") }}
             </span>
             <span class="hidden">
-              {{ i18n.cardDetails.amexcvcNonjs }}
+              {{ __("cardDetails.amexcvcNonjs") }}
             </span>
             <span class="amex-cvc hidden">
-              {{ i18n.cardDetails.amexcvcTip }}
+              {{ __("cardDetails.amexcvcTip") }}
             </span>
           </span>
           {% if highlightErrorFields.cvc %}
@@ -178,22 +178,22 @@
                 class="govuk-input govuk-!-width-one-quarter cvc"
                 maxlength="4"
                 autocomplete="cc-csc"/>
-        <img src="/images/security-code.png" class="generic-cvc" alt="{{ i18n.cardDetails.cvcTip }}"/>
+        <img src="/images/security-code.png" class="generic-cvc" alt="{{ __("cardDetails.cvcTip") }}"/>
         <span class="either hidden">
-          {{ i18n.commonConjunctions.or }}
+          {{ __("commonConjunctions.or") }}
         </span>
-        <img src="/images/amex-security-code.png" class="amex-cvc hidden" alt="{{ i18n.cardDetails.amexcvcTip }}"/>
+        <img src="/images/amex-security-code.png" class="amex-cvc hidden" alt="{{ __("cardDetails.amexcvcTip") }}"/>
       </div>
       <div class="govuk-form-group govuk-!-width-two-thirds {% if highlightErrorFields.addressCountry %} govuk-form-group--error{% endif %}" data-validation="addressCountry">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-1">{{ i18n.cardDetails.billingAddress }}</h2>
-        <span class="govuk-hint govuk-!-margin-bottom-2">{{ i18n.cardDetails.billingAddressHint }}</span>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-1">{{ __("cardDetails.billingAddress") }}</h2>
+        <span class="govuk-hint govuk-!-margin-bottom-2">{{ __("cardDetails.billingAddressHint") }}</span>
 
         <label id="address-country-lbl" for="address-country" class="govuk-label govuk-label--s">
               <span
                   class="address-country-label"
                   data-label-replace="addressCountry"
-                  data-original-label="{{ i18n.cardDetails.country }}">
-                {{ i18n.cardDetails.country }}
+                  data-original-label="{{ __("cardDetails.country") }}">
+                {{ __("cardDetails.country") }}
               </span>
           {% if highlightErrorFields.addressCountry %}
             <p class="govuk-error-message" id="error-address-country">
@@ -214,8 +214,8 @@
               <span
                   class="address-line-1-label"
                   data-label-replace="addressLine1"
-                  data-original-label="{{ i18n.cardDetails.building }}">
-                {{ i18n.cardDetails.building }}
+                  data-original-label="{{ __("cardDetails.building") }}">
+                {{ __("cardDetails.building") }}
               </span>
 
           {% if highlightErrorFields.addressLine1 %}
@@ -246,8 +246,8 @@
               <span
                   class="address-city-label"
                   data-label-replace="addressCity"
-                  data-original-label="{{ i18n.cardDetails.city }}">
-                {{ i18n.cardDetails.city }}
+                  data-original-label="{{ __("cardDetails.city") }}">
+                {{ __("cardDetails.city") }}
               </span>
           {% if highlightErrorFields.addressCity %}
             <p class="govuk-error-message" id="error-address-city">
@@ -268,8 +268,8 @@
               <span
                   class="address-postcode-label"
                   data-label-replace="addressPostcode"
-                  data-original-label="{{ i18n.cardDetails.postcode }}">
-                {{ i18n.cardDetails.postcode }}
+                  data-original-label="{{ __("cardDetails.postcode") }}">
+                {{ __("cardDetails.postcode") }}
               </span>
 
           {% if highlightErrorFields.addressPostcode %}
@@ -291,10 +291,10 @@
               <span
                   class="email-label"
                   data-label-replace="email"
-                  data-original-label="{{ i18n.cardDetails.email }}">
-                {{ i18n.cardDetails.email }}
+                  data-original-label="{{ __("cardDetails.email") }}">
+                {{ __("cardDetails.email") }}
               </span>
-          <span class="govuk-hint govuk-!-margin-bottom-2">{{ i18n.cardDetails.emailHint }}</span>
+          <span class="govuk-hint govuk-!-margin-bottom-2">{{ __("cardDetails.emailHint") }}</span>
 
           {% if highlightErrorFields.email %}
             <p class="govuk-error-message" id="error-email">
@@ -310,13 +310,13 @@
                 value="{{ email }}"
                 autocomplete="email"
                 data-confirmation="true"
-                data-confirmation-label="{{ i18n.cardDetails.emailConfirmation }} "/>
+                data-confirmation-label="{{ __("cardDetails.emailConfirmation") }} "/>
       </div>
       {% if typos %}
         <div class="govuk-form-group form-group-email-typo govuk-form-group--error">
           <legend for="email-typo" id="email-typo-lbl" class="govuk-label govuk-label--s error-label">
             <p class="govuk-error-message" id="error-typo">
-              {{ i18n.fieldErrors.fields.email.typo }}
+              {{ __("fieldErrors.fields.email.typo") }}
             </p>
           </legend>
           <div class="govuk-radios">
@@ -332,30 +332,30 @@
         </div>
       {% endif %}
       <div>
-        <button id="submit-card-details" type="submit" class="govuk-button"
-          {% if typos %}
-          data-click-events
-          data-click-category="Typo made"
-          data-click-action="Corrected email: {{ typos.domain }}"
-          {% endif %}
-          >{{ i18n.commonButtons.continueButton }}</button>
+        <input id="submit-card-details" type="submit" class="govuk-button" value="{{ __("commonButtons.continueButton") }}" name="submitCardDetails"
+        {% if typos %}
+        data-click-events
+        data-click-category="Typo made"
+        data-click-action="Corrected email: {{ typos.domain }}"
+        {% endif %}
+        />
       </div>
     </form>
     <form id="cancel" name="cancel" method="POST" action="{{ post_cancel_action }}" class="form">
       <div>
-        <input id="cancel-payment" type="submit" class="button-reset" value="{{ i18n.commonButtons.cancelButton }}" name="cancel">
+        <input id="cancel-payment" type="submit" class="button-reset" value="{{ __("commonButtons.cancelButton") }}" name="cancel">
         <input id="csrf2" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       </div>
     </form>
   </div>
   <div class="govuk-grid-column-one-third payment-summary-wrap">
     <aside class="payment-summary">
-      <h2 class="govuk-heading-m">{{ i18n.paymentSummary.title }}</h2>
+      <h2 class="govuk-heading-m">{{ __("paymentSummary.title") }}</h2>
       <p id="payment-description" class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-19">
         {{ description }}
       </p>
       <p class="govuk-body govuk-!-font-size-19 govuk-!-margin-bottom-0">
-        {{ i18n.paymentSummary.totalAmount }}
+        {{ __("paymentSummary.totalAmount") }}
         <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold">£{{ amount }}</span>
       </p>
     </aside>

--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.confirmDetails.title }}
+  {{ __("confirmDetails.title") }}
 {% endblock %}
 
 {% set mainClasses = "confirm-page" %}
@@ -9,13 +9,13 @@
 {% block content %}
 <div class="govuk-grid-row govuk-!-margin-bottom-9">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ i18n.confirmDetails.title }}</h1>
+    <h1 class="govuk-heading-l">{{ __("confirmDetails.title") }}</h1>
 
     <table class="govuk-table">
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ i18n.confirmDetails.card }}
+            {{ __("confirmDetails.card") }}
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="card-number">
             {{ charge.cardDetails.cardNumber }}
@@ -23,7 +23,7 @@
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ i18n.confirmDetails.expiry }}
+            {{ __("confirmDetails.expiry") }}
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="expiry-date">
             {{ charge.cardDetails.expiryDate }}
@@ -31,7 +31,7 @@
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ i18n.confirmDetails.name }}
+
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="cardholder-name">
             {{ charge.cardDetails.cardholderName }}
@@ -39,7 +39,7 @@
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ i18n.confirmDetails.address }}
+            {{ __("confirmDetails.address") }}
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="address">
             {{ charge.cardDetails.billingAddress }}
@@ -47,7 +47,7 @@
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ i18n.confirmDetails.email }}
+            {{ __("confirmDetails.email") }}
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="email">
             {{ charge.email }}
@@ -59,23 +59,23 @@
     <form id="confirmation" method="POST" action="{{ confirmPath }}" class="form">
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       <input id="chargeId" name="chargeId" type="hidden" value="{{ charge.id }}"/>
-      <button id="confirm" class="govuk-button govuk-!-margin-top-6" data-module="stop-double-submit">{{ i18n.commonButtons.confirmButton }}</button>
+      <button id="confirm" class="govuk-button govuk-!-margin-top-6" data-module="stop-double-submit">{{ __("commonButtons.confirmButton") }}</button>
     </form>
     <form id="cancel" name="cancel" method="POST" action="{{ post_cancel_action }}" class="form">
       <div>
-        <input id="cancel-payment" type="submit" class="button-reset" value="{{ i18n.commonButtons.cancelButton }}" name="cancel">
+        <input id="cancel-payment" type="submit" class="button-reset" value="{{ __("commonButtons.cancelButton") }}" name="cancel">
         <input id="csrf2" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       </div>
     </form>
   </div>
   <div class="govuk-grid-column-one-third payment-summary-wrap">
     <aside class="payment-summary">
-      <h2 class="govuk-heading-m">{{ i18n.paymentSummary.title }}</h2>
+      <h2 class="govuk-heading-m">{{ __("paymentSummary.title") }}</h2>
       <p id="payment-description" class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-39">
         {{ charge.description }}
       </p>
       <p class="govuk-body govuk-!-font-size-39 govuk-!-margin-bottom-0">
-        {{ i18n.paymentSummary.totalAmount }}
+        {{ __("paymentSummary.totalAmount") }}
         <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold">£{{ charge.amount }}</span>
       </p>
     </aside>

--- a/app/views/error.njk
+++ b/app/views/error.njk
@@ -1,18 +1,18 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.errorViews.error }} - GOV.UK Pay
+  {{ __("errorViews.error") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
   <main id="content" class="content-wrapper error-pages grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-large general-error">
-        {{ i18n.errorViews.error }}
+        {{ __("errorViews.error") }}
       </h1>
       <p id="errorMsg" class="lede">{{ message }}</p>
       {% if returnUrl %}
-        <a id="return-url" class="govuk-link" class="lede" href="{{ returnUrl }}">{{ i18n.errorViews.tryAgain }}</a>
+        <a id="return-url" class="govuk-link" class="lede" href="{{ returnUrl }}">{{ __("errorViews.tryAgain") }}</a>
       {% endif %}
     </div>
   </main>

--- a/app/views/error_with_return_url.njk
+++ b/app/views/error_with_return_url.njk
@@ -1,17 +1,17 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.errorViews.error }} - GOV.UK Pay
+  {{ __("errorViews.error") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h3 class="govuk-heading-l">
-      {{ i18n.errorViews.error }}:
+      {{ __("errorViews.error") }}:
     </h3>
     <p class="govuk-body-l lede">
-      <a id="return-url" class="govuk-link" href="{{ returnUrl }}">{{ i18n.commonButtons.goBackToService }}</a>
+      <a id="return-url" class="govuk-link" href="{{ returnUrl }}">{{ __("commonButtons.goBackToService") }}</a>
     </p>
     <div class="govuk-body" id="errorMsg">{{ message }}</div>
   </div>

--- a/app/views/errors/charge_confirm_state_completed.njk
+++ b/app/views/errors/charge_confirm_state_completed.njk
@@ -1,16 +1,16 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.errorViews.paymentStatus }} {{ status }} - GOV.UK Pay
+  {{ __("errorViews.paymentStatus") }} {{ status }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l {{ status }}">{{ i18n.errorViews.paymentStatus }} {{ status }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.toMakeChanges }}</p>
+    <h1 class="govuk-heading-l {{ status }}">{{ __("errorViews.paymentStatus") }} {{ status }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.toMakeChanges") }}</p>
     <p class="govuk-body-l lede">
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.viewSummary }}</a>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.viewSummary") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/auth_3ds_required.njk
+++ b/app/views/errors/incorrect_state/auth_3ds_required.njk
@@ -1,17 +1,17 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.commonHeadings.inProgress }} - GOV.UK Pay
+  {{ __("commonHeadings.inProgress") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ i18n.commonHeadings.inProgress }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.either }}</p>
-    <a class="govuk-body-l lede" href="/card_details/{{ chargeId }}/3ds_required" id="threeds-required-link">{{ i18n.errorViews.continue }}</a>
-    <p class="govuk-body-l lede">{{ i18n.commonConjunctions.or }}<br/>
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.tryAgain }}</a>
+    <h1 class="govuk-heading-l">{{ __("commonHeadings.inProgress") }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.either") }}</p>
+    <a class="govuk-body-l lede" href="/card_details/{{ chargeId }}/3ds_required" id="threeds-required-link">{{ __("errorViews.continue") }}</a>
+    <p class="govuk-body-l lede">{{ __("commonConjunctions.or") }}<br/>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/auth_failure.njk
+++ b/app/views/errors/incorrect_state/auth_failure.njk
@@ -1,16 +1,16 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.errorViews.problem }} - GOV.UK Pay
+  {{ __("errorViews.problem") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l qa-payment-declined">{{ i18n.errorViews.declined }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.contactYourBank }}</p>
+    <h1 class="govuk-heading-l qa-payment-declined">{{ __("errorViews.declined") }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.contactYourBank") }}</p>
 
-    <p class="govuk-body-l lede"><a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.tryAgain }}</a></p>
+    <p class="govuk-body-l lede"><a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a></p>
   </div>
 </div>
 {% endblock %}

--- a/app/views/errors/incorrect_state/auth_success.njk
+++ b/app/views/errors/incorrect_state/auth_success.njk
@@ -1,18 +1,18 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.commonHeadings.inProgress }} - GOV.UK Pay
+  {{ __("commonHeadings.inProgress") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ i18n.commonHeadings.inProgress }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.either }}<br/>
-      <a href="/card_details/{{chargeId}}/confirm" id="confirm-link">{{ i18n.errorViews.continue }}</a>
+    <h1 class="govuk-heading-l">{{ __("commonHeadings.inProgress") }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.either") }}<br/>
+      <a href="/card_details/{{chargeId}}/confirm" id="confirm-link">{{ __("errorViews.continue") }}</a>
     </p>
-    <p class="govuk-body-l lede">{{ i18n.commonConjunctions.or }}<br/>
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.tryAgain }}</a>
+    <p class="govuk-body-l lede">{{ __("commonConjunctions.or") }}<br/>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/auth_waiting.njk
+++ b/app/views/errors/incorrect_state/auth_waiting.njk
@@ -1,18 +1,18 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.commonHeadings.inProgress }} - GOV.UK Pay
+  {{ __("commonHeadings.inProgress") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ i18n.commonHeadings.inProgress }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.either }}<br/>
-      <a href="/card_details/{{ chargeId }}/auth_waiting" id="confirm-link">{{ i18n.errorViews.continue }}</a>
+    <h1 class="govuk-heading-l">{{ __("commonHeadings.inProgress") }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.either") }}<br/>
+      <a href="/card_details/{{ chargeId }}/auth_waiting" id="confirm-link">{{ __("errorViews.continue") }}</a>
     </p>
-    <p class="govuk-body-l lede">{{ i18n.commonConjunctions.or }}<br/>
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.tryAgain }}</a>
+    <p class="govuk-body-l lede">{{ __("commonConjunctions.or") }}<br/>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/capture_failure.njk
+++ b/app/views/errors/incorrect_state/capture_failure.njk
@@ -1,16 +1,16 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.errorViews.paymentStatus }} {{ status }} - GOV.UK Pay
+  {{ __("errorViews.paymentStatus") }} {{ status }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ i18n.errorViews.unsuccessful }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.noMoneyTaken }}</p>
+    <h1 class="govuk-heading-l">{{ __("errorViews.unsuccessful") }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
     <p class="govuk-body-l lede">
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.tryAgain }}</a>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/capture_waiting.njk
+++ b/app/views/errors/incorrect_state/capture_waiting.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.commonHeadings.inProgress }} - GOV.UK Pay
+  {{ __("commonHeadings.inProgress") }} - GOV.UK Pay
 {% endblock %}
 
 {% block head %}
@@ -30,10 +30,10 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ i18n.authorisation.processing }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.authorisation.processingPayment }}</p>
+    <h1 class="govuk-heading-l">{{ __("authorisation.processing") }}</h1>
+    <p class="govuk-body-l lede">{{ __("authorisation.processingPayment") }}</p>
     <div id="spinner">
-      <img src="/images/spinner.gif" alt="{{ i18n.authorisation.spinnerAltText }}"/>
+      <img src="/images/spinner.gif" alt="{{ __("authorisation.spinnerAltText") }}"/>
     </div>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/charge_completed.njk
+++ b/app/views/errors/incorrect_state/charge_completed.njk
@@ -1,16 +1,16 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.errorViews.paymentStatus }} {{ status }}
+  {{ __("errorViews.paymentStatus") }} {{ status }}
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l {{ status }}">{{ i18n.errorViews.paymentStatus }} {{ status }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.toMakeChanges }}</p>
+    <h1 class="govuk-heading-l {{ status }}">{{ __("errorViews.paymentStatus") }} {{ status }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.toMakeChanges") }}</p>
     <p class="govuk-body-l lede">
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.viewSummary }}</a>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.viewSummary") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/session_expired.njk
+++ b/app/views/errors/incorrect_state/session_expired.njk
@@ -1,17 +1,17 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.errorViews.paymentExpired }} - GOV.UK Pay
+  {{ __("errorViews.paymentExpired") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l session-expired">{{ i18n.errorViews.sessionExpired }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.noMoneyTaken }}</p>
+    <h1 class="govuk-heading-l session-expired">{{ __("errorViews.sessionExpired") }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
     {% if returnUrl %}
       <p class="govuk-body-l lede">
-        <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.tryAgain }}</a>
+        <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
       </p>
     {% endif %}
   </div>

--- a/app/views/errors/incorrect_state/system_cancelled.njk
+++ b/app/views/errors/incorrect_state/system_cancelled.njk
@@ -1,16 +1,16 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.errorViews.paymentCancelled }} - GOV.UK Pay
+  {{ __("errorViews.paymentCancelled") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l system-cancel">{{ i18n.errorViews.paymentCancelledTitle }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.paymentCancelledDescription }}</p>
+    <h1 class="govuk-heading-l system-cancel">{{ __("errorViews.paymentCancelledTitle") }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.paymentCancelledDescription") }}</p>
     <p class="govuk-body-l lede">
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.tryAgain }}</a>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/system_error.njk
+++ b/app/views/errors/system_error.njk
@@ -1,20 +1,20 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.errorViews.error }} - GOV.UK Pay
+  {{ __("errorViews.error") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l system-error">{{ i18n.errorViews.technicalProblems }}</h1>
+    <h1 class="govuk-heading-l system-error">{{ __("errorViews.technicalProblems") }}</h1>
     {% if returnUrl %}
-      <p class="govuk-body-l lede">{{ i18n.errorViews.noMoneyTaken }}</p>
+      <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
       <p class="govuk-body-l lede">
-        <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ i18n.errorViews.tryAgain }}</a>
+        <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
       </p>
     {% else %}
-      <p class="govuk-body-l lede">{{ i18n.errorViews.noMoneyTaken }}</p>
+      <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
     {% endif %}
   </div>
 </div>

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -1,8 +1,6 @@
 <!-- Javascript -->
 <script type="text/javascript">
-  {% if i18n_as_string %}
-  var i18n = {{ i18n_as_string | safe }};
-  {% endif %}
+  var i18n = {{ translationStrings | safe }};
 </script>
 <script src="{{ js_path }}"></script>
 <script id="govuk-script-analytics" type="text/javascript">

--- a/app/views/user_cancelled.njk
+++ b/app/views/user_cancelled.njk
@@ -1,16 +1,16 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ i18n.authorisation.userCancelledPayment }} - GOV.UK Pay
+  {{ __("authorisation.userCancelledPayment") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l user-cancel">{{ i18n.authorisation.userCancelledPayment }}</h1>
-    <p class="govuk-body-l lede">{{ i18n.errorViews.noMoneyTaken }}</p>
+    <h1 class="govuk-heading-l user-cancel">{{ __("authorisation.userCancelledPayment") }}</h1>
+    <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
     <p class="govuk-body-l lede">
-      <a id="return-url" class="govuk-link" href="{{ returnUrl }}">{{ i18n.commonButtons.goBackToService }}</a>
+      <a id="return-url" class="govuk-link" href="{{ returnUrl }}">{{ __("commonButtons.goBackToService") }}</a>
     </p>
   </div>
 </div>

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,154 +1,154 @@
 {
-  "cardDetails": {
-    "withdrawalText": {
-      "debit_credit": "Accepted credit and debit card types",
-      "debit": "Credit card payments are not accepted. Please use a debit card."
-    },
-    "title": "Enter card details",
-    "expiry": "Expiry date",
-    "expiryHint": "For example, 10/20",
-    "expiryMonth": "Month",
-    "expiryYear": "Year",
-    "cvc": "Card security code",
-    "cvcTip": "The last 3 digits on the back of the card",
-    "amexcvcTip": "The last 4 digits after the card number on the front",
-    "amexcvcNonjs": "For American Express,",
-    "cardNo": "Card number",
-    "cardholderName": "Name on card",
-    "billingAddress": "Billing address",
-    "billingAddressHint": "This is the address associated with the card",
-    "building": "Building number or name and street",
-    "city": "Town or city",
-    "postcode": "Postcode",
-    "country": "Country or territory",
-    "email": "Email",
-    "emailHint": "We’ll send your payment confirmation here",
-    "emailConfirmation": "An email will be sent to:"
-  },
-  "commonButtons": {
-    "continueButton": "Continue",
-    "confirmButton": "Confirm payment",
-    "cancelButton": "Cancel payment",
-    "goBackToService": "Go back to the service"
-  },
-  "confirmDetails": {
-    "title": "Confirm your payment",
-    "card": "Card number:",
-    "expiry": "Expiry date:",
-    "name": "Name on card:",
-    "address": "Billing address:",
-    "email": "Confirmation email:"
-  },
-  "commonConjunctions": {
-    "or": "or"
-  },
-  "commonHeadings": {
-    "inProgress": "Your payment is in progress"
-  },
-  "paymentSummary": {
-    "title": "Payment summary",
-    "totalAmount": "Total amount:"
-  },
-  "errorViews": {
-    "either": "You can either:",
-    "continue": "Continue with your payment",
-    "tryAgain": "Go back to try the payment again",
-    "problem": "There was a problem with your payment",
-    "declined": "Your payment has been declined",
-    "contactYourBank": "Contact your bank for more details. No money has been taken from your account.",
-    "paymentStatus": "Your payment was",
-    "unsuccessful": "Your payment was unsuccessful",
-    "noMoneyTaken": "No money has been taken from your account.",
-    "toMakeChanges": "To make any changes to your payment you’ll need to contact the service.",
-    "viewSummary": "View your payment summary",
-    "paymentExpired": "Your payment expired",
-    "sessionExpired": "Your payment session has expired",
-    "paymentCancelled": "Your Payment was cancelled",
-    "paymentCancelledTitle": "Payment cancelled",
-    "paymentCancelledDescription": "Your payment has been cancelled by the government service. This may have happened for a number of reasons.",
-    "error": "An error occurred",
-    "technicalProblems": "Sorry, we’re experiencing technical problems"
-  },
-  "authorisation": {
-    "extraSteps": "You may need to complete some extra verification steps.",
-    "approvalNeeded": "To continue with your payment, we need your bank’s approval.",
-    "approved": "The card details have been approved by the bank.",
-    "checkingDetails": "Checking card details",
-    "checkingDetailsDescription": "Your payment details are being checked.",
-    "spinnerAltText": "waiting",
-    "processingPayment": "Your payment is being processed.",
-    "processing": "Processing card details",
-    "userCancelledPayment": "Your payment has been cancelled"
-  },
-  "fieldErrors": {
-    "summary": "The following fields are missing or contain errors",
-    "generic": "Enter a valid %s",
-    "fields": {
-      "cardholderName": {
-        "name": "name",
-        "message": "Enter the name as it appears on the card",
-        "containsTooManyDigits": "Enter the name as it appears on the card",
-        "containsSuspectedCVC": "Enter the name as it appears on the card"
-      },
-      "cardNo": {
-        "name": "card number",
-        "message": "Enter a valid card number",
-        "numberIncorrectLength": "Card number is not the correct length",
-        "luhnInvalid": "Enter a valid card number",
-        "cardNotSupported": "This card type is not accepted",
-        "nonNumeric": " Enter a valid card number"
-      },
-      "cvc": {
-        "name": "card security code",
-        "message": "Enter a valid card security code",
-        "invalidLength": "Enter a valid card security code"
-      },
-      "expiryDate": {
-        "name": "expiry date",
-        "message": "Enter a valid expiry date"
-      },
-      "expiryMonth": {
-        "name": "expiry date",
-        "message": "Enter a valid expiry date",
-        "invalidMonth": "Enter a valid expiry date",
-        "invalidYear": "Enter a valid expiry date",
-        "inThePast": "Enter an expiry date in the future"
-      },
-      "expiryYear": {
-        "name": "expiry year",
-        "message": "Enter a valid expiry date",
-        "invalidYear": "This expiry year is not a valid"
-      },
-      "addressLine1": {
-        "name": "building name/number and street",
-        "message": "Enter a valid billing address",
-        "containsTooManyDigits": "Enter a valid billing address"
-      },
-      "addressLine2": {
-        "name": "additional address line",
-        "message": "Enter valid address information",
-        "containsTooManyDigits": "Enter valid address information"
-      },
-      "addressCity": {
-        "name": "town/city",
-        "message": "Enter a valid town/city",
-        "containsTooManyDigits": "Enter a valid town/city"
-      },
-      "addressPostcode": {
-        "name": "postcode",
-        "message": "Enter a valid postcode",
-        "containsTooManyDigits": "Enter a valid postcode"
-      },
-      "email": {
-        "name": "email",
-        "message": "Enter a valid email",
-        "containsTooManyDigits": "Enter a valid email",
-        "typo": "There might be a mistake in the last part of your email address. Select your email address."
-      },
-      "addressCountry": {
-        "name": "country or territory",
-        "message": "Enter a valid country or territory"
-      }
-    }
-  }
+	"cardDetails": {
+		"withdrawalText": {
+			"debit_credit": "Accepted credit and debit card types",
+			"debit": "Credit card payments are not accepted. Please use a debit card."
+		},
+		"title": "Enter card details",
+		"expiry": "Expiry date",
+		"expiryHint": "For example, 10/20",
+		"expiryMonth": "Month",
+		"expiryYear": "Year",
+		"cvc": "Card security code",
+		"cvcTip": "The last 3 digits on the back of the card",
+		"amexcvcTip": "The last 4 digits after the card number on the front",
+		"amexcvcNonjs": "For American Express,",
+		"cardNo": "Card number",
+		"cardholderName": "Name on card",
+		"billingAddress": "Billing address",
+		"billingAddressHint": "This is the address associated with the card",
+		"building": "Building number or name and street",
+		"city": "Town or city",
+		"postcode": "Postcode",
+		"country": "Country or territory",
+		"email": "Email",
+		"emailHint": "We’ll send your payment confirmation here",
+		"emailConfirmation": "An email will be sent to:"
+	},
+	"commonButtons": {
+		"continueButton": "Continue",
+		"confirmButton": "Confirm payment",
+		"cancelButton": "Cancel payment",
+		"goBackToService": "Go back to the service"
+	},
+	"confirmDetails": {
+		"title": "Confirm your payment",
+		"card": "Card number:",
+		"expiry": "Expiry date:",
+		"name": "Name on card:",
+		"address": "Billing address:",
+		"email": "Confirmation email:"
+	},
+	"commonConjunctions": {
+		"or": "or"
+	},
+	"commonHeadings": {
+		"inProgress": "Your payment is in progress"
+	},
+	"paymentSummary": {
+		"title": "Payment summary",
+		"totalAmount": "Total amount:"
+	},
+	"errorViews": {
+		"either": "You can either:",
+		"continue": "Continue with your payment",
+		"tryAgain": "Go back to try the payment again",
+		"problem": "There was a problem with your payment",
+		"declined": "Your payment has been declined",
+		"contactYourBank": "Contact your bank for more details. No money has been taken from your account.",
+		"paymentStatus": "Your payment was",
+		"unsuccessful": "Your payment was unsuccessful",
+		"noMoneyTaken": "No money has been taken from your account.",
+		"toMakeChanges": "To make any changes to your payment you’ll need to contact the service.",
+		"viewSummary": "View your payment summary",
+		"paymentExpired": "Your payment expired",
+		"sessionExpired": "Your payment session has expired",
+		"paymentCancelled": "Your Payment was cancelled",
+		"paymentCancelledTitle": "Payment cancelled",
+		"paymentCancelledDescription": "Your payment has been cancelled by the government service. This may have happened for a number of reasons.",
+		"error": "An error occurred",
+		"technicalProblems": "Sorry, we’re experiencing technical problems"
+	},
+	"authorisation": {
+		"extraSteps": "You may need to complete some extra verification steps.",
+		"approvalNeeded": "To continue with your payment, we need your bank’s approval.",
+		"approved": "The card details have been approved by the bank.",
+		"checkingDetails": "Checking card details",
+		"checkingDetailsDescription": "Your payment details are being checked.",
+		"spinnerAltText": "waiting",
+		"processingPayment": "Your payment is being processed.",
+		"processing": "Processing card details",
+		"userCancelledPayment": "Your payment has been cancelled"
+	},
+	"fieldErrors": {
+		"summary": "The following fields are missing or contain errors",
+		"generic": "Enter a valid %s",
+		"fields": {
+			"cardholderName": {
+				"name": "name",
+				"message": "Enter the name as it appears on the card",
+				"containsTooManyDigits": "Enter the name as it appears on the card",
+				"containsSuspectedCVC": "Enter the name as it appears on the card"
+			},
+			"cardNo": {
+				"name": "card number",
+				"message": "Enter a valid card number",
+				"numberIncorrectLength": "Card number is not the correct length",
+				"luhnInvalid": "Enter a valid card number",
+				"cardNotSupported": "This card type is not accepted",
+				"nonNumeric": " Enter a valid card number"
+			},
+			"cvc": {
+				"name": "card security code",
+				"message": "Enter a valid card security code",
+				"invalidLength": "Enter a valid card security code"
+			},
+			"expiryDate": {
+				"name": "expiry date",
+				"message": "Enter a valid expiry date"
+			},
+			"expiryMonth": {
+				"name": "expiry date",
+				"message": "Enter a valid expiry date",
+				"invalidMonth": "Enter a valid expiry date",
+				"invalidYear": "Enter a valid expiry date",
+				"inThePast": "Enter an expiry date in the future"
+			},
+			"expiryYear": {
+				"name": "expiry year",
+				"message": "Enter a valid expiry date",
+				"invalidYear": "This expiry year is not a valid"
+			},
+			"addressLine1": {
+				"name": "building name/number and street",
+				"message": "Enter a valid billing address",
+				"containsTooManyDigits": "Enter a valid billing address"
+			},
+			"addressLine2": {
+				"name": "additional address line",
+				"message": "Enter valid address information",
+				"containsTooManyDigits": "Enter valid address information"
+			},
+			"addressCity": {
+				"name": "town/city",
+				"message": "Enter a valid town/city",
+				"containsTooManyDigits": "Enter a valid town/city"
+			},
+			"addressPostcode": {
+				"name": "postcode",
+				"message": "Enter a valid postcode",
+				"containsTooManyDigits": "Enter a valid postcode"
+			},
+			"email": {
+				"name": "email",
+				"message": "Enter a valid email",
+				"containsTooManyDigits": "Enter a valid email",
+				"typo": "There might be a mistake in the last part of your email address. Select your email address."
+			},
+			"addressCountry": {
+				"name": "country or territory",
+				"message": "Enter a valid country or territory"
+			}
+		}
+	}
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -82,8 +82,7 @@
   },
   "fieldErrors": {
     "summary": "The following fields are missing or contain errors",
-    "missing": "is missing",
-    "invalid": "is invalid",
+    "generic": "Enter a valid %s",
     "fields": {
       "cardholderName": {
         "name": "name",

--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ if (!process.env.DISABLE_APPMETRICS) {
 
 // Node.js core dependencies
 const path = require('path')
-const fs = require('fs')
 const v8 = require('v8')
 
 // npm dependencies
@@ -85,11 +84,12 @@ function initialiseGlobalMiddleware (app) {
 
 function initialisei18n (app) {
   i18n.configure({
-    locales: ['en'],
+    locales: ['en', 'cy'],
     directory: path.join(__dirname, '/locales'),
     objectNotation: true,
     defaultLocale: 'en',
-    register: global
+    register: global,
+    autoReload: NODE_ENV !== 'production'
   })
 
   app.use(i18n.init)
@@ -126,14 +126,6 @@ function initialiseTemplateEngine (app) {
   // if it's not production we want to re-evaluate the assets on each file change
   nunjucksEnvironment.addGlobal('css_path', NODE_ENV === 'production' ? CSS_PATH : staticify.getVersionedPath('/stylesheets/application.css'))
   nunjucksEnvironment.addGlobal('js_path', NODE_ENV === 'production' ? JAVASCRIPT_PATH : staticify.getVersionedPath('/javascripts/application.min.js'))
-  // Initialise internationalisation
-  fs.readFile('./locales/en.json', 'utf8', (err, data) => {
-    if (err) {
-      throw err
-    }
-    nunjucksEnvironment.addGlobal('i18n', JSON.parse(data))
-    nunjucksEnvironment.addGlobal('i18n_as_string', data)
-  })
 }
 
 function initialisePublic (app) {

--- a/test/test_helpers/html_assertions.js
+++ b/test/test_helpers/html_assertions.js
@@ -2,11 +2,17 @@
 const cheerio = require('cheerio')
 const chai = require('chai')
 const nunjucks = require('nunjucks')
-const i18n = require('../../locales/en.json')
+const lodash = require('lodash')
 
 // Global initialisation
 const views = ['./app/views', './node_modules/govuk-frontend']
 const environment = nunjucks.configure(views)
+const strings = require('./../../locales/en.json')
+
+// Shim for i18n to make it recognise the __() function and return the English string
+environment.addGlobal('__', string => {
+  return lodash.get(strings, string)
+})
 
 module.exports = {
   render: render
@@ -14,8 +20,6 @@ module.exports = {
 
 function render (templateName, templateData) {
   const pathToTemplate = templateName + '.njk'
-
-  templateData.i18n = i18n
 
   return environment.render(pathToTemplate, templateData)
 }


### PR DESCRIPTION
Reconfigure app to use i18n in a way which means english isn’t hard coded.

This is also changes the way the strings are fed into the the templates which required switching to using `_("object.path")` syntax

Also added cy.json which contains the welsh strings