### PR TITLE
PP-4098 get language from charge

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -270,7 +270,6 @@ module.exports = {
       hitPage: routeFor('new', charge.id) + '/success',
       charge: charge,
       confirmPath: confirmPath,
-      gatewayAccount: {serviceName: charge.gatewayAccount.serviceName},
       post_cancel_action: routeFor('cancel', charge.id)
     }, confirmPath))
   },

--- a/app/middleware/resolve_language.js
+++ b/app/middleware/resolve_language.js
@@ -4,6 +4,8 @@
 const i18n = require('i18n')
 
 module.exports = function (req, res, next) {
-  res.locals.translationStrings = JSON.stringify(i18n.getCatalog('en'))
+  const language = req.chargeData.language || 'en'
+  i18n.setLocale(req, language)
+  res.locals.translationStrings = JSON.stringify(i18n.getCatalog(language))
   next()
 }

--- a/app/middleware/resolve_language.js
+++ b/app/middleware/resolve_language.js
@@ -7,5 +7,6 @@ module.exports = function (req, res, next) {
   const language = req.chargeData.language || 'en'
   i18n.setLocale(req, language)
   res.locals.translationStrings = JSON.stringify(i18n.getCatalog(language))
+  res.locals.language = language
   next()
 }

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -17,7 +17,7 @@ class Service {
    **/
   constructor (serviceData) {
     this.externalId = serviceData.external_id
-    this.name = serviceData.name
+    this.name = serviceData.service_name
     this.gatewayAccountIds = serviceData.gateway_account_ids
     this.customBranding =
       serviceData.custom_branding ? {

--- a/app/router.js
+++ b/app/router.js
@@ -32,13 +32,13 @@ exports.bind = function (app) {
   const card = paths.card
 
   const middlewareStack = [
-    resolveLanguage,
     csrfCheck,
     csrfTokenGeneration,
     actionName,
     retrieveCharge,
     resolveService,
-    stateEnforcer
+    stateEnforcer,
+    resolveLanguage
   ]
 
   app.get(card.new.path, middlewareStack, charge.new)

--- a/app/views/includes/custom.njk
+++ b/app/views/includes/custom.njk
@@ -1,9 +1,3 @@
-{% set serviceName = service.name[language] %}
-
-{% if not serviceName %}
-  {% set serviceName = service.name.en %}
-{% endif %}
-
 <header class="govuk-header " role="banner" data-module="header">
   <div class="govuk-header__container govuk-width-container">
 

--- a/app/views/includes/custom.njk
+++ b/app/views/includes/custom.njk
@@ -1,3 +1,9 @@
+{% set serviceName = service.name[language] %}
+
+{% if not serviceName %}
+  {% set serviceName = service.name.en %}
+{% endif %}
+
 <header class="govuk-header " role="banner" data-module="header">
   <div class="govuk-header__container govuk-width-container">
 
@@ -10,7 +16,7 @@
     </div>
     <div class="govuk-header__content">
       <a href="/" class="govuk-header__link govuk-header__link--service-name">
-        {{ gatewayAccount.serviceName }}
+        {{ serviceName }}
       </a>
     </div>
   </div>

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -26,13 +26,19 @@
   {% set bodyClasses = "custom-branding" %}
 {% endif %}
 
+{% set serviceName = service.name[language] %}
+
+{% if not serviceName %}
+  {% set serviceName = service.name.en %}
+{% endif %}
+
 {% block header %}
   {% if service and service.customBranding and service.customBranding.cssUrl %}
     {% include "includes/custom.njk" %}
   {% else %}
     {{ govukHeader({
       homepageUrl: 'https://www.gov.uk',
-      serviceName: gatewayAccount.serviceName,
+      serviceName: serviceName,
       serviceUrl: '#'
     }) }}
   {% endif %}

--- a/test/integration/charge_ft_tests.js
+++ b/test/integration/charge_ft_tests.js
@@ -157,6 +157,11 @@ describe('chargeTests', function () {
                 'brand': 'VISA',
                 'label': 'Visa'
               }]
+            },
+            service: {
+              name: {
+                en: 'Pranks incorporated'
+              }
             }
           })
 
@@ -787,7 +792,6 @@ describe('chargeTests', function () {
           expect($('#expiry-date').text()).to.contains('11/99')
           expect($('#cardholder-name').text()).to.contains('Test User')
           expect($('#address').text()).to.contains('line1, line2, city, postcode, United Kingdom')
-          expect($('.govuk-header__link--service-name').text()).to.contains('Pranks incorporated')
           expect($('.payment-summary #amount').text()).to.eql('£23.45')
           expect($('.payment-summary #payment-description').text()).to.contain('Payment Description')
         })

--- a/test/middleware/resolve_language_test.js
+++ b/test/middleware/resolve_language_test.js
@@ -1,0 +1,74 @@
+// NPM dependencies
+const path = require('path')
+const i18n = require('i18n')
+const assert = require('assert')
+
+// local dependencies
+const resolveLanguage = require('../../app/middleware/resolve_language.js')
+
+// local constants
+const res = {
+  locals: {}
+}
+
+describe('Resolve language from Charge object', function () {
+  beforeEach(function () {
+    i18n.configure({
+      locales: ['en', 'cy'],
+      directory: path.join(__dirname, '../../locales'),
+      objectNotation: true,
+      defaultLocale: 'en',
+      register: global
+    })
+  })
+
+  describe('If language is set to English', function () {
+    const req = {
+      chargeData: {
+        language: 'en'
+      }
+    }
+
+    it('should set language and use English strings', function (done) {
+      resolveLanguage(req, res, function () {
+        assert(res.locals.language === req.chargeData.language)
+        const strings = JSON.parse(res.locals.translationStrings)
+        assert(strings.cardDetails.title === 'Enter card details')
+        done()
+      })
+    })
+  })
+
+  describe('If no language is set', function () {
+    const req = {
+      chargeData: {
+      }
+    }
+
+    it('should default to English', function (done) {
+      resolveLanguage(req, res, function () {
+        assert(res.locals.language === 'en')
+        const strings = JSON.parse(res.locals.translationStrings)
+        assert(strings.cardDetails.title === 'Enter card details')
+        done()
+      })
+    })
+  })
+
+  describe('If language is set to Welsh', function () {
+    const req = {
+      chargeData: {
+        language: 'cy'
+      }
+    }
+
+    it('should set language and use Welsh strings', function (done) {
+      resolveLanguage(req, res, function () {
+        assert(res.locals.language === req.chargeData.language)
+        const strings = JSON.parse(res.locals.translationStrings)
+        assert(strings.cardDetails.title === 'Rhowch fanylion y cerdyn')
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Retrieve language from charge object
- Previously we were getting the service name from the gateway account
object now getting it from the service object (which comes from
adminusers).
- Pass the language to the template and use that to get the correct
service name translation.