### PR TITLE
PP-4196 Include properties for corporate surcharge in cardAuth call

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -104,7 +104,7 @@ module.exports = {
     const cardModel = Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER])
     const authUrl = normalise.authUrl(charge)
     const validator = chargeValidator(i18n.__('fieldErrors'), logger, cardModel)
-    let cardBrand
+    let card
 
     normalise.addressLines(req.body)
     normalise.whitespace(req.body)
@@ -119,7 +119,7 @@ module.exports = {
         })
         .then(data => {
           subSegment.close()
-          cardBrand = data.cardBrand
+          card = data.card
           let emailChanged = false
           let userEmail = req.body.email
           if (req.body.originalemail) {
@@ -153,7 +153,7 @@ module.exports = {
                 const startTime = new Date()
                 const correlationId = req.headers[CORRELATION_HEADER] || ''
                 baseClient.post(authUrl, {
-                  data: normalise.apiPayload(req, cardBrand),
+                  data: normalise.apiPayload(req, card),
                   correlationId: correlationId
                 }, (data, json) => {
                   logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', authUrl, new Date() - startTime)

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -1,13 +1,16 @@
-var countries = require('../services/countries')
-var humps = require('humps')
-var normaliseCards = require('../services/normalise_cards.js')
-var _ = require('lodash')
+'use strict'
+
+// NPM dependencies
+const humps = require('humps')
+const _ = require('lodash')
+
+// Local dependencies
+const countries = require('../services/countries')
+const normaliseCards = require('../services/normalise_cards.js')
 
 module.exports = (function () {
-  'use strict'
-
-  var _charge = function (charge, chargeId) {
-    var chargeObj = {
+  const _charge = function (charge, chargeId) {
+    const chargeObj = {
       id: chargeId,
       amount: penceToPounds(charge.amount),
       service_return_url: charge.return_url,
@@ -26,11 +29,11 @@ module.exports = (function () {
     return chargeObj
   }
 
-  var penceToPounds = function (pence) {
+  const penceToPounds = function (pence) {
     return (parseInt(pence) / 100).toFixed(2)
   }
 
-  var addressForApi = function (body) {
+  const addressForApi = function (body) {
     return {
       line1: body.addressLine1,
       line2: body.addressLine2,
@@ -40,14 +43,14 @@ module.exports = (function () {
     }
   }
   // body is passed by reference
-  var addressLines = function (body) {
+  const addressLines = function (body) {
     if (!body.addressLine1 && body.addressLine2) {
       body.addressLine1 = body.addressLine2
       delete body.addressLine2
     }
   }
-  var whitespace = function (body) {
-    var toIgnore = [
+  const whitespace = function (body) {
+    const toIgnore = [
       'submitCardDetails',
       'csrfToken',
       'chargeId'
@@ -60,15 +63,15 @@ module.exports = (function () {
     })
   }
 
-  var _normaliseConfirmationDetails = function (cardDetails) {
+  const _normaliseConfirmationDetails = function (cardDetails) {
     cardDetails.cardNumber = '************' + cardDetails.last_digits_card_number
     delete cardDetails.last_digits_card_number
-    var normalisedDetails = humps.camelizeKeys(cardDetails)
+    const normalisedDetails = humps.camelizeKeys(cardDetails)
     normalisedDetails.billingAddress = _normaliseAddress(cardDetails.billing_address)
     return normalisedDetails
   }
 
-  var _normaliseAddress = function (address) {
+  const _normaliseAddress = function (address) {
     return [address.line1,
       address.line2,
       address.city,
@@ -76,13 +79,13 @@ module.exports = (function () {
       countries.translateCountryISOtoName(address.country)].filter(function (str) { return str }).join(', ')
   }
 
-  var _normaliseGatewayAccountDetails = function (accountDetails) {
-    var gatewayAccountDetails = humps.camelizeKeys(accountDetails)
+  const _normaliseGatewayAccountDetails = function (accountDetails) {
+    const gatewayAccountDetails = humps.camelizeKeys(accountDetails)
     gatewayAccountDetails.cardTypes = normaliseCards(gatewayAccountDetails.cardTypes)
     return gatewayAccountDetails
   }
 
-  var _normaliseAuth3dsData = function (auth3dsData) {
+  const _normaliseAuth3dsData = function (auth3dsData) {
     return {
       paRequest: auth3dsData.paRequest,
       issuerUrl: auth3dsData.issuerUrl,
@@ -92,7 +95,7 @@ module.exports = (function () {
   }
 
   // an empty string is equal to false in soft equality used by filter
-  var addressForView = function (body) {
+  const addressForView = function (body) {
     return [body.addressLine1,
       body.addressLine2,
       body.addressCity,
@@ -100,17 +103,17 @@ module.exports = (function () {
       countries.translateCountryISOtoName(body.addressCountry)].filter(function (str) { return str }).join(', ')
   }
 
-  var creditCard = function (creditCardNo) {
+  const creditCard = function (creditCardNo) {
     creditCardNo = (creditCardNo) || ''
     return creditCardNo.replace(/\D/g, '')
   }
 
-  var expiryDate = function (month, year) {
+  const expiryDate = function (month, year) {
     month = (month.length === 1) ? '0' + month : month
     return month.slice(-2) + '/' + year.slice(-2)
   }
 
-  var apiPayload = function (req, card) {
+  const apiPayload = function (req, card) {
     return {
       'card_number': creditCard(req.body.cardNo),
       'cvc': req.body.cvc,
@@ -125,13 +128,13 @@ module.exports = (function () {
     }
   }
 
-  var authUrl = function (charge) {
-    var authLink = charge.links.find((link) => { return link.rel === 'cardAuth' })
+  const authUrl = function (charge) {
+    const authLink = charge.links.find((link) => { return link.rel === 'cardAuth' })
     return authLink.href
   }
 
-  var chargeUrl = function (charge) {
-    var selfLink = charge.links.find((link) => { return link.rel === 'self' })
+  const chargeUrl = function (charge) {
+    const selfLink = charge.links.find((link) => { return link.rel === 'self' })
     return selfLink.href
   }
 

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -110,13 +110,15 @@ module.exports = (function () {
     return month.slice(-2) + '/' + year.slice(-2)
   }
 
-  var apiPayload = function (req, cardBrand) {
+  var apiPayload = function (req, card) {
     return {
       'card_number': creditCard(req.body.cardNo),
       'cvc': req.body.cvc,
-      'card_brand': cardBrand,
+      'card_brand': card.brand,
       'expiry_date': expiryDate(req.body.expiryMonth, req.body.expiryYear),
       'cardholder_name': req.body.cardholderName,
+      'card_type': card.type,
+      'corporate_card': card.corporate,
       'address': addressForApi(req.body),
       'accept_header': req.header('accept'),
       'user_agent_header': req.header('user-agent')

--- a/app/utils/charge_validation_backend.js
+++ b/app/utils/charge_validation_backend.js
@@ -14,8 +14,12 @@ module.exports = (translations, logger, cardModel) => {
       const validation = validator.verify(req.body)
       cardModel.checkCard(normalise.creditCard(req.body.cardNo), req.chargeData.language)
         .then(card => {
-          logger.debug('Card supported - ', {cardBrand: card.brand})
-          resolve({validation, cardBrand: card.brand})
+          logger.debug('Card supported - ', {
+            cardBrand: card.brand,
+            cardType: card.type,
+            cardCorporate: card.corporate
+          })
+          resolve({validation, card})
         })
         .catch(err => {
           logger.error('Card not supported - ', {'err': err.message})

--- a/test/integration/charge_ft_tests.js
+++ b/test/integration/charge_ft_tests.js
@@ -50,7 +50,7 @@ const serviceFixtures = require('../fixtures/service_fixtures')
 
 // Constants
 const EMPTY_BODY = ''
-let defaultCorrelationHeader = {
+const defaultCorrelationHeader = {
   reqheaders: {'x-request-id': 'some-unique-id'}
 }
 const gatewayAccount = {
@@ -62,9 +62,9 @@ const gatewayAccount = {
 
 let mockServer
 
-let defaultCardID = {brand: 'visa', label: 'visa', type: 'D', corporate: false}
+const defaultCardID = {brand: 'visa', label: 'visa', type: 'D', corporate: false}
 
-let mockSuccessCardIdResponse = function (data) {
+const mockSuccessCardIdResponse = function (data) {
   nock(process.env.CARDID_HOST)
     .post('/v1/api/card', () => {
       return true
@@ -73,19 +73,19 @@ let mockSuccessCardIdResponse = function (data) {
 }
 
 describe('chargeTests', function () {
-  let localServer = process.env.CONNECTOR_HOST
-  let adminUsersHost = process.env.ADMINUSERS_URL
+  const localServer = process.env.CONNECTOR_HOST
+  const adminUsersHost = process.env.ADMINUSERS_URL
 
   const servicesResource = `/v1/api/services`
-  let connectorChargePath = '/v1/frontend/charges/'
-  let chargeId = '23144323'
-  let frontendCardDetailsPath = '/card_details'
-  let frontendCardDetailsPostPath = '/card_details/' + chargeId
+  const connectorChargePath = '/v1/frontend/charges/'
+  const chargeId = '23144323'
+  const frontendCardDetailsPath = '/card_details'
+  const frontendCardDetailsPostPath = '/card_details/' + chargeId
   const gatewayAccountId = gatewayAccount.gatewayAccountId
 
-  let connectorAuthUrl = localServer + connectorChargePath + chargeId + '/cards'
-  let enteringCardDetailsState = 'ENTERING CARD DETAILS'
-  let RETURN_URL = 'http://www.example.com/service'
+  const connectorAuthUrl = localServer + connectorChargePath + chargeId + '/cards'
+  const enteringCardDetailsState = 'ENTERING CARD DETAILS'
+  const RETURN_URL = 'http://www.example.com/service'
 
   function connectorExpects (data) {
     return mockServer.post(connectorChargePath + chargeId + '/cards', body => {
@@ -120,7 +120,7 @@ describe('chargeTests', function () {
   }
 
   function fullConnectorCardData (cardNumber) {
-    let cardData = minimumConnectorCardData(cardNumber)
+    const cardData = minimumConnectorCardData(cardNumber)
     cardData.address.line2 = 'bla bla'
     cardData.address.city = 'London'
     cardData.address.country = 'GB'
@@ -128,7 +128,7 @@ describe('chargeTests', function () {
   }
 
   function fullFormCardData (cardNumber) {
-    let cardData = minimumFormCardData(cardNumber)
+    const cardData = minimumFormCardData(cardNumber)
     cardData.addressLine2 = 'bla bla'
     return cardData
   }
@@ -203,7 +203,7 @@ describe('chargeTests', function () {
 
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
-        let cookieValue = cookie.create(chargeId)
+        const cookieValue = cookie.create(chargeId)
         return getChargeRequest(app, cookieValue, chargeId)
       }
 
@@ -280,7 +280,7 @@ describe('chargeTests', function () {
       })
 
       it('should redirect user to auth_waiting when connector returns 409', function (done) {
-        let cookieValue = cookie.create(chargeId)
+        const cookieValue = cookie.create(chargeId)
         nock(process.env.CONNECTOR_HOST)
           .patch('/v1/frontend/charges/23144323')
           .reply(200)
@@ -303,7 +303,7 @@ describe('chargeTests', function () {
       })
 
       it('should redirect user to confirm when connector returns 200 for authorisation success', function (done) {
-        let cookieValue = cookie.create(chargeId)
+        const cookieValue = cookie.create(chargeId)
         nock(process.env.CONNECTOR_HOST)
           .patch('/v1/frontend/charges/23144323')
           .reply(200)
@@ -321,7 +321,7 @@ describe('chargeTests', function () {
       })
 
       it('should send expected card data to connector for the case of a corporate debit card', function (done) {
-        let cookieValue = cookie.create(chargeId)
+        const cookieValue = cookie.create(chargeId)
         nock(process.env.CONNECTOR_HOST)
           .patch('/v1/frontend/charges/23144323')
           .reply(200)
@@ -339,7 +339,7 @@ describe('chargeTests', function () {
       })
 
       it('should send expected card data to connector for the case of a non-corporate credit card', function (done) {
-        let cookieValue = cookie.create(chargeId)
+        const cookieValue = cookie.create(chargeId)
         nock(process.env.CONNECTOR_HOST)
           .patch('/v1/frontend/charges/23144323')
           .reply(200)
@@ -357,7 +357,7 @@ describe('chargeTests', function () {
       })
 
       it('should redirect user to confirm when connector returns 200 for authorisation and 3DS is required', function (done) {
-        let cookieValue = cookie.create(chargeId)
+        const cookieValue = cookie.create(chargeId)
         nock(process.env.CONNECTOR_HOST)
           .patch('/v1/frontend/charges/23144323')
           .reply(200)
@@ -375,7 +375,7 @@ describe('chargeTests', function () {
       })
 
       it('should redirect user from /auth_waiting to /confirm when connector returns a successful status', function (done) {
-        let cookieValue = cookie.create(chargeId)
+        const cookieValue = cookie.create(chargeId)
         defaultConnectorResponseForGetCharge(chargeId, State.AUTH_SUCCESS, gatewayAccountId)
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
@@ -433,7 +433,7 @@ describe('chargeTests', function () {
       })
 
       it('should error without csrf', function (done) {
-        let cookieValue = cookie.create(chargeId)
+        const cookieValue = cookie.create(chargeId)
         defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
@@ -445,7 +445,7 @@ describe('chargeTests', function () {
       })
 
       it('should send card data including optional fields to connector', function (done) {
-        let cookieValue = cookie.create(chargeId)
+        const cookieValue = cookie.create(chargeId)
         mockSuccessCardIdResponse(defaultCardID)
         nock(process.env.CONNECTOR_HOST)
           .patch('/v1/frontend/charges/23144323')
@@ -1322,7 +1322,7 @@ describe('chargeTests', function () {
     })
 
     it('should send 3ds data to connector and render an error if connector post failed', function (done) {
-      let cookieValue = cookie.create(chargeId)
+      const cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
         .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
         .post(`${connectorChargePath}${chargeId}/3ds`, {pa_response: 'aPaResponse'}).replyWithError(404)


### PR DESCRIPTION
- Added the whole `card` object (which includes `brand`, `type` and
 `corporate` properties) to be returned from `charge_validation_backend`
  module instead of only `brand`
- include 'corporate_card' and 'card_type' properties in request body
  when calling v1/frontend/charges/CHARGE_ID/cards. These values come
  from call to card id
- updated existing tests for confirming the patch to
  /v1/frontend/charges/ and the post to
  /v1/frontend/charges/{CHARGE_ID}/cards to expect these new properties
  to be included
- added new tests to check the combinations of card type and
  corporate/non-corporate
- Renamed `defaultCardId` to `mockSuccessCardIdResponse` within `charge_ft_tests.js` for clarity. 
 Note that the card number previously being passed to `defaultCardId` was not being used.

with @stephencdaly and @danworth and @DanailMinchev 