### PR TITLE
bau: log memory stats

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ if (!process.env.DISABLE_APPMETRICS) {
 // Node.js core dependencies
 const path = require('path')
 const fs = require('fs')
+const v8 = require('v8')
 
 // npm dependencies
 const express = require('express')
@@ -77,6 +78,9 @@ function initialiseGlobalMiddleware (app) {
   app.use(compression())
 
   app.disable('x-powered-by')
+
+  logger.info('Heap statistics: ' + v8.getHeapStatistics())
+  logger.info('process.memoryUsage: ' + process.memoryUsage())
 }
 
 function initialisei18n (app) {


### PR DESCRIPTION
As part of the performance testing epic
(https://payments-platform.atlassian.net/browse/PP-4004) we have made some
changes to improve performance Some of these are:

- caching token requests in publicapi
- upgrading frontend's ec2 instances from m3.medium -> c4.large

It would be good to log the memory statistics for each server process in node
should we need to further improve performance (for example, by changing the
heap size, which would then affect when the garbage collection kicks in) for
frontend in the future. We currently have no easy way to know this.

@oswaldquek
