### PR TITLE
PP-4205 - Construct card authorisation connector URL in frontend

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -104,7 +104,7 @@ module.exports = {
     const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
     const charge = normalise.charge(req.chargeData, req.chargeId)
     const cardModel = Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER])
-    const authUrl = normalise.authUrl(charge)
+    const authUrl = paths.generateRoute('connectorCharge.cardAuth', {chargeId: charge.id})
     const chargeOptions = {email_collection_mode: charge.gatewayAccount.emailCollectionMode}
     const validator = chargeValidator(i18n.__('fieldErrors'), logger, cardModel, chargeOptions)
     let card
@@ -219,7 +219,7 @@ module.exports = {
     const namespace = getNamespace(clsXrayConfig.nameSpaceName)
     const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
     const charge = normalise.charge(req.chargeData, req.chargeId)
-    const authUrl = normalise.authUrl(charge)
+    const authUrl = paths.generateRoute('connectorCharge.cardAuth', {chargeId: charge.id})
 
     const convertedPayload = {
       body: {

--- a/app/paths.js
+++ b/app/paths.js
@@ -134,6 +134,10 @@ const paths = {
     threeDs: {
       path: process.env.CONNECTOR_HOST + '/v1/frontend/charges/:chargeId/3ds',
       action: 'post'
+    },
+    cardAuth: {
+      path: process.env.CONNECTOR_HOST + '/v1/frontend/charges/:chargeId/cards',
+      action: 'post'
     }
   }
 }

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -138,16 +138,6 @@ module.exports = (function () {
     }
   }
 
-  const authUrl = function (charge) {
-    const authLink = charge.links.find((link) => { return link.rel === 'cardAuth' })
-    return authLink.href
-  }
-
-  const chargeUrl = function (charge) {
-    const selfLink = charge.links.find((link) => { return link.rel === 'self' })
-    return selfLink.href
-  }
-
   return {
     charge: _charge,
     addressForApi: addressForApi,
@@ -156,8 +146,6 @@ module.exports = (function () {
     addressForView: addressForView,
     creditCard: creditCard,
     expiryDate: expiryDate,
-    apiPayload: apiPayload,
-    authUrl: authUrl,
-    chargeUrl: chargeUrl
+    apiPayload: apiPayload
   }
 }())


### PR DESCRIPTION
## WHAT
- Clicking continue on the payment screen would fail when testing locally as we were trying to POST to the connector card auth URL '/v1/frontend/charges/{chargeId}/cards' using https, which frontend running locally does not allow.

## HOW 
- Construct URL in frontend rather than using URL in links of charge object retrieved from connector


