### PR TITLE
PP-4196 Corporate card information on confirmation page

### DIFF
--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -26,6 +26,12 @@ module.exports = (function () {
     if (charge.card_details) {
       chargeObj.cardDetails = _normaliseConfirmationDetails(charge.card_details)
     }
+    if (charge.corporate_surcharge) {
+      chargeObj.corporateSurcharge = penceToPounds(charge.corporate_surcharge)
+    }
+    if (charge.total_amount) {
+      chargeObj.totalAmount = penceToPounds(charge.total_amount)
+    }
     return chargeObj
   }
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -350,7 +350,7 @@
     </form>
   </div>
   <div class="govuk-grid-column-one-third payment-summary-wrap">
-    <aside class="payment-summary govuk-!-font-size-19">
+    <aside class="payment-summary">
       <h2 class="govuk-heading-m">{{ __("paymentSummary.title") }}</h2>
       <p id="payment-description" class="govuk-body govuk-!-font-weight-bold">
         {{ description }}

--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -69,14 +69,20 @@
     </form>
   </div>
   <div class="govuk-grid-column-one-third payment-summary-wrap">
-    <aside class="payment-summary">
+    <aside class="payment-summary govuk-!-font-size-19">
       <h2 class="govuk-heading-m">{{ __("paymentSummary.title") }}</h2>
-      <p id="payment-description" class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-39">
+      <p id="payment-description" class="govuk-body govuk-!-font-weight-bold">
         {{ charge.description }}
       </p>
-      <p class="govuk-body govuk-!-font-size-39 govuk-!-margin-bottom-0">
+      {% if charge.corporateSurcharge %}
+      <p class="govuk-body" id="payment-summary-breakdown">
+        {{ __("paymentSummary.amount") }} <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount">£{{ charge.amount }}</span><br/>
+        {{ __("paymentSummary.corporateCardFee") }} <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee">£{{ charge.corporateSurcharge }}</span>
+      </p>
+      {% endif %}
+      <p class="govuk-body govuk-!-margin-bottom-0">
         {{ __("paymentSummary.totalAmount") }}
-        <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold">£{{ charge.amount }}</span>
+        <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold">£{{ charge.totalAmount if charge.totalAmount else charge.amount }}</span>
       </p>
     </aside>
   </div>

--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -69,7 +69,7 @@
     </form>
   </div>
   <div class="govuk-grid-column-one-third payment-summary-wrap">
-    <aside class="payment-summary govuk-!-font-size-19">
+    <aside class="payment-summary">
       <h2 class="govuk-heading-m">{{ __("paymentSummary.title") }}</h2>
       <p id="payment-description" class="govuk-body govuk-!-font-weight-bold">
         {{ charge.description }}

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -87,6 +87,14 @@ function cardTypes () {
   ]
 }
 
