### PR TITLE
PP-4320 - fix JS error appearing in console

### DIFF
--- a/app/assets/javascripts/modules/form-validation.js
+++ b/app/assets/javascripts/modules/form-validation.js
@@ -134,7 +134,7 @@ var formValidation = function () {
     // validation happens on blur, check which input the user is on now
     var focusedGroup = getFormGroup(document.activeElement)
     var inGroup = focusedGroup === group
-    var groupHasError = getFormGroup(input).classList.contains('govuk-form-group--error')
+    var groupHasError = group ? group.classList.contains('govuk-form-group--error') : false
     var lastOfgroup = input.hasAttribute('data-last-of-form-group')
     var required = input.hasAttribute('data-required')
     if ((lastOfgroup && required) || groupHasError) { return checkValidation(input) }


### PR DESCRIPTION
The error was related to the inline validation on the expiry date,
because there are two inputs within one form group it got confused
and raised an error in the console. it didnt negatively impact the
process but just looks unprofessional.