### PR TITLE
PP-4347 token.js now makes connector calls via a Connector client, rather than directly to base_client

### DIFF
--- a/app/models/token.js
+++ b/app/models/token.js
@@ -1,48 +1,19 @@
 'use strict'
 
-// NPM dependencies
-const logger = require('winston')
-
 // Local dependencies
-const paths = require('../paths.js')
-const baseClient = require('../utils/base_client')
-
-const createUrl = function (resource, params) {
-  return paths.generateRoute(`connectorCharge.${resource}`, params)
-}
+const connectorClient = require('../services/clients/connector_client')
 
 const destroy = function (tokenId, correlationId) {
   return new Promise(function (resolve, reject) {
     correlationId = correlationId || ''
-    logger.debug('[%s] Calling connector to delete a token -', correlationId, {
-      service: 'connector',
-      method: 'DELETE',
-      url: createUrl('token', {chargeTokenId: '{tokenId}'})
-    })
-    const startTime = new Date()
-    const deleteUrl = createUrl('token', {chargeTokenId: tokenId})
-    baseClient.delete(deleteUrl, {correlationId: correlationId}, null, null)
+    connectorClient({correlationId}).deleteToken({tokenId})
       .then(response => {
-        logger.info('[%s] - %s to %s ended - total time %dms', 'DELETE',
-          correlationId, deleteUrl, new Date() - startTime)
         if (response.statusCode !== 204) {
-          logger.warn('Calling connector to delete a token failed -', {
-            service: 'connector',
-            method: 'DELETE',
-            url: createUrl('token', {chargeTokenId: '{tokenId}'})
-          })
           return reject(new Error('DELETE_FAILED'))
         }
         resolve(response.body)
       })
       .catch(err => {
-        logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'DELETE', deleteUrl, new Date() - startTime)
-        logger.error('[%s] Calling connector to delete a token threw exception -', correlationId, {
-          service: 'connector',
-          method: 'DELETE',
-          url: createUrl('token', {chargeTokenId: '{tokenId}'}),
-          error: err
-        })
         reject(new Error('CLIENT_UNAVAILABLE'), err)
       })
   })


### PR DESCRIPTION
## WHAT
All token actions exposed by token.js now call a connector base client that abstracts base_client calls to connector, rather than having these handled inside the module.

This reduces repeated code, consolidates logging and cleans things up along the same lines as self-service.


