### PR TITLE
PP-4205 Implement redirect to service

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -93,10 +93,10 @@ module.exports = {
     const charge = normalise.charge(req.chargeData, req.chargeId)
     appendChargeForNewView(charge, req, charge.id)
     charge.countries = countries
-    if (charge.status === State.ENTERING_CARD_DETAILS) return views.display(res, CHARGE_VIEW, withAnalytics(charge, charge))
+    if (charge.status === State.ENTERING_CARD_DETAILS) return views.display(req, res, CHARGE_VIEW, withAnalytics(charge, charge))
     Charge(req.headers[CORRELATION_HEADER]).updateToEnterDetails(charge.id).then(
-      () => views.display(res, CHARGE_VIEW, withAnalytics(charge, charge)),
-      () => views.display(res, 'NOT_FOUND', withAnalyticsError()))
+      () => views.display(req, res, CHARGE_VIEW, withAnalytics(charge, charge)),
+      () => views.display(req, res, 'NOT_FOUND', withAnalyticsError()))
   },
   create: (req, res) => {
     const namespace = getNamespace(clsXrayConfig.nameSpaceName)
@@ -158,7 +158,7 @@ module.exports = {
             charge.countries = countries
             appendChargeForNewView(charge, req, charge.id)
             _.merge(data.validation, withAnalytics(charge, charge), _.pick(req.body, preserveProperties))
-            return views.display(res, CHARGE_VIEW, data.validation)
+            return views.display(req, res, CHARGE_VIEW, data.validation)
           }
           AWSXRay.captureAsyncFunc('Charge_email_patch', function (subSegment) {
             emailPatch
@@ -193,7 +193,7 @@ module.exports = {
               .catch(err => {
                 subSegment.close(err.message)
                 logging.failedChargePatch(err.message)
-                views.display(res, 'ERROR', withAnalyticsError())
+                views.display(req, res, 'ERROR', withAnalyticsError())
               })
           }, clsSegment)
         })
@@ -299,7 +299,7 @@ module.exports = {
     switch (charge.status) {
       case (State.AUTH_READY):
       case (State.AUTH_3DS_READY):
-        views.display(res, AUTH_WAITING_VIEW, withAnalytics(charge))
+        views.display(req, res, AUTH_WAITING_VIEW, withAnalytics(charge))
         break
       case (State.AUTH_3DS_REQUIRED):
         redirect(res).toAuth3dsRequired(req.chargeId)
@@ -324,19 +324,19 @@ module.exports = {
             redirect(res).toAuthWaiting(charge.id)
             break
           case 500:
-            views.display(res, 'SYSTEM_ERROR', withAnalytics(charge))
+            views.display(req, res, 'SYSTEM_ERROR', withAnalytics(charge))
             break
           default:
-            views.display(res, 'ERROR', withAnalytics(charge))
+            views.display(req, res, 'ERROR', withAnalytics(charge))
         }
       })
       .catch(() => {
-        views.display(res, 'ERROR', withAnalytics(charge))
+        views.display(req, res, 'ERROR', withAnalytics(charge))
       })
   },
   auth3dsRequired: (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)
-    views.display(res, AUTH_3DS_REQUIRED_VIEW, withAnalytics(charge))
+    views.display(req, res, AUTH_3DS_REQUIRED_VIEW, withAnalytics(charge))
   },
   auth3dsRequiredOut: (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)
