### PR TITLE
PP-4347 Map charge.js calls to Connector client instead of base client

### DIFF
--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -1,12 +1,11 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const logger = require('winston')
 
 // local dependencies
-const baseClient = require('../utils/base_client')
-const paths = require('../paths')
-const State = require('./state')
+const connectorClient = require('../services/clients/connector_client')
+const State = require('./state.js')
 const StateModel = require('../models/state')
 
 // constants
@@ -23,151 +22,99 @@ const CANCELABLE_STATES = [
 module.exports = correlationId => {
   correlationId = correlationId || ''
 
-  const connectorurl = (resource, params) => {
-    return paths.generateRoute(`connectorCharge.${resource}`, params)
-  }
-
-  const updateToEnterDetails = (chargeId) => {
+  const updateToEnterDetails = function (chargeId) {
     return updateStatus(chargeId, State.ENTERING_CARD_DETAILS)
   }
 
-  const updateStatus = (chargeId, status) => {
-    return new Promise((resolve, reject) => {
-      const url = connectorurl('updateStatus', {chargeId: chargeId})
-      const data = {new_status: status}
-
-      logger.debug('[%s] Calling connector to update charge status -', correlationId, {
-        service: 'connector',
-        method: 'PUT',
-        chargeId: chargeId,
-        newStatus: status,
-        url: url
-      })
-
-      const startTime = new Date()
-
-      baseClient.put(url, {payload: data, correlationId: correlationId}, null, null)
+  const updateStatus = function (chargeId, status) {
+    return new Promise(function (resolve, reject) {
+      connectorClient({correlationId}).updateStatus({chargeId, payload: {new_status: status}})
         .then(response => {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PUT', url, new Date() - startTime)
           updateComplete(response, {resolve, reject})
         })
         .catch(err => {
-          logger.info('[] - %s to %s ended - total time %dms', 'PUT', url, new Date() - startTime)
-          logger.error('Calling connector to update charge status threw exception -', {
-            service: 'connector',
-            method: 'PUT',
-            chargeId: chargeId,
-            url: url,
-            error: err
-          })
           clientUnavailable(err, {resolve, reject})
         })
     })
   }
 
-  const find = (chargeId, subSegment) => {
-    return new Promise((resolve, reject) => {
-      const url = connectorurl('show', {chargeId: chargeId})
-
-      logger.debug('[%s] Calling connector to get charge -', correlationId, {
-        service: 'connector',
-        method: 'GET',
-        chargeId: chargeId,
-        url: url
-      })
-
-      const startTime = new Date()
-      baseClient.get(url, {correlationId: correlationId}, null, subSegment)
+  const find = function (chargeId) {
+    return new Promise(function (resolve, reject) {
+      connectorClient({correlationId}).findCharge({chargeId})
         .then(response => {
           if (response.statusCode !== 200) {
-            logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
-            logger.warn('[%s] Calling connector to get charge failed -', correlationId, {
-              service: 'connector',
-              method: 'GET',
-              chargeId: chargeId,
-              url: url,
-              status: response.statusCode
-            })
             return reject(new Error('GET_FAILED'))
           }
           resolve(response.body)
         })
         .catch(err => {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
-          logger.error('[%s] Calling connector to get charge threw exception -', correlationId, {
-            service: 'connector',
-            method: 'GET',
-            chargeId: chargeId,
-            url: url,
-            error: err
-          })
           clientUnavailable(err, {resolve, reject})
         })
     })
   }
 
-  const capture = chargeId => {
-    return new Promise((resolve, reject) => {
-      const url = connectorurl('capture', {chargeId: chargeId})
-
-      logger.debug('[%s] Calling connector to do capture -', correlationId, {
-        service: 'connector',
-        method: 'POST',
-        chargeId: chargeId,
-        url: url
-      })
-
-      const startTime = new Date()
-      baseClient.post(url, {correlationId: correlationId}, null, null)
+  const capture = function (chargeId) {
+    return new Promise(function (resolve, reject) {
+      connectorClient({correlationId}).capture({chargeId})
         .then(response => {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
           captureComplete(response, {resolve, reject})
         })
         .catch(err => {
-          logger.info('[%s] - %s to %s ended - total time %dms', 'POST', correlationId, url, new Date() - startTime)
-          logger.error('[%s] Calling connector to do capture failed -', correlationId, {
-            service: 'connector',
-            method: 'POST',
-            chargeId: chargeId,
-            url: url,
-            error: err
-          })
           captureFail(err, {resolve, reject})
         })
     })
   }
 
-  const cancel = chargeId => {
-    return new Promise((resolve, reject) => {
-      const url = connectorurl('cancel', {chargeId: chargeId})
-
-      logger.debug('[%s] Calling connector to cancel a charge -', correlationId, {
-        service: 'connector',
-        method: 'POST',
-        chargeId: chargeId,
-        url: url
-      })
-
-      const startTime = new Date()
-      baseClient.post(url, {correlationId: correlationId}, null, null)
+  const cancel = function (chargeId) {
+    return new Promise(function (resolve, reject) {
+      connectorClient({correlationId}).cancel({chargeId})
         .then(response => {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
           cancelComplete(response, {resolve, reject})
         })
         .catch(err => {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
-          logger.error('[%s] Calling connector cancel a charge threw exception -', correlationId, {
-            service: 'connector',
-            method: 'POST',
-            url: url,
-            error: err
-          })
           cancelFail(err, {resolve, reject})
         })
     })
   }
 
-  const cancelComplete = (response, defer) => {
+  const findByToken = function (tokenId) {
+    return new Promise(function (resolve, reject) {
+      connectorClient({correlationId}).findByToken({tokenId})
+        .then(response => {
+          if (response.statusCode !== 200) {
+            return reject(new Error('GET_FAILED'))
+          }
+          resolve(response.body)
+        })
+        .catch(err => {
+          clientUnavailable(err, {resolve, reject})
+        })
+    })
+  }
+
+  const patch = function (chargeId, op, path, value, subSegment) {
+    return new Promise(function (resolve, reject) {
+      const payload = {
+        op: op,
+        path: path,
+        value: value
+      }
+      connectorClient({correlationId}).patch({chargeId, payload}, subSegment)
+        .then(response => {
+          const code = response.statusCode
+          if (code === 200) {
+            resolve()
+          } else {
+            reject(new Error('Calling connector to patch a charge returned an unexpected status code'))
+          }
+        })
+        .catch(err => {
+          reject(err)
+        })
+    })
+  }
+
+  const cancelComplete = function (response, defer) {
     const code = response.statusCode
     if (code === 204) return defer.resolve()
     logger.error('[%s] Calling connector cancel a charge failed -', correlationId, {
@@ -179,57 +126,22 @@ module.exports = correlationId => {
     return defer.reject(new Error('POST_FAILED'))
   }
 
-  const cancelFail = (err, defer) => {
+  const cancelFail = function (err, defer) {
     clientUnavailable(err, defer)
   }
 
-  const findByToken = tokenId => {
-    return new Promise((resolve, reject) => {
-      logger.debug('[%s] Calling connector to find a charge by token -', correlationId, {
-        service: 'connector',
-        method: 'GET'
-      })
-
-      const startTime = new Date()
-      const findByUrl = connectorurl('findByToken', {chargeTokenId: tokenId})
-
-      baseClient.get(findByUrl, {correlationId: correlationId}, null, null)
-        .then(response => {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', findByUrl, new Date() - startTime)
-          if (response.statusCode !== 200) {
-            logger.warn('[%s] Calling connector to find a charge by token failed -', correlationId, {
-              service: 'connector',
-              method: 'GET',
-              status: response.statusCode
-            })
-            return reject(new Error('GET_FAILED'))
-          }
-          resolve(response.body)
-        })
-        .catch(err => {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', findByUrl, new Date() - startTime)
-          logger.error('[%s] Calling connector to find a charge by token threw exception -', correlationId, {
-            service: 'connector',
-            method: 'GET',
-            error: err
-          })
-          clientUnavailable(err, {resolve, reject})
-        })
-    })
-  }
-
-  const captureComplete = (response, defer) => {
+  const captureComplete = function (response, defer) {
     const code = response.statusCode
     if (code === 204) return defer.resolve()
     if (code === 400) return defer.reject(new Error('CAPTURE_FAILED'))
     return defer.reject(new Error('POST_FAILED'))
   }
 
-  const captureFail = (err, defer) => {
+  const captureFail = function (err, defer) {
     clientUnavailable(err, defer)
   }
 
-  const updateComplete = (response, defer) => {
+  const updateComplete = function (response, defer) {
     if (response.statusCode !== 204) {
       logger.error('[%s] Calling connector to update charge status failed -', correlationId, {
         chargeId: response.body,
@@ -238,56 +150,14 @@ module.exports = correlationId => {
       defer.reject(new Error('UPDATE_FAILED'))
       return
     }
-
     defer.resolve({success: 'OK'})
-  }
-
-  const patch = (chargeId, op, path, value, subSegment) => {
-    return new Promise((resolve, reject) => {
-      const startTime = new Date()
-      const chargesUrl = process.env.CONNECTOR_HOST + '/v1/frontend/charges/'
-
-      logger.debug('[%s] Calling connector to patch charge -', correlationId, {
-        service: 'connector',
-        method: 'PATCH'
-      })
-
-      const params = {
-        payload: {
-          op: op,
-          path: path,
-          value: value
-        },
-        correlationId: correlationId
-      }
-
-      baseClient.patch(chargesUrl + chargeId, params, null, null)
-        .then(response => {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', chargesUrl, new Date() - startTime)
-          const code = response.statusCode
-          if (code === 200) {
-            resolve()
-          } else {
-            reject(new Error('Calling connector to patch a charge returned an unexpected status code'))
-          }
-        }, subSegment)
-        .catch(err => {
-          logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', chargesUrl, new Date() - startTime)
-          logger.error('[%s] Calling connector to patch a charge threw exception -', correlationId, {
-            service: 'connector',
-            method: 'PATCH',
-            error: err
-          })
-          reject(err)
-        })
-    })
   }
 
   const isCancellableCharge = chargeStatus => {
     return CANCELABLE_STATES.includes(chargeStatus)
   }
 
-  const clientUnavailable = (error, defer) => {
+  const clientUnavailable = function (error, defer) {
     defer.reject(new Error('CLIENT_UNAVAILABLE'), error)
   }
 

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -9,17 +9,73 @@ const requestLogger = require('../../utils/request_logger')
 
 // Constants
 const SERVICE_NAME = 'connector'
+
 const CARD_AUTH_PATH = '/v1/frontend/charges/{chargeId}/cards'
 const CARD_3DS_PATH = '/v1/frontend/charges/{chargeId}/3ds'
+const CARD_STATUS_PATH = '/v1/frontend/charges/{chargeId}/status'
+const CARD_CAPTURE_PATH = '/v1/frontend/charges/{chargeId}/capture'
+const CARD_CANCEL_PATH = '/v1/frontend/charges/{chargeId}/cancel'
+const CARD_FIND_BY_TOKEN_PATH = '/v1/frontend/tokens/{chargeTokenId}/charge'
+const CARD_CHARGE_PATH = '/v1/frontend/charges/{chargeId}'
 
 let baseUrl
 let correlationId
+
+/** @private */
+const _getFindChargeUrlFor = chargeId => baseUrl + CARD_CHARGE_PATH.replace('{chargeId}', chargeId)
 
 /** @private */
 const _getAuthUrlFor = chargeId => baseUrl + CARD_AUTH_PATH.replace('{chargeId}', chargeId)
 
 /** @private */
 const _getThreeDsFor = chargeId => baseUrl + CARD_3DS_PATH.replace('{chargeId}', chargeId)
+
+/** @private */
+const _getUpdateStatusUrlFor = chargeId => baseUrl + CARD_STATUS_PATH.replace('{chargeId}', chargeId)
+
+/** @private */
+const _getCaptureUrlFor = chargeId => baseUrl + CARD_CAPTURE_PATH.replace('{chargeId}', chargeId)
+
+/** @private */
+const _getCancelUrlFor = chargeId => baseUrl + CARD_CANCEL_PATH.replace('{chargeId}', chargeId)
+
+/** @private */
+const _getFindByTokenUrlFor = tokenId => baseUrl + CARD_FIND_BY_TOKEN_PATH.replace('{chargeTokenId}', tokenId)
+
+/** @private */
+const _getPatchUrlFor = chargeId => baseUrl + CARD_CHARGE_PATH.replace('{chargeId}', chargeId)
+
+/** @private */
+const _putConnector = (url, payload, description, subSegment) => {
+  return new Promise(function (resolve, reject) {
+    const startTime = new Date()
+    const context = {
+      url: url,
+      method: 'PUT',
+      description: description,
+      service: SERVICE_NAME
+    }
+    requestLogger.logRequestStart(context)
+    baseClient.put(
+      url,
+      {payload, correlationId},
+      null,
+      subSegment
+    ).then(response => {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PUT', url, new Date() - startTime)
+      resolve(response)
+    }).catch(err => {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PUT', url, new Date() - startTime)
+      logger.error('Calling connector threw exception -', {
+        service: 'connector',
+        method: 'PUT',
+        url: url,
+        error: err
+      })
+      reject(err)
+    })
+  })
+}
 
 /** @private */
 const _postConnector = (url, payload, description) => {
@@ -34,36 +90,151 @@ const _postConnector = (url, payload, description) => {
     requestLogger.logRequestStart(context)
     baseClient.post(
       url,
-      {
-        payload: payload,
-        correlationId: correlationId
-      },
+      {payload, correlationId},
       null,
       null
     ).then(response => {
       logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
       resolve(response)
     }).catch(err => {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
+      logger.error('Calling connector threw exception -', {
+        service: 'connector',
+        method: 'POST',
+        url: url,
+        error: err
+      })
       reject(err)
     })
   })
 }
 
-const threeDs = (chargeOptions) => {
-  const authUrl = _getThreeDsFor(chargeOptions.chargeId)
-  return _postConnector(authUrl, chargeOptions.payload, '3ds')
+/** @private */
+const _patchConnector = (url, payload, description) => {
+  return new Promise(function (resolve, reject) {
+    const startTime = new Date()
+    const context = {
+      url: url,
+      method: 'PATCH',
+      description: description,
+      service: SERVICE_NAME
+    }
+    requestLogger.logRequestStart(context)
+    baseClient.patch(
+      url,
+      {payload, correlationId},
+      null,
+      null
+    ).then(response => {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', url, new Date() - startTime)
+      resolve(response)
+    }).catch(err => {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', url, new Date() - startTime)
+      logger.error('Calling connector threw exception -', {
+        service: 'connector',
+        method: 'PATCH',
+        url: url,
+        error: err
+      })
+      reject(err)
+    })
+  })
 }
 
-const chargeAuth = (chargeOptions) => {
+/** @private */
+const _getConnector = (url, description) => {
+  return new Promise(function (resolve, reject) {
+    const startTime = new Date()
+    const context = {
+      url: url,
+      method: 'GET',
+      description: description,
+      service: SERVICE_NAME
+    }
+    requestLogger.logRequestStart(context)
+    baseClient.get(
+      url,
+      {correlationId},
+      null,
+      null
+    ).then(response => {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
+      if (response.statusCode !== 200) {
+        logger.warn('[%s] Calling connector to GET something returned a non http 200 response', correlationId, {
+          service: 'connector',
+          method: 'GET',
+          status: response.statusCode
+        })
+      }
+      resolve(response)
+    }).catch(err => {
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
+      logger.error('Calling connector threw exception -', {
+        service: 'connector',
+        method: 'GET',
+        url: url,
+        error: err
+      })
+      reject(err)
+    })
+  })
+}
+
+// POST functions
+const threeDs = chargeOptions => {
+  const threeDsUrl = _getThreeDsFor(chargeOptions.chargeId)
+  return _postConnector(threeDsUrl, chargeOptions.payload, '3ds')
+}
+
+const chargeAuth = chargeOptions => {
   const authUrl = _getAuthUrlFor(chargeOptions.chargeId)
   return _postConnector(authUrl, chargeOptions.payload, 'create charge')
+}
+
+const capture = chargeOptions => {
+  const captureUrl = _getCaptureUrlFor(chargeOptions.chargeId)
+  return _postConnector(captureUrl, null, 'do capture')
+}
+
+const cancel = chargeOptions => {
+  const cancelUrl = _getCancelUrlFor(chargeOptions.chargeId)
+  return _postConnector(cancelUrl, null, 'cancel charge')
+}
+
+// PUT functions
+const updateStatus = (chargeOptions, subSegment) => {
+  const updateStatusUrl = _getUpdateStatusUrlFor(chargeOptions.chargeId)
+  return _putConnector(updateStatusUrl, chargeOptions.payload, 'update status', subSegment)
+}
+
+// PATCH functions
+const patch = chargeOptions => {
+  const patchUrl = _getPatchUrlFor(chargeOptions.chargeId)
+  return _patchConnector(patchUrl, chargeOptions.payload, 'patch')
+}
+
+// GET functions
+const findCharge = chargeOptions => {
+  const findChargeUrl = _getFindChargeUrlFor(chargeOptions.chargeId)
+  return _getConnector(findChargeUrl, 'find charge')
+}
+
+const findByToken = chargeOptions => {
+  const findByTokenUrl = _getFindByTokenUrlFor(chargeOptions.tokenId)
+  return _getConnector(findByTokenUrl, 'find by token')
 }
 
 module.exports = function (clientOptions = {}) {
   baseUrl = clientOptions.baseUrl || process.env.CONNECTOR_HOST
   correlationId = clientOptions.correlationId || ''
   return {
-    chargeAuth: chargeAuth,
-    threeDs: threeDs
+    chargeAuth,
+    threeDs,
+    updateStatus,
+    findCharge,
+    capture,
+    cancel,
+    findByToken,
+    patch
   }
 }


### PR DESCRIPTION
Further migration so any calls to Connector are done via a Connector client, and not using the base client directly. This reduces logging code, facilitates debugging and testing, and generally cleans up things into a direction we want to be going in.