+function rawSuccessfulGetChargeCorporateCardOnly (status, returnUrl, chargeId, gatewayAccountId) {
+  const charge = rawSuccessfulGetCharge(status, returnUrl, chargeId, gatewayAccountId)
+  charge.amount = 2345
+  charge.corporate_surcharge = 250
+  charge.total_amount = 2595
+  return charge
+}
+
 function rawSuccessfulGetChargeDebitCardOnly (status, returnUrl, chargeId, gatewayAccountId) {
   var charge = rawSuccessfulGetCharge(status, returnUrl, chargeId, gatewayAccountId)
   charge.gateway_account.card_types = [
@@ -260,6 +268,8 @@ module.exports = {
   rawSuccessfulGetCharge: rawSuccessfulGetCharge,
 
   rawSuccessfulGetChargeDebitCardOnly: rawSuccessfulGetChargeDebitCardOnly,
+
+  rawSuccessfulGetChargeCorporateCardOnly: rawSuccessfulGetChargeCorporateCardOnly,
 
   templateValue: function (res, key, value) {
     var body = JSON.parse(res.text)

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -39,12 +39,12 @@ function connectorCaptureUrl (chargeId) {
 }
 
 function connectorRespondsWith (chargeId, charge) {
-  var connectorMock = nock(localConnector())
+  const connectorMock = nock(localConnector())
   connectorMock.get(connectorChargePath + chargeId).reply(200, charge)
 }
 
 function adminusersRespondsWith (gatewayAccountId, service) {
-  var adminusersMock = nock(localAdminusers())
+  const adminusersMock = nock(localAdminusers())
   adminusersMock.get(`${adminusersServicePath}?gatewayAccountId=${gatewayAccountId}`).reply(200, service)
 }
 
@@ -96,7 +96,7 @@ function rawSuccessfulGetChargeCorporateCardOnly (status, returnUrl, chargeId, g
 }
 
 function rawSuccessfulGetChargeDebitCardOnly (status, returnUrl, chargeId, gatewayAccountId) {
-  var charge = rawSuccessfulGetCharge(status, returnUrl, chargeId, gatewayAccountId)
+  const charge = rawSuccessfulGetCharge(status, returnUrl, chargeId, gatewayAccountId)
   charge.gateway_account.card_types = [
     {
       'type': 'DEBIT',
@@ -108,7 +108,7 @@ function rawSuccessfulGetChargeDebitCardOnly (status, returnUrl, chargeId, gatew
 }
 
 function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}) {
-  var charge = {
+  const charge = {
     'amount': 2345,
     'description': 'Payment Description',
     'status': status,
@@ -212,7 +212,7 @@ module.exports = {
             .expect(200)
             .end(function (err, res) {
               if (err) done(err)
-              var response = JSON.parse(res.text)
+              const response = JSON.parse(res.text)
               Object.keys(expectedResponse).map(function (key) {
                 expectedResponse[key].should.equal(response[key])
               })
@@ -247,9 +247,9 @@ module.exports = {
 
   connectorResponseForPutCharge: function (chargeId, statusCode, responseBody, overrideUrl) {
     initConnectorUrl()
-    var connectorMock = nock(localConnector())
-    var mockPath = connectorChargePath + chargeId + '/status'
-    var payload = {'new_status': 'ENTERING CARD DETAILS'}
+    const connectorMock = nock(localConnector())
+    const mockPath = connectorChargePath + chargeId + '/status'
+    const payload = {'new_status': 'ENTERING CARD DETAILS'}
     connectorMock.put(mockPath, payload).reply(statusCode, responseBody)
   },
 
@@ -260,29 +260,29 @@ module.exports = {
 
   defaultConnectorResponseForGetCharge: function (chargeId, status, gatewayAccountId) {
     initConnectorUrl()
-    var returnUrl = 'http://www.example.com/service'
-    var rawResponse = rawSuccessfulGetCharge(status, returnUrl, chargeId, gatewayAccountId)
+    const returnUrl = 'http://www.example.com/service'
+    const rawResponse = rawSuccessfulGetCharge(status, returnUrl, chargeId, gatewayAccountId)
     connectorRespondsWith(chargeId, rawResponse)
   },
 
-  rawSuccessfulGetCharge: rawSuccessfulGetCharge,
+  rawSuccessfulGetCharge,
 
-  rawSuccessfulGetChargeDebitCardOnly: rawSuccessfulGetChargeDebitCardOnly,
+  rawSuccessfulGetChargeDebitCardOnly,
 
-  rawSuccessfulGetChargeCorporateCardOnly: rawSuccessfulGetChargeCorporateCardOnly,
+  rawSuccessfulGetChargeCorporateCardOnly,
 
   templateValue: function (res, key, value) {
-    var body = JSON.parse(res.text)
+    const body = JSON.parse(res.text)
     return chaiExpect(_.result(body, key)).to.deep.equal(value)
   },
 
   templateValueNotUndefined: function (res, key) {
-    var body = JSON.parse(res.text)
+    const body = JSON.parse(res.text)
     return chaiExpect(_.result(body, key)).to.not.be.undefined
   },
 
   templateValueUndefined: function (res, key) {
-    var body = JSON.parse(res.text)
+    const body = JSON.parse(res.text)
     return chaiExpect(_.result(body, key)).to.be.undefined
   },
 
@@ -294,6 +294,6 @@ module.exports = {
     return csrf().create(process.env.CSRF_USER_SECRET)
   },
 
-  cardTypes: cardTypes
+  cardTypes
 
 }


### PR DESCRIPTION
## WHAT

- Added `charge.corporate_surcharge` which is corporate card fee and can be present or not to the `confirm.njk` template.
- Added `charge.total_amount` which is total amount of the charge and can be present or not to the `confirm.njk` template.
- Added UI test with connector mock.

with @stephencdaly
