### PR TITLE
PP-4347 Set NODE_WORKER_COUNT in cypress tests

### DIFF
--- a/test/cypress/test.env
+++ b/test/cypress/test.env
@@ -6,3 +6,4 @@ COOKIE_MAX_AGE=10800000
 SESSION_ENCRYPTION_KEY=naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk
 NODE_TEST_MODE=true
 NODE_ENV=test
+NODE_WORKER_COUNT=1


### PR DESCRIPTION
Otherwise Jenkins gets sad. Frontend tries to use all 36 cores, with hilarious consequences.