### PR TITLE
BAU bump product page version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12858,8 +12858,8 @@
       }
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/2.1.53/pay-product-page-2.1.53.tgz",
-      "integrity": "sha512-MMB0c973EYM9Q/cNZrb2lggv+4x5MCCOaHIL25LALcsGR11FiSv7Ivx0Ss9HkhTST6Odq4xBvi6R8ORpuXwJTQ==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/2.1.54/pay-product-page-2.1.54.tgz",
+      "integrity": "sha512-Y1FZus2Xq6r0iyb+O6UM3XqpuMYoQqhYBJKg2snzDNNEins5ZTxIyjpzqmtYh4fTXISxbUEJehQkrd2xPoXKzQ==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "node-sass": "4.9.x",
     "nyc": "11.7.x",
     "pact": "4.3.2",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.53/pay-product-page-2.1.53.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.54/pay-product-page-2.1.54.tgz",
     "proxyquire": "~2.0.1",
     "sass-lint": "^1.12.1",
     "sinon": "5.0.x",


### PR DESCRIPTION
Bumps the product page version to include updates to the Blue badge
page.

Solo: @ejrowley