@@ -354,18 +354,18 @@ module.exports = {
       if (md) {
         data.md = md
       }
-      views.display(res, AUTH_3DS_REQUIRED_OUT_VIEW, data)
+      views.display(req, res, AUTH_3DS_REQUIRED_OUT_VIEW, data)
     } else if (htmlOut) {
-      views.display(res, AUTH_3DS_REQUIRED_HTML_OUT_VIEW, {
+      views.display(req, res, AUTH_3DS_REQUIRED_HTML_OUT_VIEW, {
         htmlOut: Buffer.from(htmlOut, 'base64').toString('utf8')
       })
     } else {
-      views.display(res, 'ERROR', withAnalytics(charge))
+      views.display(req, res, 'ERROR', withAnalytics(charge))
     }
   },
   auth3dsRequiredIn: (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)
-    views.display(res, AUTH_3DS_REQUIRED_IN_VIEW, {
+    views.display(req, res, AUTH_3DS_REQUIRED_IN_VIEW, {
       threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
       paResponse: _.get(req, 'body.PaRes'),
       md: _.get(req, 'body.MD')
@@ -373,7 +373,7 @@ module.exports = {
   },
   auth3dsRequiredInEpdq: (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)
-    views.display(res, AUTH_3DS_REQUIRED_IN_VIEW, {
+    views.display(req, res, AUTH_3DS_REQUIRED_IN_VIEW, {
       threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
       providerStatus: _.get(req, 'query.status', 'success')
     })
@@ -381,7 +381,7 @@ module.exports = {
   confirm: (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)
     const confirmPath = routeFor('confirm', charge.id)
-    views.display(res, CONFIRM_VIEW, withAnalytics(charge, {
+    views.display(req, res, CONFIRM_VIEW, withAnalytics(charge, {
       hitPage: routeFor('new', charge.id) + '/success',
       charge: charge,
       confirmPath: confirmPath,
@@ -395,8 +395,8 @@ module.exports = {
       .then(
         () => redirect(res).toReturn(req.chargeId),
         err => {
-          if (err.message === 'CAPTURE_FAILED') return views.display(res, 'CAPTURE_FAILURE', withAnalytics(charge))
-          views.display(res, 'SYSTEM_ERROR', withAnalytics(
+          if (err.message === 'CAPTURE_FAILED') return views.display(req, res, 'CAPTURE_FAILURE', withAnalytics(charge))
+          views.display(req, res, 'SYSTEM_ERROR', withAnalytics(
             charge,
             {returnUrl: routeFor('return', charge.id)}
           ))
@@ -406,9 +406,9 @@ module.exports = {
   captureWaiting: (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)
     if (charge.status === State.CAPTURE_READY) {
-      views.display(res, CAPTURE_WAITING_VIEW, withAnalytics(charge))
+      views.display(req, res, CAPTURE_WAITING_VIEW, withAnalytics(charge))
     } else {
-      views.display(res, 'CAPTURE_SUBMITTED', withAnalytics(charge, {returnUrl: routeFor('return', charge.id)}))
+      views.display(req, res, 'CAPTURE_SUBMITTED', withAnalytics(charge, {returnUrl: routeFor('return', charge.id)}))
     }
   },
   cancel: (req, res) => {
@@ -416,8 +416,8 @@ module.exports = {
     Charge(req.headers[CORRELATION_HEADER])
       .cancel(req.chargeId)
       .then(
-        () => views.display(res, 'USER_CANCELLED', withAnalytics(charge, {returnUrl: routeFor('return', charge.id)})),
-        () => views.display(res, 'SYSTEM_ERROR', withAnalytics(charge, {returnUrl: routeFor('return', charge.id)}))
+        () => views.display(req, res, 'USER_CANCELLED', withAnalytics(charge, {returnUrl: routeFor('return', charge.id)})),
+        () => views.display(req, res, 'SYSTEM_ERROR', withAnalytics(charge, {returnUrl: routeFor('return', charge.id)}))
       )
   }
 }

--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -5,7 +5,7 @@ const logger = require('winston')
 
 // local dependencies
 const Charge = require('../models/charge')
-const views = require('../utils/views')
+const responseRouter = require('../utils/response_router')
 const CORRELATION_HEADER = require('../utils/correlation_header').CORRELATION_HEADER
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 
@@ -18,7 +18,7 @@ exports.return = (req, res) => {
       .then(() => res.redirect(req.chargeData.return_url))
       .catch(() => {
         logger.error('Return controller failed to cancel payment', {'chargeId': req.chargeId})
-        views.display(req, res, 'SYSTEM_ERROR', withAnalyticsError())
+        responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalyticsError())
       })
   } else {
     return res.redirect(req.chargeData.return_url)

--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -4,10 +4,10 @@
 const logger = require('winston')
 
 // local dependencies
-const Charge = require('../models/charge.js')
-const views = require('../utils/views.js')
-const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
-const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
+const Charge = require('../models/charge')
+const views = require('../utils/views')
+const CORRELATION_HEADER = require('../utils/correlation_header').CORRELATION_HEADER
+const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 
 exports.return = (req, res) => {
   const correlationId = req.headers[CORRELATION_HEADER] || ''

--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -5,26 +5,15 @@ const logger = require('winston')
 
 // local dependencies
 const Charge = require('../models/charge.js')
-const StateModel = require('../models/state.js')
 const views = require('../utils/views.js')
 const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
 const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 
-// constants
-const CANCELABLE_STATES = [
-  StateModel.CREATED,
-  StateModel.ENTERING_CARD_DETAILS,
-  StateModel.AUTH_SUCCESS,
-  StateModel.AUTH_READY,
-  StateModel.CAPTURE_READY,
-  StateModel.AUTH_3DS_REQUIRED,
-  StateModel.AUTH_3DS_READY
-]
-
 exports.return = (req, res) => {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
-  if (CANCELABLE_STATES.includes(req.chargeData.status)) {
-    return Charge(correlationId).cancel(req.chargeId)
+  const charge = Charge(correlationId)
+  if (charge.isCancellableCharge(req.chargeData.status)) {
+    return charge.cancel(req.chargeId)
       .then(() => logger.warn('Return controller cancelled payment', {'chargeId': req.chargeId}))
       .then(() => res.redirect(req.chargeData.return_url))
       .catch(() => {

--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -29,7 +29,7 @@ exports.return = (req, res) => {
       .then(() => res.redirect(req.chargeData.return_url))
       .catch(() => {
         logger.error('Return controller failed to cancel payment', {'chargeId': req.chargeId})
-        views.display(res, 'SYSTEM_ERROR', withAnalyticsError())
+        views.display(req, res, 'SYSTEM_ERROR', withAnalyticsError())
       })
   } else {
     return res.redirect(req.chargeData.return_url)

--- a/app/controllers/secure_controller.js
+++ b/app/controllers/secure_controller.js
@@ -7,7 +7,7 @@ const csrf = require('csrf')
 const {generateRoute} = require('../paths')
 const Token = require('../models/token')
 const Charge = require('../models/charge')
-const views = require('../utils/views')
+const responseRouter = require('../utils/response_router')
 const {createChargeIdSessionKey} = require('../utils/session')
 const {setSessionVariable} = require('../utils/cookies')
 const CORRELATION_HEADER = require('../utils/correlation_header').CORRELATION_HEADER
@@ -25,6 +25,6 @@ exports.new = (req, res) => {
       res.redirect(303, generateRoute(resolveActionName(chargeData.status, 'get'), {chargeId}))
     })
     .catch(() => {
-      views.display(req, res, 'SYSTEM_ERROR', withAnalyticsError())
+      responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalyticsError())
     })
 }

--- a/app/controllers/secure_controller.js
+++ b/app/controllers/secure_controller.js
@@ -1,18 +1,18 @@
 'use strict'
 
-// NPM dependencies
+// npm dependencies
 const csrf = require('csrf')
 
 // local dependencies
-const {generateRoute} = require('../paths.js')
-const Token = require('../models/token.js')
-const Charge = require('../models/charge.js')
-const views = require('../utils/views.js')
-const {createChargeIdSessionKey} = require('../utils/session.js')
+const {generateRoute} = require('../paths')
+const Token = require('../models/token')
+const Charge = require('../models/charge')
+const views = require('../utils/views')
+const {createChargeIdSessionKey} = require('../utils/session')
 const {setSessionVariable} = require('../utils/cookies')
-const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
-const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
-const {resolveActionName} = require('../services/state_service.js')
+const CORRELATION_HEADER = require('../utils/correlation_header').CORRELATION_HEADER
+const withAnalyticsError = require('../utils/analytics').withAnalyticsError
+const {resolveActionName} = require('../services/state_service')
 
 exports.new = (req, res) => {
   const chargeTokenId = req.params.chargeTokenId || req.body.chargeTokenId

--- a/app/controllers/secure_controller.js
+++ b/app/controllers/secure_controller.js
@@ -25,6 +25,6 @@ exports.new = (req, res) => {
       res.redirect(303, generateRoute(resolveActionName(chargeData.status, 'get'), {chargeId}))
     })
     .catch(() => {
-      views.display(res, 'SYSTEM_ERROR', withAnalyticsError())
+      views.display(req, res, 'SYSTEM_ERROR', withAnalyticsError())
     })
 }

--- a/app/controllers/static_controller.js
+++ b/app/controllers/static_controller.js
@@ -1,12 +1,14 @@
 'use strict'
+
 // npm dependencies
 const logger = require('winston')
 
 // local dependencies
-const views = require('../utils/views.js')
-const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
+const views = require('../utils/views')
+const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 
 exports.humans = (req, res) => views.display(req, res, 'HUMANS', withAnalyticsError())
+
 exports.naxsi_error = (req, res) => {
   logger.error('NAXSI ERROR:- ' + req.headers['x-naxsi_sig'])
   views.display(req, res, 'NAXSI_SYSTEM_ERROR', withAnalyticsError())

--- a/app/controllers/static_controller.js
+++ b/app/controllers/static_controller.js
@@ -6,8 +6,8 @@ const logger = require('winston')
 const views = require('../utils/views.js')
 const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
 
-exports.humans = (req, res) => views.display(res, 'HUMANS', withAnalyticsError())
+exports.humans = (req, res) => views.display(req, res, 'HUMANS', withAnalyticsError())
 exports.naxsi_error = (req, res) => {
   logger.error('NAXSI ERROR:- ' + req.headers['x-naxsi_sig'])
-  views.display(res, 'NAXSI_SYSTEM_ERROR', withAnalyticsError())
+  views.display(req, res, 'NAXSI_SYSTEM_ERROR', withAnalyticsError())
 }

--- a/app/controllers/static_controller.js
+++ b/app/controllers/static_controller.js
@@ -4,12 +4,12 @@
 const logger = require('winston')
 
 // local dependencies
-const views = require('../utils/views')
+const responseRouter = require('../utils/response_router')
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 
-exports.humans = (req, res) => views.display(req, res, 'HUMANS', withAnalyticsError())
+exports.humans = (req, res) => responseRouter.response(req, res, 'HUMANS', withAnalyticsError())
 
 exports.naxsi_error = (req, res) => {
   logger.error('NAXSI ERROR:- ' + req.headers['x-naxsi_sig'])
-  views.display(req, res, 'NAXSI_SYSTEM_ERROR', withAnalyticsError())
+  responseRouter.response(req, res, 'NAXSI_SYSTEM_ERROR', withAnalyticsError())
 }

--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -1,10 +1,14 @@
 'use strict'
 
+// npm dependencies
 const csrf = require('csrf')
-const session = require('../utils/session.js')
-const views = require('../utils/views.js')
-const chargeParam = require('../services/charge_param_retriever.js')
 const logger = require('winston')
+
+// local dependencies
+const session = require('../utils/session')
+const views = require('../utils/views')
+const chargeParam = require('../services/charge_param_retriever')
+
 exports.csrfTokenGeneration = (req, res, next) => {
   const chargeId = chargeParam.retrieve(req)
   const chargeSession = session.retrieve(req, chargeId)

--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -19,10 +19,10 @@ exports.csrfCheck = (req, res, next) => {
   chargeSession.csrfTokens = chargeSession.csrfTokens || []
 
   if (!chargeSession.csrfSecret) {
-    views.display(res, 'UNAUTHORISED')
+    views.display(req, res, 'UNAUTHORISED')
     logger.error('CSRF secret is not defined')
   } else if (!csrfValid(csrfToken, chargeSession, req)) {
-    views.display(res, 'SYSTEM_ERROR')
+    views.display(req, res, 'SYSTEM_ERROR')
     logger.error('CSRF is invalid')
   } else {
     chargeSession.csrfTokens.push(csrfToken)

--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -6,7 +6,7 @@ const logger = require('winston')
 
 // local dependencies
 const session = require('../utils/session')
-const views = require('../utils/views')
+const responseRouter = require('../utils/response_router')
 const chargeParam = require('../services/charge_param_retriever')
 
 exports.csrfTokenGeneration = (req, res, next) => {
@@ -23,10 +23,10 @@ exports.csrfCheck = (req, res, next) => {
   chargeSession.csrfTokens = chargeSession.csrfTokens || []
 
   if (!chargeSession.csrfSecret) {
-    views.display(req, res, 'UNAUTHORISED')
+    responseRouter.response(req, res, 'UNAUTHORISED')
     logger.error('CSRF secret is not defined')
   } else if (!csrfValid(csrfToken, chargeSession, req)) {
-    views.display(req, res, 'SYSTEM_ERROR')
+    responseRouter.response(req, res, 'SYSTEM_ERROR')
     logger.error('CSRF is invalid')
   } else {
     chargeSession.csrfTokens.push(csrfToken)

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -6,9 +6,9 @@ const {Cache} = require('memory-cache')
 const lodash = require('lodash')
 
 // local dependencies
-const views = require('../utils/views.js')
-const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
-const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
+const views = require('../utils/views')
+const CORRELATION_HEADER = require('../utils/correlation_header').CORRELATION_HEADER
+const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 const getAdminUsersClient = require('../services/clients/adminusers_client')
 
 // constants

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -17,7 +17,7 @@ const serviceCache = new Cache()
 
 module.exports = (req, res, next) => {
   const gatewayAccountId = lodash.get(req, 'chargeData.gateway_account.gateway_account_id')
-  if (!req.chargeId && !req.chargeData) return views.display(res, 'UNAUTHORISED', withAnalyticsError())
+  if (!req.chargeId && !req.chargeData) return views.display(req, res, 'UNAUTHORISED', withAnalyticsError())
   const cachedService = serviceCache.get(gatewayAccountId)
   if (cachedService) {
     res.locals.service = cachedService

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -6,7 +6,7 @@ const {Cache} = require('memory-cache')
 const lodash = require('lodash')
 
 // local dependencies
-const views = require('../utils/views')
+const responseRouter = require('../utils/response_router')
 const CORRELATION_HEADER = require('../utils/correlation_header').CORRELATION_HEADER
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 const getAdminUsersClient = require('../services/clients/adminusers_client')
@@ -17,7 +17,7 @@ const serviceCache = new Cache()
 
 module.exports = (req, res, next) => {
   const gatewayAccountId = lodash.get(req, 'chargeData.gateway_account.gateway_account_id')
-  if (!req.chargeId && !req.chargeData) return views.display(req, res, 'UNAUTHORISED', withAnalyticsError())
+  if (!req.chargeId && !req.chargeData) return responseRouter.response(req, res, 'UNAUTHORISED', withAnalyticsError())
   const cachedService = serviceCache.get(gatewayAccountId)
   if (cachedService) {
     res.locals.service = cachedService

--- a/app/middleware/retrieve_charge.js
+++ b/app/middleware/retrieve_charge.js
@@ -1,15 +1,15 @@
 'use strict'
 
-// NPM dependencies
+// npm dependencies
 const AWSXRay = require('aws-xray-sdk')
 const {getNamespace} = require('continuation-local-storage')
 
 // local dependencies
-const views = require('../utils/views.js')
-const Charge = require('../models/charge.js')
-const chargeParam = require('../services/charge_param_retriever.js')
-const CORRELATION_HEADER = require('../utils/correlation_header.js').CORRELATION_HEADER
-const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
+const views = require('../utils/views')
+const Charge = require('../models/charge')
+const chargeParam = require('../services/charge_param_retriever')
+const CORRELATION_HEADER = require('../utils/correlation_header').CORRELATION_HEADER
+const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 
 // constants
 const clsXrayConfig = require('../../config/xray-cls')
@@ -22,7 +22,7 @@ module.exports = (req, res, next) => {
     views.display(req, res, 'UNAUTHORISED', withAnalyticsError())
   } else {
     req.chargeId = chargeId
-    AWSXRay.captureAsyncFunc('Charge_find', function (subsegment) {
+    AWSXRay.captureAsyncFunc('Charge_find', (subsegment) => {
       Charge(req.headers[CORRELATION_HEADER]).find(chargeId)
         .then(data => {
           subsegment.close()

--- a/app/middleware/retrieve_charge.js
+++ b/app/middleware/retrieve_charge.js
@@ -5,7 +5,7 @@ const AWSXRay = require('aws-xray-sdk')
 const {getNamespace} = require('continuation-local-storage')
 
 // local dependencies
-const views = require('../utils/views')
+const responseRouter = require('../utils/response_router')
 const Charge = require('../models/charge')
 const chargeParam = require('../services/charge_param_retriever')
 const CORRELATION_HEADER = require('../utils/correlation_header').CORRELATION_HEADER
@@ -19,7 +19,7 @@ module.exports = (req, res, next) => {
   const namespace = getNamespace(clsXrayConfig.nameSpaceName)
   const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
   if (!chargeId) {
-    views.display(req, res, 'UNAUTHORISED', withAnalyticsError())
+    responseRouter.response(req, res, 'UNAUTHORISED', withAnalyticsError())
   } else {
     req.chargeId = chargeId
     AWSXRay.captureAsyncFunc('Charge_find', (subsegment) => {
@@ -31,7 +31,7 @@ module.exports = (req, res, next) => {
         })
         .catch(() => {
           subsegment.close('error')
-          views.display(req, res, 'SYSTEM_ERROR', withAnalyticsError())
+          responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalyticsError())
         })
     }, clsSegment)
   }

--- a/app/middleware/retrieve_charge.js
+++ b/app/middleware/retrieve_charge.js
@@ -19,7 +19,7 @@ module.exports = (req, res, next) => {
   const namespace = getNamespace(clsXrayConfig.nameSpaceName)
   const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
   if (!chargeId) {
-    views.display(res, 'UNAUTHORISED', withAnalyticsError())
+    views.display(req, res, 'UNAUTHORISED', withAnalyticsError())
   } else {
     req.chargeId = chargeId
     AWSXRay.captureAsyncFunc('Charge_find', function (subsegment) {
@@ -31,7 +31,7 @@ module.exports = (req, res, next) => {
         })
         .catch(() => {
           subsegment.close('error')
-          views.display(res, 'SYSTEM_ERROR', withAnalyticsError())
+          views.display(req, res, 'SYSTEM_ERROR', withAnalyticsError())
         })
     }, clsSegment)
   }

--- a/app/middleware/state_enforcer.js
+++ b/app/middleware/state_enforcer.js
@@ -4,10 +4,10 @@
 const lodash = require('lodash')
 
 // local dependencies
-const views = require('../utils/views.js')
-const stateService = require('../services/state_service.js')
-const paths = require('../paths.js')
-const withAnalyticsError = require('../utils/analytics.js').withAnalyticsError
+const views = require('../utils/views')
+const stateService = require('../services/state_service')
+const paths = require('../paths')
+const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 
 module.exports = (req, res, next) => {
   const correctStates = stateService.resolveStates(req.actionName)

--- a/app/middleware/state_enforcer.js
+++ b/app/middleware/state_enforcer.js
@@ -14,7 +14,7 @@ module.exports = (req, res, next) => {
   const currentState = req.chargeData.status
   if (!correctStates.includes(currentState)) {
     const stateName = currentState.toUpperCase().replace(/\s/g, '_')
-    views.display(res, stateName, {
+    views.display(req, res, stateName, {
       chargeId: req.chargeId,
       returnUrl: paths.generateRoute('card.return', {chargeId: req.chargeId}),
       analytics: getGoogleAnalytics(req)

--- a/app/middleware/state_enforcer.js
+++ b/app/middleware/state_enforcer.js
@@ -4,7 +4,7 @@
 const lodash = require('lodash')
 
 // local dependencies
-const views = require('../utils/views')
+const responseRouter = require('../utils/response_router')
 const stateService = require('../services/state_service')
 const paths = require('../paths')
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
@@ -14,7 +14,7 @@ module.exports = (req, res, next) => {
   const currentState = req.chargeData.status
   if (!correctStates.includes(currentState)) {
     const stateName = currentState.toUpperCase().replace(/\s/g, '_')
-    views.display(req, res, stateName, {
+    responseRouter.response(req, res, stateName, {
       chargeId: req.chargeId,
       returnUrl: paths.generateRoute('card.return', {chargeId: req.chargeId}),
       analytics: getGoogleAnalytics(req)

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// NPM dependencies
-const _ = require('lodash')
+// npm dependencies
+const lodash = require('lodash')
 
-// Local dependencies
+// local dependencies
 const countries = require('../services/countries')
 
 /**
@@ -46,7 +46,7 @@ class Service {
    * @returns {boolean} if the service got a non-GOV.UK branding
    */
   hasCustomBranding () {
-    return !_.isEmpty(this.customBranding)
+    return !lodash.isEmpty(this.customBranding)
   }
 
   /**
@@ -59,7 +59,7 @@ class Service {
    * @returns {boolean} if the service got merchant details specified
    */
   hasMerchantDetails () {
-    return !_.isEmpty(this.merchantDetails)
+    return !lodash.isEmpty(this.merchantDetails)
   }
 }
 

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -23,19 +23,21 @@ class Service {
     this.externalId = serviceData.external_id
     this.name = serviceData.service_name
     this.gatewayAccountIds = serviceData.gateway_account_ids
+    this.redirectToServiceImmediatelyOnTerminalState = serviceData.redirect_to_service_immediately_on_terminal_state
+
     this.customBranding =
       serviceData.custom_branding ? {
         cssUrl: serviceData.custom_branding.css_url,
         imageUrl: serviceData.custom_branding.image_url
       } : undefined
+
     this.merchantDetails = serviceData.merchant_details ? {
       name: serviceData.merchant_details.name,
       addressLine1: serviceData.merchant_details.address_line1,
       addressLine2: serviceData.merchant_details.address_line2,
       city: serviceData.merchant_details.address_city,
       postcode: serviceData.merchant_details.address_postcode,
-      countryName: countries.translateCountryISOtoName(serviceData.merchant_details.address_country),
-      redirectToServiceImmediatelyOnTerminalState: serviceData.redirect_to_service_immediately_on_terminal_state
+      countryName: countries.translateCountryISOtoName(serviceData.merchant_details.address_country)
     } : undefined
   }
 

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -5,9 +5,9 @@ const logger = require('winston')
 
 // local dependencies
 const baseClient = require('../utils/base_client')
-const paths = require('../paths.js')
-const State = require('./state.js')
-const StateModel = require('../models/state.js')
+const paths = require('../paths')
+const State = require('./state')
+const StateModel = require('../models/state')
 
 // constants
 const CANCELABLE_STATES = [
@@ -20,19 +20,19 @@ const CANCELABLE_STATES = [
   StateModel.AUTH_3DS_READY
 ]
 
-module.exports = function (correlationId) {
+module.exports = correlationId => {
   correlationId = correlationId || ''
 
-  const connectorurl = function (resource, params) {
+  const connectorurl = (resource, params) => {
     return paths.generateRoute(`connectorCharge.${resource}`, params)
   }
 
-  const updateToEnterDetails = function (chargeId) {
+  const updateToEnterDetails = (chargeId) => {
     return updateStatus(chargeId, State.ENTERING_CARD_DETAILS)
   }
 
-  const updateStatus = function (chargeId, status) {
-    return new Promise(function (resolve, reject) {
+  const updateStatus = (chargeId, status) => {
+    return new Promise((resolve, reject) => {
       const url = connectorurl('updateStatus', {chargeId: chargeId})
       const data = {new_status: status}
 
@@ -47,7 +47,7 @@ module.exports = function (correlationId) {
       const startTime = new Date()
 
       baseClient.put(url, {payload: data, correlationId: correlationId}, null, null)
-        .then((response) => {
+        .then(response => {
           logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PUT', url, new Date() - startTime)
           updateComplete(response, {resolve, reject})
         })
@@ -65,8 +65,8 @@ module.exports = function (correlationId) {
     })
   }
 
-  const find = function (chargeId, subSegment) {
-    return new Promise(function (resolve, reject) {
+  const find = (chargeId, subSegment) => {
+    return new Promise((resolve, reject) => {
       const url = connectorurl('show', {chargeId: chargeId})
 
       logger.debug('[%s] Calling connector to get charge -', correlationId, {
@@ -78,7 +78,7 @@ module.exports = function (correlationId) {
 
       const startTime = new Date()
       baseClient.get(url, {correlationId: correlationId}, null, subSegment)
-        .then((response) => {
+        .then(response => {
           if (response.statusCode !== 200) {
             logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
             logger.warn('[%s] Calling connector to get charge failed -', correlationId, {
@@ -106,8 +106,8 @@ module.exports = function (correlationId) {
     })
   }
 
-  const capture = function (chargeId) {
-    return new Promise(function (resolve, reject) {
+  const capture = chargeId => {
+    return new Promise((resolve, reject) => {
       const url = connectorurl('capture', {chargeId: chargeId})
 
       logger.debug('[%s] Calling connector to do capture -', correlationId, {
@@ -119,7 +119,7 @@ module.exports = function (correlationId) {
 
       const startTime = new Date()
       baseClient.post(url, {correlationId: correlationId}, null, null)
-        .then((response) => {
+        .then(response => {
           logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
           captureComplete(response, {resolve, reject})
         })
@@ -137,8 +137,8 @@ module.exports = function (correlationId) {
     })
   }
 
-  const cancel = function (chargeId) {
-    return new Promise(function (resolve, reject) {
+  const cancel = chargeId => {
+    return new Promise((resolve, reject) => {
       const url = connectorurl('cancel', {chargeId: chargeId})
 
       logger.debug('[%s] Calling connector to cancel a charge -', correlationId, {
@@ -150,7 +150,7 @@ module.exports = function (correlationId) {
 
       const startTime = new Date()
       baseClient.post(url, {correlationId: correlationId}, null, null)
-        .then((response) => {
+        .then(response => {
           logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
           cancelComplete(response, {resolve, reject})
         })
@@ -167,7 +167,7 @@ module.exports = function (correlationId) {
     })
   }
 
-  const cancelComplete = function (response, defer) {
+  const cancelComplete = (response, defer) => {
     const code = response.statusCode
     if (code === 204) return defer.resolve()
     logger.error('[%s] Calling connector cancel a charge failed -', correlationId, {
@@ -179,12 +179,12 @@ module.exports = function (correlationId) {
     return defer.reject(new Error('POST_FAILED'))
   }
 
-  const cancelFail = function (err, defer) {
+  const cancelFail = (err, defer) => {
     clientUnavailable(err, defer)
   }
 
-  const findByToken = function (tokenId) {
-    return new Promise(function (resolve, reject) {
+  const findByToken = tokenId => {
+    return new Promise((resolve, reject) => {
       logger.debug('[%s] Calling connector to find a charge by token -', correlationId, {
         service: 'connector',
         method: 'GET'
@@ -218,18 +218,18 @@ module.exports = function (correlationId) {
     })
   }
 
-  const captureComplete = function (response, defer) {
+  const captureComplete = (response, defer) => {
     const code = response.statusCode
     if (code === 204) return defer.resolve()
     if (code === 400) return defer.reject(new Error('CAPTURE_FAILED'))
     return defer.reject(new Error('POST_FAILED'))
   }
 
-  const captureFail = function (err, defer) {
+  const captureFail = (err, defer) => {
     clientUnavailable(err, defer)
   }
 
-  const updateComplete = function (response, defer) {
+  const updateComplete = (response, defer) => {
     if (response.statusCode !== 204) {
       logger.error('[%s] Calling connector to update charge status failed -', correlationId, {
         chargeId: response.body,
@@ -242,8 +242,8 @@ module.exports = function (correlationId) {
     defer.resolve({success: 'OK'})
   }
 
-  const patch = function (chargeId, op, path, value, subSegment) {
-    return new Promise(function (resolve, reject) {
+  const patch = (chargeId, op, path, value, subSegment) => {
+    return new Promise((resolve, reject) => {
       const startTime = new Date()
       const chargesUrl = process.env.CONNECTOR_HOST + '/v1/frontend/charges/'
 
@@ -262,7 +262,7 @@ module.exports = function (correlationId) {
       }
 
       baseClient.patch(chargesUrl + chargeId, params, null, null)
-        .then((response) => {
+        .then(response => {
           logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', chargesUrl, new Date() - startTime)
           const code = response.statusCode
           if (code === 200) {
@@ -283,22 +283,22 @@ module.exports = function (correlationId) {
     })
   }
 
-  const isCancellableCharge = function (chargeStatus) {
+  const isCancellableCharge = chargeStatus => {
     return CANCELABLE_STATES.includes(chargeStatus)
   }
 
-  const clientUnavailable = function (error, defer) {
+  const clientUnavailable = (error, defer) => {
     defer.reject(new Error('CLIENT_UNAVAILABLE'), error)
   }
 
   return {
-    updateStatus: updateStatus,
-    updateToEnterDetails: updateToEnterDetails,
-    find: find,
-    capture: capture,
-    findByToken: findByToken,
-    cancel: cancel,
-    patch: patch,
-    isCancellableCharge: isCancellableCharge
+    updateStatus,
+    updateToEnterDetails,
+    find,
+    capture,
+    findByToken,
+    cancel,
+    patch,
+    isCancellableCharge
   }
 }

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -7,6 +7,18 @@ const logger = require('winston')
 const baseClient = require('../utils/base_client')
 const paths = require('../paths.js')
 const State = require('./state.js')
+const StateModel = require('../models/state.js')
+
+// constants
+const CANCELABLE_STATES = [
+  StateModel.CREATED,
+  StateModel.ENTERING_CARD_DETAILS,
+  StateModel.AUTH_SUCCESS,
+  StateModel.AUTH_READY,
+  StateModel.CAPTURE_READY,
+  StateModel.AUTH_3DS_REQUIRED,
+  StateModel.AUTH_3DS_READY
+]
 
 module.exports = function (correlationId) {
   correlationId = correlationId || ''
@@ -271,6 +283,10 @@ module.exports = function (correlationId) {
     })
   }
 
+  const isCancellableCharge = function (chargeStatus) {
+    return CANCELABLE_STATES.includes(chargeStatus)
+  }
+
   const clientUnavailable = function (error, defer) {
     defer.reject(new Error('CLIENT_UNAVAILABLE'), error)
   }
@@ -282,6 +298,7 @@ module.exports = function (correlationId) {
     capture: capture,
     findByToken: findByToken,
     cancel: cancel,
-    patch: patch
+    patch: patch,
+    isCancellableCharge: isCancellableCharge
   }
 }

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -21,7 +21,7 @@ module.exports = {
     const data = {
       external_id: serviceData.external_id || random.randomUuid(),
       name: serviceData.name || 'service name',
-      gateway_account_ids: serviceData.gateway_account_ids || [random.randomInt()],
+      gateway_account_ids: serviceData.gateway_account_ids || [random.randomInt(1, 9999999)],
       custom_branding: serviceData.custom_branding || defaultCustomBranding,
       merchant_details: serviceData.merchant_details || defaultMerchantDetails,
       redirect_to_service_immediately_on_terminal_state: serviceData.redirect_to_service_immediately_on_terminal_state === true

--- a/test/middleware/retrieve_charge_test.js
+++ b/test/middleware/retrieve_charge_test.js
@@ -11,14 +11,14 @@ const AWSXRay = require('aws-xray-sdk')
 
 const retrieveCharge = proxyquire(path.join(__dirname, '/../../app/middleware/retrieve_charge.js'), {
   'aws-xray-sdk': {
-    captureAsyncFunc: function (name, callback) {
+    captureAsyncFunc: (name, callback) => {
       callback(new AWSXRay.Segment('stub-subsegment'))
     }
   },
   'continuation-local-storage': {
-    getNamespace: function () {
+    getNamespace: () => {
       return {
-        get: function () {
+        get: () => {
           return new AWSXRay.Segment('stub-segment')
         }
       }
@@ -35,10 +35,10 @@ const ANALYTICS_ERROR = {
   }
 }
 
-describe('retrieve param test', function () {
+describe('retrieve param test', () => {
   const response = {
-    status: function () {},
-    render: function () {},
+    status: () => {},
+    render: () => {},
     locals: {}
   }
   let status
@@ -53,44 +53,50 @@ describe('retrieve param test', function () {
   }
   const chargeId = 'foo'
 
-  beforeEach(function () {
+  beforeEach(() => {
     status = sinon.stub(response, 'status')
     render = sinon.stub(response, 'render')
     next = sinon.spy()
     nock.cleanAll()
   })
 
-  afterEach(function () {
+  afterEach(() => {
     status.restore()
     render.restore()
   })
 
   // We don't need to test all states as they are tested in
   // the charge param retriever tests
-  it('should call not found view if charge param does not return an id', function () {
+  it('should call not found view if charge param does not return an id', () => {
     retrieveCharge({params: {}, body: {}}, response, next)
     assert(status.calledWith(403))
-    assert(render.calledWith('errors/incorrect_state/session_expired', {viewName: 'UNAUTHORISED', analytics: ANALYTICS_ERROR.analytics}))
+    assert(render.calledWith('errors/incorrect_state/session_expired', {
+      viewName: 'UNAUTHORISED',
+      analytics: ANALYTICS_ERROR.analytics
+    }))
     expect(next.notCalled).to.be.true // eslint-disable-line
   })
 
-  it('should call not found view if the connector does not respond', function (done) {
+  it('should call not found view if the connector does not respond', done => {
     retrieveCharge(validRequest, response, next)
     const testPromise = new Promise((resolve, reject) => {
       setTimeout(() => { resolve() }, 700)
     })
 
-    testPromise.then((result) => {
+    testPromise.then(result => {
       try {
         assert(status.calledWith(500))
-        assert(render.calledWith('errors/system_error', {viewName: 'SYSTEM_ERROR', analytics: ANALYTICS_ERROR.analytics}))
+        assert(render.calledWith('errors/system_error', {
+          viewName: 'SYSTEM_ERROR',
+          analytics: ANALYTICS_ERROR.analytics
+        }))
         expect(next.notCalled).to.be.true // eslint-disable-line
         done()
       } catch (err) { done(err) }
     }, done)
   })
 
-  it('should set chargeData chargeID and call next on success', function (done) {
+  it('should set chargeData chargeID and call next on success', done => {
     const chargeData = {foo: 'bar'}
     nock(process.env.CONNECTOR_HOST)
       .get(`/v1/frontend/charges/${chargeId}`)
@@ -101,7 +107,7 @@ describe('retrieve param test', function () {
       setTimeout(() => { resolve() }, 100)
     })
 
-    testPromise.then((result) => {
+    testPromise.then(result => {
       try {
         expect(status.calledWith(200))
         expect(validRequest.chargeId).to.equal(chargeId)

--- a/test/middleware/retrieve_charge_test.js
+++ b/test/middleware/retrieve_charge_test.js
@@ -38,7 +38,8 @@ const ANALYTICS_ERROR = {
 describe('retrieve param test', function () {
   const response = {
     status: function () {},
-    render: function () {}
+    render: function () {},
+    locals: {}
   }
   let status
   let render

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -9,7 +9,6 @@ const nock = require('nock')
 
 // local dependencies
 const serviceFixtures = require('../fixtures/service_fixtures')
-const Service = require('../../app/models/Service.class')
 const frontendCardDetailsPath = '/card_details'
 
 // constants
@@ -271,13 +270,20 @@ module.exports = {
   },
 
   defaultAdminusersResponseForGetService: function (gatewayAccountId) {
-    let service = new Service(serviceFixtures.validServiceResponse({gateway_account_ids: [gatewayAccountId]}).getPlain())
-    adminusersRespondsWith(gatewayAccountId, service)
+    const serviceResponse = serviceFixtures.validServiceResponse({gateway_account_ids: [gatewayAccountId]}).getPlain()
+    adminusersRespondsWith(gatewayAccountId, serviceResponse)
   },
 
-  defaultConnectorResponseForGetCharge: function (chargeId, status, gatewayAccountId, emailSettings) {
+  adminusersResponseForGetServiceWithDirectRedirectEnabled: function (gatewayAccountId) {
+    const serviceResponse = serviceFixtures.validServiceResponse({
+      gateway_account_ids: [gatewayAccountId],
+      redirect_to_service_immediately_on_terminal_state: true
+    }).getPlain()
+    adminusersRespondsWith(gatewayAccountId, serviceResponse)
+  },
+
+  defaultConnectorResponseForGetCharge: function (chargeId, status, gatewayAccountId, returnUrl = 'http://www.example.com/service') {
     initConnectorUrl()
-    const returnUrl = 'http://www.example.com/service'
     const rawResponse = rawSuccessfulGetCharge(status, returnUrl, chargeId, gatewayAccountId)
     connectorRespondsWith(chargeId, rawResponse)
   },

--- a/test/utils/views_test.js
+++ b/test/utils/views_test.js
@@ -2,21 +2,73 @@
 
 // npm dependencies
 const {expect} = require('chai')
+const sinon = require('sinon')
+const lodash = require('lodash')
 
 // local dependencies
 const serviceFixtures = require('../fixtures/service_fixtures')
 const Service = require('../../app/models/Service.class')
 const views = require('../../app/utils/views.js')
-const sinon = require('sinon')
-const _ = require('lodash')
+const testHelpers = require('../test_helpers/test_helpers')
 
-describe('views helper', function () {
+// constants
+const nonTerminalActions = [
+  'auth_3ds_required',
+  'auth_3ds_required_in',
+  'auth_3ds_required_out',
+  'auth_3ds_required_html_out',
+  'auth_waiting',
+  'confirm',
+  'charge',
+  'capture_waiting',
+  'HUMANS',
+  'AUTHORISATION_3DS_REQUIRED',
+  'AUTHORISATION_SUCCESS',
+  'AUTHORISATION_READY',
+  'CAPTURE_READY'
+]
+
+const terminalActions = [
+  'NOT_FOUND',
+  'ERROR',
+  'SESSION_INCORRECT',
+  'SYSTEM_ERROR',
+  'NAXSI_SYSTEM_ERROR',
+  'UNAUTHORISED',
+  'CAPTURE_SUBMITTED',
+  'CREATED',
+  'EXPIRED',
+  'EXPIRE_CANCEL_READY',
+  'EXPIRE_CANCEL_FAILED',
+  'SYSTEM_CANCELLED',
+  'SYSTEM_CANCEL_READY',
+  'SYSTEM_CANCEL_ERROR',
+  'USER_CANCELLED',
+  'USER_CANCEL_READY',
+  'USER_CANCEL_ERROR',
+  'CAPTURED',
+  'CAPTURE_APPROVED',
+  'CAPTURE_APPROVED_RETRY',
+  'CAPTURE_ERROR',
+  'CAPTURE_FAILURE',
+  'AUTHORISATION_REJECTED',
+  'AUTHORISATION_CANCELLED',
+  'AUTHORISATION_ERROR',
+  'ENTERING_CARD_DETAILS',
+  'AWAITING_CAPTURE_REQUEST'
+]
+
+describe('views helper with default behaviour of the views', () => {
   const service = serviceFixtures.validServiceResponse().getPlain()
+
+  const request = {}
 
   const response = {
     status: function () {},
     render: function () {},
-    locals: {service: new Service(service)}
+    locals: {
+      service: new Service(service)
+    }
   }
 
   let status
@@ -33,26 +85,29 @@ describe('views helper', function () {
   })
 
   it('should call a view correctly', () => {
-    views.display(response, 'NOT_FOUND')
+    views.display(request, response, 'NOT_FOUND')
     expect(status.lastCall.args).to.deep.equal([404])
     expect(render.lastCall.args).to.deep.equal(['error', {message: 'Page cannot be found', viewName: 'NOT_FOUND'}])
   })
 
   it('should return a 200 by default', () => {
-    views.display(response, 'CAPTURE_FAILURE')
+    views.display(request, response, 'CAPTURE_FAILURE')
     expect(status.lastCall.args).to.deep.equal([200])
     expect(render.lastCall.args).to.deep.equal(['errors/incorrect_state/capture_failure', {viewName: 'CAPTURE_FAILURE'}])
   })
 
   it('should return locals passed in', () => {
-    views.display(response, 'HUMANS', {custom: 'local'})
+    views.display(request, response, 'HUMANS', {custom: 'local'})
     expect(render.lastCall.args[1]).to.have.property('custom').to.equal('local')
   })
 
-  it('should rendor error view when view not found', function () {
-    views.display(response, 'AINT_NO_VIEW_HERE')
+  it('should render error view when view not found', function () {
+    views.display(request, response, 'AINT_NO_VIEW_HERE')
     expect(status.lastCall.args).to.deep.equal([500])
-    expect(render.lastCall.args).to.deep.equal(['error', {message: 'There is a problem, please try again later', viewName: 'error'}])
+    expect(render.lastCall.args).to.deep.equal(['error', {
+      message: 'There is a problem, please try again later',
+      viewName: 'error'
+    }])
   })
 
   const defaultTemplates = {
@@ -73,12 +128,126 @@ describe('views helper', function () {
     }
   }
 
-  _.forEach(defaultTemplates, (values, name) => {
-    it('should be able to render default ' + name + ' page', () => {
-      views.display(response, name)
-      expect(status.lastCall.args).to.deep.equal([values.code])
-      expect(render.lastCall.args).to.deep.equal([values.template, {message: values.message, viewName: name}])
+  lodash.forEach(defaultTemplates, (objectValue, objectKey) => {
+    it('should be able to render default ' + objectKey + ' page', () => {
+      views.display(request, response, objectKey)
+      expect(status.lastCall.args).to.deep.equal([objectValue.code])
+      expect(render.lastCall.args).to.deep.equal([objectValue.template, {
+        message: objectValue.message,
+        viewName: objectKey
+      }])
     })
+  })
+})
+
+describe('views helper with non-terminal view states', () => {
+  const service = serviceFixtures.validServiceResponse({
+    redirect_to_service_immediately_on_terminal_state: true
+  }).getPlain()
+
+  const request = {}
+
+  const response = {
+    status: function () {},
+    render: function () {},
+    locals: {
+      service: new Service(service)
+    }
   }
-  )
+
+  let status
+  let render
+
+  beforeEach(function () {
+    status = sinon.stub(response, 'status')
+    render = sinon.stub(response, 'render')
+  })
+
+  afterEach(function () {
+    status.restore()
+    render.restore()
+  })
+
+  nonTerminalActions.forEach((action) => {
+    const currentView = views[action]
+    it('should render non-terminal ' + action + ' page when redirectToServiceImmediatelyOnTerminalState is enabled', () => {
+      views.display(request, response, action)
+      expect(status.lastCall.args).to.deep.equal([currentView.code || 200])
+      expect(render.called).to.be.equal(true)
+    })
+  })
+})
+
+describe('test views helper redirects to return URL for terminal states when redirectToServiceImmediatelyOnTerminalState is enabled', () => {
+  const service = serviceFixtures.validServiceResponse({
+    redirect_to_service_immediately_on_terminal_state: true
+  }).getPlain()
+  const returnUrl = 'https://service.example.com/return_url'
+  const chargeData = testHelpers.rawSuccessfulGetCharge('capture error', returnUrl)
+
+  const request = {
+    chargeData: chargeData
+  }
+
+  const response = {
+    redirect: function () {},
+    locals: {
+      service: new Service(service)
+    }
+  }
+
+  let redirect
+
+  beforeEach(function () {
+    redirect = sinon.stub(response, 'redirect')
+  })
+
+  afterEach(function () {
+    redirect.restore()
+  })
+
+  terminalActions.forEach((action) => {
+    it('should redirect to return URL on terminal ' + action + ' page', () => {
+      views.display(request, response, action)
+      expect(redirect.lastCall.args).to.deep.equal([returnUrl])
+    })
+  })
+})
+
+describe('test views helper renders page for terminal states when redirectToServiceImmediatelyOnTerminalState is disabled', () => {
+  const service = serviceFixtures.validServiceResponse({
+    redirect_to_service_immediately_on_terminal_state: false
+  }).getPlain()
+
+  const request = {}
+
+  const response = {
+    status: function () {},
+    render: function () {},
+    locals: {
+      service: new Service(service)
+    }
+  }
+
+  let status
+  let render
+
+  beforeEach(function () {
+    status = sinon.stub(response, 'status')
+    render = sinon.stub(response, 'render')
+  })
+
+  afterEach(function () {
+    status.restore()
+    render.restore()
+  })
+
+  terminalActions.forEach((action) => {
+    const currentView = views[action]
+    it('should render terminal ' + action + ' page', () => {
+      views.display(request, response, action)
+      expect(status.lastCall.args).to.deep.equal([currentView.code || 200])
+      expect(render.called).to.be.equal(true)
+    })
+  })
 })

--- a/test/utils/views_test.js
+++ b/test/utils/views_test.js
@@ -8,7 +8,7 @@ const lodash = require('lodash')
 // local dependencies
 const serviceFixtures = require('../fixtures/service_fixtures')
 const Service = require('../../app/models/Service.class')
-const views = require('../../app/utils/views.js')
+const views = require('../../app/utils/views')
 const testHelpers = require('../test_helpers/test_helpers')
 
 // constants
@@ -64,8 +64,8 @@ describe('views helper with default behaviour of the views', () => {
   const request = {}
 
   const response = {
-    status: function () {},
-    render: function () {},
+    status: () => {},
+    render: () => {},
     locals: {
       service: new Service(service)
     }
@@ -74,12 +74,12 @@ describe('views helper with default behaviour of the views', () => {
   let status
   let render
 
-  beforeEach(function () {
+  beforeEach(() => {
     status = sinon.stub(response, 'status')
     render = sinon.stub(response, 'render')
   })
 
-  afterEach(function () {
+  afterEach(() => {
     status.restore()
     render.restore()
   })
@@ -101,7 +101,7 @@ describe('views helper with default behaviour of the views', () => {
     expect(render.lastCall.args[1]).to.have.property('custom').to.equal('local')
   })
 
-  it('should render error view when view not found', function () {
+  it('should render error view when view not found', () => {
     views.display(request, response, 'AINT_NO_VIEW_HERE')
     expect(status.lastCall.args).to.deep.equal([500])
     expect(render.lastCall.args).to.deep.equal(['error', {
@@ -148,8 +148,8 @@ describe('views helper with non-terminal view states', () => {
   const request = {}
 
   const response = {
-    status: function () {},
-    render: function () {},
+    status: () => {},
+    render: () => {},
     locals: {
       service: new Service(service)
     }
@@ -158,12 +158,12 @@ describe('views helper with non-terminal view states', () => {
   let status
   let render
 
-  beforeEach(function () {
+  beforeEach(() => {
     status = sinon.stub(response, 'status')
     render = sinon.stub(response, 'render')
   })
 
-  afterEach(function () {
+  afterEach(() => {
     status.restore()
     render.restore()
   })
@@ -190,7 +190,7 @@ describe('test views helper redirects to return URL for terminal states when red
   }
 
   const response = {
-    redirect: function () {},
+    redirect: () => {},
     locals: {
       service: new Service(service)
     }
@@ -198,11 +198,11 @@ describe('test views helper redirects to return URL for terminal states when red
 
   let redirect
 
-  beforeEach(function () {
+  beforeEach(() => {
     redirect = sinon.stub(response, 'redirect')
   })
 
-  afterEach(function () {
+  afterEach(() => {
     redirect.restore()
   })
 
@@ -222,8 +222,8 @@ describe('test views helper renders page for terminal states when redirectToServ
   const request = {}
 
   const response = {
-    status: function () {},
-    render: function () {},
+    status: () => {},
+    render: () => {},
     locals: {
       service: new Service(service)
     }
@@ -232,12 +232,12 @@ describe('test views helper renders page for terminal states when redirectToServ
   let status
   let render
 
-  beforeEach(function () {
+  beforeEach(() => {
     status = sinon.stub(response, 'status')
     render = sinon.stub(response, 'render')
   })
 
-  afterEach(function () {
+  afterEach(() => {
     status.restore()
     render.restore()
   })


### PR DESCRIPTION
## WHAT
- Move the `redirectToServiceImmediatelyOnTerminalState` property on the `Service` model to correct place
- Perform a redirect to the return URL when a terminal state in the payment flow is reached, rather than show our pages

## HOW 
- Modified `views.js` to add an additional `terminalView` property on action objects to determine whether a view is a terminal state
- In `views.display`, if the action has the `terminalView` set to `true` and `redirect_to_service_immediately_on_terminal_state` is set to `true` on the `Service`, perform a redirect to the return URL
- Added tests to test the new logic introduced to `views.display`
- Originally we were attempting to cancel the charge before the redirect if an error occurred leaving it in a cancellable state. However after discussion we reverted this change, as it didn't make sense to change the charge status to `USER CANCELLED` in this case. However, we modified some code in `return_controller.js` around cancellation to allow for this, which we left in as we thought our changes were an improvement.

with @DanailMinchev 


