### PR TITLE
PP-4205 Use direct redirect property

### DIFF
--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -30,7 +30,8 @@ class Service {
       addressLine2: serviceData.merchant_details.address_line2,
       city: serviceData.merchant_details.address_city,
       postcode: serviceData.merchant_details.address_postcode,
-      countryName: countries.translateCountryISOtoName(serviceData.merchant_details.address_country)
+      countryName: countries.translateCountryISOtoName(serviceData.merchant_details.address_country),
+      redirectToServiceImmediatelyOnTerminalState: serviceData.redirect_to_service_immediately_on_terminal_state
     } : undefined
   }
 

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -1,5 +1,9 @@
 'use strict'
+
+// NPM dependencies
 const _ = require('lodash')
+
+// Local dependencies
 const countries = require('../services/countries')
 
 /**

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -1,17 +1,16 @@
 'use strict'
 
-// Custom dependencies
+// Local dependencies
 const pactBase = require('./pact_base')
+const random = require('../../app/utils/random')
 
 // Global setup
 const pactServices = pactBase({array: ['service_ids']})
 
-let random = require('../../app/utils/random')
-
 module.exports = {
   validServiceResponse: (serviceData = {}) => {
-    let defaultCustomBranding = {css_url: 'css url', image_url: 'image url'}
-    let defaultMerchantDetails = {
+    const defaultCustomBranding = {css_url: 'css url', image_url: 'image url'}
+    const defaultMerchantDetails = {
       name: 'Give Me Your Money',
       address_line1: 'Clive House',
       address_line2: '10 Downing Street',
@@ -19,7 +18,7 @@ module.exports = {
       address_postcode: 'AW1H 9UX',
       address_country: 'GB'
     }
-    let data = {
+    const data = {
       external_id: serviceData.external_id || random.randomUuid(),
       name: serviceData.name || 'service name',
       gateway_account_ids: serviceData.gateway_account_ids || [random.randomInt()],

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -11,7 +11,7 @@ let random = require('../../app/utils/random')
 module.exports = {
   validServiceResponse: (serviceData = {}) => {
     let defaultCustomBranding = {css_url: 'css url', image_url: 'image url'}
-    let defaultMerchantDetais = {
+    let defaultMerchantDetails = {
       name: 'Give Me Your Money',
       address_line1: 'Clive House',
       address_line2: '10 Downing Street',
@@ -24,7 +24,8 @@ module.exports = {
       name: serviceData.name || 'service name',
       gateway_account_ids: serviceData.gateway_account_ids || [random.randomInt()],
       custom_branding: serviceData.custom_branding || defaultCustomBranding,
-      merchant_details: serviceData.merchant_details || defaultMerchantDetais
+      merchant_details: serviceData.merchant_details || defaultMerchantDetails,
+      redirect_to_service_immediately_on_terminal_state: serviceData.redirect_to_service_immediately_on_terminal_state === true
     }
 
     return {

--- a/test/middleware/resolve_service_test.js
+++ b/test/middleware/resolve_service_test.js
@@ -44,14 +44,14 @@ describe('resolve service middleware', function () {
     const gatewayAccountId = '1'
     const service = new Service(serviceFixtures.validServiceResponse({gateway_account_ids: [gatewayAccountId]}).getPlain())
     const resolveService = resolveServiceMiddleware(Promise.resolve(service))
-    let chargeData = {}
-    let req = {
+    const chargeData = {}
+    const req = {
       headers: [],
       chargeId: '111',
       chargeData: _.set(chargeData, 'gateway_account.gateway_account_id', gatewayAccountId)
     }
-    let res = {locals: {}}
-    let nextSpy = sinon.spy()
+    const res = {locals: {}}
+    const nextSpy = sinon.spy()
 
     resolveService(req, res, nextSpy).should.be.fulfilled.then(() => {
       expect(res.locals.service).to.not.be.undefined // eslint-disable-line
@@ -61,17 +61,17 @@ describe('resolve service middleware', function () {
 
   it('should display UNAUTHORISED if charge id is missing', function () {
     const resolveService = resolveServiceMiddleware()
-    let expectedRenderData = {'analytics': analyticsDataForErrors, 'viewName': 'UNAUTHORISED'}
-    let req = {
+    const expectedRenderData = {'analytics': analyticsDataForErrors, 'viewName': 'UNAUTHORISED'}
+    const req = {
       headers: []
     }
-    let res = {
+    const res = {
       status: sinon.spy(),
       render: sinon.spy(),
       locals: {}
     }
 
-    let nextSpy = sinon.spy()
+    const nextSpy = sinon.spy()
     resolveService(req, res, nextSpy)
     expect(res.status.calledWith(403)).to.be.equal(true)
     expect(res.render.calledWith('errors/incorrect_state/session_expired', expectedRenderData)).to.be.equal(true) // eslint-disable-line
@@ -80,21 +80,21 @@ describe('resolve service middleware', function () {
   it('should log an error if it fails to retrieving service data', function (done) {
     const gatewayAccountId = Math.random()
     const resolveService = resolveServiceMiddleware(Promise.reject(new Error('err')))
-    let chargeData = {}
+    const chargeData = {}
     _.set(chargeData, 'gateway_account.gateway_account_id', gatewayAccountId)
     _.set(chargeData, 'gateway_account.serviceName', 'Example Service Name')
-    let req = {
+    const req = {
       headers: [],
       chargeId: '111',
       chargeData: chargeData
     }
-    let res = {
+    const res = {
       status: sinon.spy(),
       render: sinon.spy(),
       locals: {}
     }
 
-    let nextSpy = sinon.spy()
+    const nextSpy = sinon.spy()
     resolveService(req, res, nextSpy).should.be.fulfilled.then(() => {
       expect(errorLogger.called).to.equal(true)
       expect(errorLogger.lastCall.args[0]).to.equal(`Failed to retrieve service information for service: ${chargeData.gateway_account.serviceName}`)

--- a/test/middleware/resolve_service_test.js
+++ b/test/middleware/resolve_service_test.js
@@ -54,6 +54,7 @@ describe('resolve service middleware', function () {
     let nextSpy = sinon.spy()
 
     resolveService(req, res, nextSpy).should.be.fulfilled.then(() => {
+      expect(res.locals.service).to.not.be.undefined // eslint-disable-line
       expect(nextSpy.called).to.be.equal(true)
     }).should.notify(done)
   })
@@ -97,6 +98,8 @@ describe('resolve service middleware', function () {
     resolveService(req, res, nextSpy).should.be.fulfilled.then(() => {
       expect(errorLogger.called).to.equal(true)
       expect(errorLogger.lastCall.args[0]).to.equal(`Failed to retrieve service information for service: ${chargeData.gateway_account.serviceName}`)
+      expect(res.locals.service).to.be.undefined // eslint-disable-line
+      expect(nextSpy.called).to.be.equal(true)
     }).should.notify(done)
   })
 })

--- a/test/models/service_test.js
+++ b/test/models/service_test.js
@@ -10,7 +10,7 @@ const serviceFixtures = require('../fixtures/service_fixtures')
 
 describe('Service model from service raw data', function () {
   it('should contain expected merchant details country name', function () {
-    let serviceModel = new Service(serviceFixtures.validServiceResponse({
+    const serviceModel = new Service(serviceFixtures.validServiceResponse({
       merchant_details: {
         name: 'Give Me Your Money',
         address_line1: 'Clive House',
@@ -25,14 +25,14 @@ describe('Service model from service raw data', function () {
   })
 
   it('should return merchant details as undefined when not in raw data', function () {
-    let data = {
+    const data = {
       external_id: '1234',
       name: 'service name',
       gateway_account_ids: [1],
       custom_branding: {css_url: 'css url', image_url: 'image url'}
     }
 
-    let serviceModel = new Service(data)
+    const serviceModel = new Service(data)
 
     expect(serviceModel.merchantDetails).to.equal(undefined)
   })

--- a/test/models/service_test.js
+++ b/test/models/service_test.js
@@ -1,14 +1,16 @@
+'use strict'
+
+// NPM dependencies
 const path = require('path')
 const expect = require('chai').expect
+
+// Local dependencies
 const Service = require(path.join(__dirname, '/../../app/models/Service.class'))
+const serviceFixtures = require('../fixtures/service_fixtures')
 
 describe('Service model from service raw data', function () {
   it('should contain expected merchant details country name', function () {
-    let data = {
-      external_id: '1234',
-      name: 'service name',
-      gateway_account_ids: [1],
-      custom_branding: {css_url: 'css url', image_url: 'image url'},
+    let serviceModel = new Service(serviceFixtures.validServiceResponse({
       merchant_details: {
         name: 'Give Me Your Money',
         address_line1: 'Clive House',
@@ -17,9 +19,7 @@ describe('Service model from service raw data', function () {
         address_postcode: 'AW1H 9UX',
         address_country: 'GB'
       }
-    }
-
-    let serviceModel = new Service(data)
+    }).getPlain())
 
     expect(serviceModel.merchantDetails.countryName).to.equal('United Kingdom')
   })


### PR DESCRIPTION
## WHAT
- Use new 'redirect_to_service_immediately_on_terminal_state' property returned by adminusers GET service call when resolving the service in middleware.
- Modified service test fixture to expect new property.
- Made some minor alterations to some tests:
  - The happy path test in resolve_service_test now asserts on something that will prove the resolve was successful.
  - Use the service fixture to construct the input JSON in service_test.

with @DanailMinchev




