### PR TITLE
PP-4108 Add status `AWAITING CAPTURE REQUEST`

### DIFF
--- a/app/utils/views.js
+++ b/app/utils/views.js
@@ -202,6 +202,12 @@ module.exports = {
 
   ENTERING_CARD_DETAILS: systemError,
 
+  AWAITING_CAPTURE_REQUEST: {
+    view: 'errors/charge_confirm_state_completed',
+    locals: {status: 'successful'},
+    analyticsPage: '/success_return'
+  },
+
   display: function (res, viewName, options) {
     let action = lodash.result(this, viewName)
     options = options || {}

--- a/test/enforce_status_views_tests.js
+++ b/test/enforce_status_views_tests.js
@@ -119,6 +119,10 @@ describe('The /charge endpoint dealt statuses', function () {
     {
       name: 'user cancel error',
       view: 'USER_CANCEL_ERROR'
+    },
+    {
+      name: 'awaiting capture request',
+      view: 'AWAITING_CAPTURE_REQUEST'
     }
   ]
   beforeEach(function () {
@@ -249,6 +253,11 @@ describe('The /confirm endpoint dealt statuses', function () {
     {
       name: 'user cancel error',
       view: 'USER_CANCEL_ERROR'
+    },
+    {
+      name: 'awaiting capture request',
+      view: 'AWAITING_CAPTURE_REQUEST',
+      viewState: 'successful'
     }
   ]
   beforeEach(function () {


### PR DESCRIPTION
## WHAT
- Made frontend aware of the status `AWAITING CAPTURE REQUEST`

## HOW 
- This new status will map the functionality of `CAPTURED`, as long as the
user is concerned the payment was successful
- Made the view enforcer return success page when a charge with this state
is retrieved from connector, on urls: `/chargeid` and `/chargeid/confirm`

with @danworth



