### PR TITLE
Match worker count to number of cpus

### DIFF
--- a/app/services/environment.js
+++ b/app/services/environment.js
@@ -5,4 +5,4 @@ const os = require('os')
 /**
  * @return {Number} Number of node workers in cluster
  */
-exports.getWorkerCount = () => os.cpus().length || 1
+exports.getWorkerCount = () => process.env.NODE_WORKER_COUNT || os.cpus().length || 1

--- a/app/services/environment.js
+++ b/app/services/environment.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const os = require('os')
+
 /**
  * @return {Number} Number of node workers in cluster
  */
-exports.getWorkerCount = () => process.env.NODE_WORKER_COUNT || 1
+exports.getWorkerCount = () => os.cpus().length || 1


### PR DESCRIPTION
The consensus in node land is that you should have one node process
per cpu core. This commit uses the built in os module to configure that.