### PR TITLE
PP-4124 Updated /check_card endpoint to return corporate information

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -195,9 +195,13 @@ module.exports = {
       Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER])
         .checkCard(normalise.creditCard(req.body.cardNo), req.chargeData.language, subSegment)
         .then(
-          () => {
+          (card) => {
             subSegment.close()
-            return res.json({'accepted': true})
+            return res.json({
+              accepted: true,
+              corporate: card.corporate,
+              type: card.type
+            })
           },
           message => {
             subSegment.close(message)

--- a/app/utils/charge_validation_backend.js
+++ b/app/utils/charge_validation_backend.js
@@ -13,9 +13,9 @@ module.exports = (translations, logger, cardModel) => {
     verify: (req) => new Promise((resolve) => {
       const validation = validator.verify(req.body)
       cardModel.checkCard(normalise.creditCard(req.body.cardNo), req.chargeData.language)
-        .then(cardBrand => {
-          logger.debug('Card supported - ', {cardBrand})
-          resolve({validation, cardBrand})
+        .then(card => {
+          logger.debug('Card supported - ', {cardBrand: card.brand})
+          resolve({validation, cardBrand: card.brand})
         })
         .catch(err => {
           logger.error('Card not supported - ', {'err': err})


### PR DESCRIPTION
## WHAT

- Added `corporate` and `type` to the response if existing `accepted` is true.
- Modified related tests.
- Reformatted code.

with @DanailMinchev and @brid
