### PR TITLE
PP-4161 Do not show billing address

### DIFF
--- a/app/assets/javascripts/modules/form-validation.js
+++ b/app/assets/javascripts/modules/form-validation.js
@@ -35,9 +35,11 @@ var formValidation = function () {
         }, false)
       })
     }
-    countrySelect.addEventListener('change', function () {
-      checkValidation(postcodeInput)
-    }, false)
+    if (window.Charge.collect_billing_address === true) {
+      countrySelect.addEventListener('change', function () {
+        checkValidation(postcodeInput)
+      }, false)
+    }
   }
 
   var checkFormSubmission = function (e) {
@@ -48,7 +50,7 @@ var formValidation = function () {
     }
     e.preventDefault()
     var validations = allValidations()
-    if (countryAutocomplete.value === '') {
+    if ((window.Charge.collect_billing_address === true) && (countryAutocomplete.value === '')) {
       countryAutocomplete.value = document.getElementById('address-country-select').value
     }
 

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -1,13 +1,13 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const logger = require('winston')
 const _ = require('lodash')
 const i18n = require('i18n')
 const {getNamespace} = require('continuation-local-storage')
 const AWSXRay = require('aws-xray-sdk')
 
-// local dependencies
+// Local dependencies
 const logging = require('../utils/logging')
 const responseRouter = require('../utils/response_router')
 const normalise = require('../services/normalise_charge')
@@ -21,7 +21,7 @@ const {commonTypos} = require('../utils/email_tools')
 const {withAnalyticsError, withAnalytics} = require('../utils/analytics')
 const connectorClient = require('../services/clients/connector_client')
 
-// constants
+// Constants
 const clsXrayConfig = require('../../config/xray-cls')
 const {views, preserveProperties} = require('../../config/charge_controller')
 const {CORRELATION_HEADER} = require('../../config/correlation_header')

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -127,7 +127,10 @@ module.exports = {
     const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
     const charge = normalise.charge(req.chargeData, req.chargeId)
     const cardModel = Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER])
-    const chargeOptions = {email_collection_mode: charge.gatewayAccount.emailCollectionMode}
+    const chargeOptions = {
+      email_collection_mode: charge.gatewayAccount.emailCollectionMode,
+      collect_billing_address: res.locals.service.collectBillingAddress
+    }
     const validator = chargeValidator(i18n.__('fieldErrors'), logger, cardModel, chargeOptions)
     let card
 
@@ -190,6 +193,9 @@ module.exports = {
                 subSegment.close()
                 const correlationId = req.headers[CORRELATION_HEADER] || ''
                 const payload = normalise.apiPayload(req, card)
+                if (res.locals.service.collectBillingAddress === false) {
+                  delete payload.address
+                }
                 connectorClient({correlationId}).chargeAuth({chargeId: req.chargeId, payload})
                   .then(handleCreateResponse(req, res, charge))
               })

--- a/app/controllers/healthcheck_controller.js
+++ b/app/controllers/healthcheck_controller.js
@@ -1,4 +1,4 @@
-// npm dependencies
+// NPM dependencies
 const _ = require('lodash')
 const logger = require('winston')
 const baseClient = require('../services/clients/base_client/base_client')

--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const logger = require('winston')
 
-// local dependencies
+// Local dependencies
 const Charge = require('../models/charge')
 const responseRouter = require('../utils/response_router')
 const CORRELATION_HEADER = require('../../config/correlation_header').CORRELATION_HEADER

--- a/app/controllers/secure_controller.js
+++ b/app/controllers/secure_controller.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const csrf = require('csrf')
 
-// local dependencies
+// Local dependencies
 const {generateRoute} = require('../paths')
 const Token = require('../models/token')
 const Charge = require('../models/charge')

--- a/app/controllers/static_controller.js
+++ b/app/controllers/static_controller.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const logger = require('winston')
 
-// local dependencies
+// Local dependencies
 const responseRouter = require('../utils/response_router')
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 

--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -1,15 +1,15 @@
 
-// npm dependencies
+// NPM dependencies
 const _ = require('lodash')
 
-// local dependencies
+// Local dependencies
 const responseRouter = require('../utils/response_router')
 const normalise = require('../services/normalise_charge')
 const paths = require('../paths')
 const {withAnalytics} = require('../utils/analytics')
 const connectorClient = require('../services/clients/connector_client')
 
-// constants
+// Constants
 const {views, threeDsEPDQResults} = require('../../config/charge_controller')
 const {CORRELATION_HEADER} = require('../../config/correlation_header')
 

--- a/app/middleware/action_name.js
+++ b/app/middleware/action_name.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// local dependencies
+// Local dependencies
 const paths = require('./../paths.js')
 const flatPaths = require('./../utils/flattened_paths.js')(paths)
 

--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -1,10 +1,10 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const csrf = require('csrf')
 const logger = require('winston')
 
-// local dependencies
+// Local dependencies
 const session = require('../utils/session')
 const responseRouter = require('../utils/response_router')
 const chargeParam = require('../services/charge_param_retriever')

--- a/app/middleware/resolve_language.js
+++ b/app/middleware/resolve_language.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// local dependencies
+// Local dependencies
 const i18n = require('i18n')
 
 module.exports = function (req, res, next) {

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -1,17 +1,17 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const logger = require('winston')
 const {Cache} = require('memory-cache')
 const lodash = require('lodash')
 
-// local dependencies
+// Local dependencies
 const responseRouter = require('../utils/response_router')
 const CORRELATION_HEADER = require('../../config/correlation_header').CORRELATION_HEADER
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 const getAdminUsersClient = require('../services/clients/adminusers_client')
 
-// constants
+// Constants
 const SERVICE_CACHE_MAX_AGE = parseInt(process.env.SERVICE_CACHE_MAX_AGE || 15 * 60 * 1000) // default to 15 mins
 const serviceCache = new Cache()
 

--- a/app/middleware/retrieve_charge.js
+++ b/app/middleware/retrieve_charge.js
@@ -1,17 +1,17 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const AWSXRay = require('aws-xray-sdk')
 const {getNamespace} = require('continuation-local-storage')
 
-// local dependencies
+// Local dependencies
 const responseRouter = require('../utils/response_router')
 const Charge = require('../models/charge')
 const chargeParam = require('../services/charge_param_retriever')
 const CORRELATION_HEADER = require('../../config/correlation_header').CORRELATION_HEADER
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 
-// constants
+// Constants
 const clsXrayConfig = require('../../config/xray-cls')
 
 module.exports = (req, res, next) => {

--- a/app/middleware/state_enforcer.js
+++ b/app/middleware/state_enforcer.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const lodash = require('lodash')
 
-// local dependencies
+// Local dependencies
 const responseRouter = require('../utils/response_router')
 const stateService = require('../services/state_service')
 const paths = require('../paths')

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -24,6 +24,7 @@ class Service {
     this.name = serviceData.service_name
     this.gatewayAccountIds = serviceData.gateway_account_ids
     this.redirectToServiceImmediatelyOnTerminalState = serviceData.redirect_to_service_immediately_on_terminal_state
+    this.collectBillingAddress = serviceData.collect_billing_address
 
     this.customBranding =
       serviceData.custom_branding ? {

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const lodash = require('lodash')
 
-// local dependencies
+// Local dependencies
 const countries = require('../services/countries')
 
 /**

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -3,12 +3,12 @@
 // NPM dependencies
 const logger = require('winston')
 
-// local dependencies
+// Local dependencies
 const connectorClient = require('../services/clients/connector_client')
 const State = require('../../config/state.js')
 const StateModel = require('../../config/state')
 
-// constants
+// Constants
 const CANCELABLE_STATES = [
   StateModel.CREATED,
   StateModel.ENTERING_CARD_DETAILS,

--- a/app/services/clients/cardid_client.js
+++ b/app/services/clients/cardid_client.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// local dependencies
+// Local dependencies
 const baseClient = require('./base_client/base_client')
 
-// constants
+// Constants
 const CARD_URL = process.env.CARDID_HOST + '/v1/api/card'
 
 /**

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -73,7 +73,9 @@ module.exports = (function () {
     cardDetails.cardNumber = '************' + cardDetails.last_digits_card_number
     delete cardDetails.last_digits_card_number
     const normalisedDetails = humps.camelizeKeys(cardDetails)
-    normalisedDetails.billingAddress = _normaliseAddress(cardDetails.billing_address)
+    if (cardDetails.billing_address) {
+      normalisedDetails.billingAddress = _normaliseAddress(cardDetails.billing_address)
+    }
     return normalisedDetails
   }
 

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -1,15 +1,15 @@
 'use strict'
 
-// NPM dependencies
+// npm dependencies
 const humps = require('humps')
-const _ = require('lodash')
+const lodash = require('lodash')
 
-// Local dependencies
+// local dependencies
 const countries = require('../services/countries')
-const normaliseCards = require('../services/normalise_cards.js')
+const normaliseCards = require('../services/normalise_cards')
 
 module.exports = (function () {
-  const _charge = function (charge, chargeId) {
+  const charge = function (charge, chargeId) {
     const chargeObj = {
       id: chargeId,
       amount: penceToPounds(charge.amount),
@@ -62,8 +62,8 @@ module.exports = (function () {
       'chargeId'
     ]
 
-    _.forIn(body, function (value, key) {
-      if (!_.includes(toIgnore, key)) {
+    lodash.forIn(body, function (value, key) {
+      if (!lodash.includes(toIgnore, key)) {
         body[key] = value.trim()
       }
     })
@@ -141,13 +141,13 @@ module.exports = (function () {
   }
 
   return {
-    charge: _charge,
-    addressForApi: addressForApi,
-    addressLines: addressLines,
-    whitespace: whitespace,
-    addressForView: addressForView,
-    creditCard: creditCard,
-    expiryDate: expiryDate,
-    apiPayload: apiPayload
+    charge,
+    addressForApi,
+    addressLines,
+    whitespace,
+    addressForView,
+    creditCard,
+    expiryDate,
+    apiPayload
   }
 }())

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -1,10 +1,10 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const humps = require('humps')
 const lodash = require('lodash')
 
-// local dependencies
+// Local dependencies
 const countries = require('../services/countries')
 const normaliseCards = require('../services/normalise_cards')
 

--- a/app/utils/add_proxy.js
+++ b/app/utils/add_proxy.js
@@ -1,10 +1,10 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const urlParse = require('url').parse
 const _ = require('lodash')
 
-// constants
+// Constants
 const {FORWARD_PROXY_URL} = process.env
 
 module.exports.addProxy = function addProxy (url) {

--- a/app/utils/analytics.js
+++ b/app/utils/analytics.js
@@ -1,12 +1,12 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const lodash = require('lodash')
 
-// local dependencies
+// Local dependencies
 const paths = require('../paths.js')
 
-// constants
+// Constants
 const ANALYTICS_ERROR = {
   analytics: {
     analyticsId: 'Service unavailable',

--- a/app/utils/charge_validation.js
+++ b/app/utils/charge_validation.js
@@ -16,7 +16,7 @@ const CUSTOM_ERRORS = {
   }
 }
 
-module.exports = (translations, logger, Card, chargeOptions = {}) => {
+module.exports = (translations, logger, Card, chargeOptions = {collect_billing_address: true}) => {
   const validations = chargeValidationFields(Card, chargeOptions)
   const fieldValidations = validations.fieldValidations
   return {

--- a/app/utils/charge_validation.js
+++ b/app/utils/charge_validation.js
@@ -1,12 +1,12 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const changeCase = require('change-case')
 
-// local dependencies
+// Local dependencies
 const chargeValidationFields = require('./charge_validation_fields')
 
-// constants
+// Constants
 const CUSTOM_ERRORS = {
   expiryYear: {
     skip: true

--- a/app/utils/charge_validation_backend.js
+++ b/app/utils/charge_validation_backend.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const _ = require('lodash')
 
-// local dependencies
+// Local dependencies
 const chargeValidator = require('./charge_validation.js')
 const normalise = require('../services/normalise_charge.js')
 

--- a/app/utils/charge_validation_fields.js
+++ b/app/utils/charge_validation_fields.js
@@ -14,24 +14,29 @@ const emailTools = require('./email_tools')
 
 // constants
 const EMAIL_MAX_LENGTH = 254
+
 const REQUIRED_FORM_FIELDS = [
   'cardNo',
   'expiryMonth',
   'expiryYear',
   'cardholderName',
   'cvc',
+  'email'
+]
+const REQUIRED_BILLING_ADDRESS_FORM_FIELDS = [
   'addressLine1',
   'addressCity',
   'addressPostcode',
-  'email',
   'addressCountry'
 ]
 
 const OPTIONAL_FORM_FIELDS = [
+]
+const OPTIONAL_BILLING_ADDRESS_FORM_FIELDS = [
   'addressLine2'
 ]
 
-module.exports = (Card) => {
+module.exports = (Card, chargeOptions = {collect_billing_address: true}) => {
   /*
      These are custom validations for each field.
      Functions should be named the same as the input name
@@ -39,10 +44,9 @@ module.exports = (Card) => {
      One is the field, second is allfields in case it is
      needed for validation.
      */
-  return {
+  const chargeValidationFields = {
     creditCardType: creditCardType,
     allowedCards: Card.allowed,
-    requiredFormFields: REQUIRED_FORM_FIELDS,
     fieldValidations: {
       cardNo: cardNo.bind(Card),
       expiryMonth,
@@ -56,8 +60,16 @@ module.exports = (Card) => {
       creditCardType: creditCardType,
       allowedCards: Card.allowed
     },
+    requiredFormFields: REQUIRED_FORM_FIELDS,
     optionalFormFields: OPTIONAL_FORM_FIELDS
   }
+
+  if (chargeOptions.collect_billing_address === true) {
+    chargeValidationFields.requiredFormFields = [...REQUIRED_FORM_FIELDS, ...REQUIRED_BILLING_ADDRESS_FORM_FIELDS]
+    chargeValidationFields.optionalFormFields = [...OPTIONAL_FORM_FIELDS, ...OPTIONAL_BILLING_ADDRESS_FORM_FIELDS]
+  }
+
+  return chargeValidationFields
 }
 
 // Validation Functions

--- a/app/utils/charge_validation_fields.js
+++ b/app/utils/charge_validation_fields.js
@@ -3,16 +3,16 @@
 // Polyfill for ZAP webdriver
 require('polyfill-array-includes')
 
-// npm dependencies
+// NPM dependencies
 const ukPostcode = require('uk-postcode')
 const rfc822Validator = require('rfc822-validate')
 
-// local dependencies
+// Local dependencies
 const luhn = require('./luhn')
 const creditCardType = require('credit-card-type')
 const emailTools = require('./email_tools')
 
-// constants
+// Constants
 const EMAIL_MAX_LENGTH = 254
 
 const REQUIRED_FORM_FIELDS = [

--- a/app/utils/cookies.js
+++ b/app/utils/cookies.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const clientSessions = require('client-sessions')
 
-// constants
+// Constants
 const {COOKIE_MAX_AGE, SESSION_ENCRYPTION_KEY, SESSION_ENCRYPTION_KEY_2, SECURE_COOKIE_OFF} = process.env
 const SESSION_COOKIE_NAME_1 = 'frontend_state'
 const SESSION_COOKIE_NAME_2 = 'frontend_state_2'

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const logger = require('winston')
 
 exports.authChargePost = url => {

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const logger = require('winston')
 
 exports.logRequestStart = context => {

--- a/app/utils/response_converter.js
+++ b/app/utils/response_converter.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// local dependencies
+// Local dependencies
 const requestLogger = require('../utils/request_logger')
 
-// constants
+// Constants
 const SUCCESS_CODES = [200, 201, 202, 204, 206]
 
 exports.createCallbackToPromiseConverter = createCallbackToPromiseConverter

--- a/app/utils/response_router.js
+++ b/app/utils/response_router.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const logger = require('winston')
 const lodash = require('lodash')
 

--- a/app/utils/session.js
+++ b/app/utils/session.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// local dependencies
+// Local dependencies
 const cookie = require('../utils/cookies')
 
 exports.createChargeIdSessionKey = chargeId => 'ch_' + chargeId

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -231,6 +231,7 @@
           </span>
           <img src="/images/amex-security-code.png" class="amex-cvc hidden" alt="{{ __("cardDetails.amexcvcTip") }}"/>
         </div>
+        {% if service.collectBillingAddress %}
         <div class="govuk-form-group govuk-!-width-two-thirds {% if highlightErrorFields.addressCountry %} govuk-form-group--error{% endif %}" data-validation="addressCountry">
           <h2 class="govuk-heading-m govuk-!-margin-bottom-1">{{ __("cardDetails.billingAddress") }}</h2>
           <span class="govuk-hint govuk-!-margin-bottom-2">{{ __("cardDetails.billingAddressHint") }}</span>
@@ -333,6 +334,7 @@
                   value="{{ addressPostcode }}"
                   autocomplete="billing postal-code"/>
         </div>
+        {% endif %}
         {% if (gatewayAccount.emailCollectionMode === 'MANDATORY') or (gatewayAccount.emailCollectionMode === 'OPTIONAL') %}
         <div class="govuk-form-group{% if highlightErrorFields.email %} govuk-form-group--error{% endif %}" data-validation="email">
           <label id="email-lbl" for="email" class="govuk-label govuk-label--s">
@@ -360,7 +362,7 @@
                   data-confirmation="true"
                   data-confirmation-label="{{ __("cardDetails.emailConfirmation") }} "/>
         </div>
-          {% endif %}
+        {% endif %}
         {% if typos %}
           <div class="govuk-form-group form-group-email-typo govuk-form-group--error">
             <legend for="email-typo" id="email-typo-lbl" class="govuk-label govuk-label--s error-label">
@@ -422,6 +424,7 @@
 
 {% block bodyEnd %}
   {% include "includes/scripts.njk" %}
+  {% if service.collectBillingAddress %}
   <script type="text/javascript" src="/public/location-autocomplete.min.js"></script>
   <script type="text/javascript">
     openregisterLocationPicker({
@@ -431,4 +434,5 @@
       displayMenu: 'overlay'
     })
   </script>
+  {% endif %}
 {% endblock %}

--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -37,6 +37,7 @@
             {{ charge.cardDetails.cardholderName }}
           </td>
         </tr>
+        {% if service.collectBillingAddress %}
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
             {{ __("confirmDetails.address") }}
@@ -45,6 +46,7 @@
             {{ charge.cardDetails.billingAddress }}
           </td>
         </tr>
+        {% endif %}
         {% if (charge.gatewayAccount.emailCollectionMode === 'MANDATORY') or (charge.gatewayAccount.emailCollectionMode === 'OPTIONAL' and charge.email) %}
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -30,7 +30,8 @@
         {% endif %}
     };
     window.Charge = {
-      email_collection_mode: '{{ gatewayAccount.emailCollectionMode | safe }}'
+      email_collection_mode: '{{ gatewayAccount.emailCollectionMode | safe }}',
+      collect_billing_address: {{ "true" if service.collectBillingAddress else "false" }}
     }
   }
 

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ if (!process.env.DISABLE_APPMETRICS) {
 // Node.js core dependencies
 const path = require('path')
 
-// npm dependencies
+// NPM dependencies
 const express = require('express')
 const nunjucks = require('nunjucks')
 const favicon = require('serve-favicon')

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -14,6 +14,25 @@ const customBrandingData = {
   }
 }
 
+const generateConfirmViewTemplateData = (templateData = {}) => {
+  const defaultService = {
+    collectBillingAddress: true
+  }
+  return {
+    charge: {
+      cardDetails: {
+        cardNumber: '************5100',
+        expiryDate: '11/99',
+        cardholderName: 'Francisco Blaya-Gonzalvez',
+        billingAddress: '1 street lane, avenue city, AB1 3DF'
+      },
+      amount: templateData.amount || '10.00',
+      description: 'Payment Description & <xss attack> assessment'
+    },
+    service: templateData.service || defaultService
+  }
+}
+
 describe('The charge view', function () {
   it('should render the amount', function () {
     var templateData = {
@@ -46,17 +65,45 @@ describe('The charge view', function () {
   })
 
   it('should show all input fields.', function () {
-    var body = renderTemplate('charge', {'id': '1234'})
+    var body = renderTemplate('charge', {
+      id: '1234',
+      service: {
+        collectBillingAddress: true
+      }
+    })
     body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
     body.should.containInputWithIdAndName('card-no', 'cardNo', 'tel').withAttribute('maxlength', '26').withLabel('card-no-lbl', 'Card number')
     body.should.containInputWithIdAndName('cvc', 'cvc', 'number').withLabel('cvc-lbl', 'Card security code')
     body.should.containInputWithIdAndName('expiry-month', 'expiryMonth', 'number')
     body.should.containInputWithIdAndName('expiry-year', 'expiryYear', 'number')
     body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('maxlength', '200').withLabel('cardholder-name-lbl', 'Name on card')
+    body.should.containSelector('#address-country')
     body.should.containInputWithIdAndName('address-line-1', 'addressLine1', 'text').withAttribute('maxlength', '100').withLabel('address-line-1-lbl', 'Building name and/or number and street')
     body.should.containInputWithIdAndName('address-line-2', 'addressLine2', 'text').withAttribute('maxlength', '100')
     body.should.containInputWithIdAndName('address-city', 'addressCity', 'text').withAttribute('maxlength', '100').withLabel('address-city-lbl', 'Town or city')
     body.should.containInputWithIdAndName('address-postcode', 'addressPostcode', 'text').withAttribute('maxlength', '10').withLabel('address-postcode-lbl', 'Postcode')
+    body.should.containInputWithIdAndName('charge-id', 'chargeId', 'hidden').withAttribute('value', '1234')
+    body.should.not.containSelector('.custom-branding-image')
+  })
+
+  it('should not show billing address for services not wanting to capture it', function () {
+    var body = renderTemplate('charge', {
+      id: '1234',
+      service: {
+        collectBillingAddress: false
+      }
+    })
+    body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
+    body.should.containInputWithIdAndName('card-no', 'cardNo', 'tel').withAttribute('maxlength', '26').withLabel('card-no-lbl', 'Card number')
+    body.should.containInputWithIdAndName('cvc', 'cvc', 'number').withLabel('cvc-lbl', 'Card security code')
+    body.should.containInputWithIdAndName('expiry-month', 'expiryMonth', 'number')
+    body.should.containInputWithIdAndName('expiry-year', 'expiryYear', 'number')
+    body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('maxlength', '200').withLabel('cardholder-name-lbl', 'Name on card')
+    body.should.not.containSelector('#address-country')
+    body.should.not.containSelector('#address-line-1')
+    body.should.not.containSelector('#address-line-2')
+    body.should.not.containSelector('#address-city')
+    body.should.not.containSelector('#address-postcode')
     body.should.containInputWithIdAndName('charge-id', 'chargeId', 'hidden').withAttribute('value', '1234')
     body.should.not.containSelector('.custom-branding-image')
   })
@@ -75,16 +122,20 @@ describe('The charge view', function () {
 
   it('should populate form data if reserved in response', function () {
     var responseData = {
-      'id': '1234',
-      'cardholderName': 'J. Vardy',
-      'addressLine1': '1 High Street',
-      'addressLine2': 'blah blah',
-      'addressCity': 'Leicester City',
-      'addressPostcode': 'CT16 1FB'
+      id: '1234',
+      cardholderName: 'J. Vardy',
+      addressLine1: '1 High Street',
+      addressLine2: 'blah blah',
+      addressCity: 'Leicester City',
+      addressPostcode: 'CT16 1FB',
+      service: {
+        collectBillingAddress: true
+      }
     }
     var body = renderTemplate('charge', responseData)
 
     body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('value', responseData.cardholderName)
+    body.should.containSelector('#address-country')
     body.should.containInputWithIdAndName('address-line-1', 'addressLine1', 'text').withAttribute('value', responseData.addressLine1)
     body.should.containInputWithIdAndName('address-line-2', 'addressLine2', 'text').withAttribute('value', responseData.addressLine2)
     body.should.containInputWithIdAndName('address-city', 'addressCity', 'text').withAttribute('value', responseData.addressCity)
@@ -93,20 +144,10 @@ describe('The charge view', function () {
 })
 
 describe('The confirm view', function () {
-  var successTemplateData = {
-    charge: {
-      'cardDetails': {
-        'cardNumber': '************5100',
-        'expiryDate': '11/99',
-        'cardholderName': 'Francisco Blaya-Gonzalvez',
-        'billingAddress': '1 street lane, avenue city, AB1 3DF'
-      },
-      'amount': '10.00',
-      'description': 'Payment Description & <xss attack> assessment'
-    }
-  }
+  const successTemplateDataWithCollectBillingAddress = generateConfirmViewTemplateData()
+
   it('should render cardNumber, expiryDate, amount and cardholder details fields', function () {
-    var body = renderTemplate('confirm', successTemplateData)
+    var body = renderTemplate('confirm', successTemplateDataWithCollectBillingAddress)
     var $ = cheerio.load(body)
     $('#payment-description').html().should.contain('Payment Description &amp; &lt;xss attack&gt; assessment')
     body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
@@ -118,8 +159,25 @@ describe('The confirm view', function () {
     body.should.containSelector('#address').withText('1 street lane, avenue city, AB1 3DF')
   })
 
+  it('should not show billing address for services not wanting to capture it', function () {
+    const body = renderTemplate('confirm', generateConfirmViewTemplateData({
+      service: {
+        collectBillingAddress: false
+      }
+    }))
+    const $ = cheerio.load(body)
+    $('#payment-description').html().should.contain('Payment Description &amp; &lt;xss attack&gt; assessment')
+    body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
+    body.should.containSelector('#card-number').withText('************5100')
+    body.should.containSelector('#expiry-date').withText('11/99')
+    body.should.containSelector('#cardholder-name').withText('Francisco Blaya-Gonzalvez')
+    body.should.not.containSelector('#address').withText('1 street lane, avenue city, AB1 3DF')
+    body.should.containSelector('#payment-description').withText('Payment Description')
+    body.should.containSelector('#amount').withText('£10.00')
+  })
+
   it('should display custom branding', () => {
-    const templateData = _.merge(successTemplateData, customBrandingData)
+    const templateData = _.merge(successTemplateDataWithCollectBillingAddress, customBrandingData)
     var body = renderTemplate('confirm', templateData)
     body.should.containSelector('.custom-branding-image')
 

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -1,15 +1,15 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const path = require('path')
 const lodash = require('lodash')
 const cheerio = require('cheerio')
 const should = require('chai').should() // eslint-disable-line
 
-// local dependencies
+// Local dependencies
 const renderTemplate = require(path.join(__dirname, '/test_helpers/html_assertions')).render
 
-// constants
+// Constants
 const customBrandingData = {
   service: {
     hasCustomBranding: true,

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -1,9 +1,15 @@
-var path = require('path')
-const _ = require('lodash')
-var renderTemplate = require(path.join(__dirname, '/test_helpers/html_assertions.js')).render
-var cheerio = require('cheerio')
-var should = require('chai').should() // eslint-disable-line
+'use strict'
 
+// npm dependencies
+const path = require('path')
+const lodash = require('lodash')
+const cheerio = require('cheerio')
+const should = require('chai').should() // eslint-disable-line
+
+// local dependencies
+const renderTemplate = require(path.join(__dirname, '/test_helpers/html_assertions')).render
+
+// constants
 const customBrandingData = {
   service: {
     hasCustomBranding: true,
@@ -35,21 +41,21 @@ const generateConfirmViewTemplateData = (templateData = {}) => {
 
 describe('The charge view', function () {
   it('should render the amount', function () {
-    var templateData = {
+    const templateData = {
       'amount': '50.00'
     }
 
-    var body = renderTemplate('charge', templateData)
+    const body = renderTemplate('charge', templateData)
     body.should.containSelector('#amount').withText('£50.00')
   })
 
   it('should have a submit form.', function () {
-    var postAction = '/post_card_path'
-    var templateData = {
+    const postAction = '/post_card_path'
+    const templateData = {
       'post_card_action': postAction
     }
 
-    var body = renderTemplate('charge', templateData)
+    const body = renderTemplate('charge', templateData)
 
     body.should.containSelector('form#card-details').withAttributes(
       {
@@ -60,12 +66,12 @@ describe('The charge view', function () {
   })
 
   it('should have a \'Continue\' button.', function () {
-    var body = renderTemplate('charge', {})
+    const body = renderTemplate('charge', {})
     body.should.containSelector('#submit-card-details')
   })
 
   it('should show all input fields.', function () {
-    var body = renderTemplate('charge', {
+    const body = renderTemplate('charge', {
       id: '1234',
       service: {
         collectBillingAddress: true
@@ -87,7 +93,7 @@ describe('The charge view', function () {
   })
 
   it('should not show billing address for services not wanting to capture it', function () {
-    var body = renderTemplate('charge', {
+    const body = renderTemplate('charge', {
       id: '1234',
       service: {
         collectBillingAddress: false
@@ -109,7 +115,7 @@ describe('The charge view', function () {
   })
 
   it('should display custom branding', () => {
-    const templateData = _.merge('charge', {'id': '1234'}, customBrandingData)
+    const templateData = lodash.merge('charge', {'id': '1234'}, customBrandingData)
     const body = renderTemplate('charge', templateData)
     body.should.containSelector('.custom-branding-image')
 
@@ -121,7 +127,7 @@ describe('The charge view', function () {
   })
 
   it('should populate form data if reserved in response', function () {
-    var responseData = {
+    const responseData = {
       id: '1234',
       cardholderName: 'J. Vardy',
       addressLine1: '1 High Street',
@@ -132,7 +138,7 @@ describe('The charge view', function () {
         collectBillingAddress: true
       }
     }
-    var body = renderTemplate('charge', responseData)
+    const body = renderTemplate('charge', responseData)
 
     body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('value', responseData.cardholderName)
     body.should.containSelector('#address-country')
@@ -147,8 +153,8 @@ describe('The confirm view', function () {
   const successTemplateDataWithCollectBillingAddress = generateConfirmViewTemplateData()
 
   it('should render cardNumber, expiryDate, amount and cardholder details fields', function () {
-    var body = renderTemplate('confirm', successTemplateDataWithCollectBillingAddress)
-    var $ = cheerio.load(body)
+    const body = renderTemplate('confirm', successTemplateDataWithCollectBillingAddress)
+    const $ = cheerio.load(body)
     $('#payment-description').html().should.contain('Payment Description &amp; &lt;xss attack&gt; assessment')
     body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
     body.should.containSelector('#card-number').withText('************5100')
@@ -177,11 +183,11 @@ describe('The confirm view', function () {
   })
 
   it('should display custom branding', () => {
-    const templateData = _.merge(successTemplateDataWithCollectBillingAddress, customBrandingData)
-    var body = renderTemplate('confirm', templateData)
+    const templateData = lodash.merge(successTemplateDataWithCollectBillingAddress, customBrandingData)
+    const body = renderTemplate('confirm', templateData)
     body.should.containSelector('.custom-branding-image')
 
-    var $ = cheerio.load(body)
+    const $ = cheerio.load(body)
     const customBrandingCssUrl = $('link').filter((i, el) => {
       return $(el).attr('href') === 'css url'
     }).attr('href')
@@ -189,7 +195,7 @@ describe('The confirm view', function () {
   })
 
   it('should render a confirm button', function () {
-    var body = renderTemplate('confirm', {confirmPath: '/card_details/123/confirm', 'charge': {id: 1234}})
+    const body = renderTemplate('confirm', {confirmPath: '/card_details/123/confirm', 'charge': {id: 1234}})
     body.should.containSelector('form#confirmation').withAttributes(
       {
         action: '/card_details/123/confirm',
@@ -200,12 +206,12 @@ describe('The confirm view', function () {
   })
 
   it('should have a cancel form.', function () {
-    var postAction = '/post_cancel_path'
-    var templateData = {
+    const postAction = '/post_cancel_path'
+    const templateData = {
       'post_cancel_action': postAction
     }
 
-    var body = renderTemplate('charge', templateData)
+    const body = renderTemplate('charge', templateData)
 
     body.should.containSelector('form#cancel').withAttributes(
       {
@@ -216,7 +222,7 @@ describe('The confirm view', function () {
   })
 
   it('should have a \'Cancel\' button.', function () {
-    var body = renderTemplate('charge', {})
+    const body = renderTemplate('charge', {})
     body.should.containInputWithIdAndName('cancel-payment', 'cancel', 'submit')
   })
 })

--- a/test/controllers/charge_controller_test.js
+++ b/test/controllers/charge_controller_test.js
@@ -1,15 +1,15 @@
 'use strict'
 
-// core dependencies
+// Core dependencies
 const path = require('path')
 
-// npm dependencies
+// NPM dependencies
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const expect = require('chai').expect
 const AWSXRay = require('aws-xray-sdk')
 
-// local dependencies
+// Local dependencies
 require(path.join(__dirname, '/../test_helpers/html_assertions'))
 
 const mockCharge = (function () {

--- a/test/enforce_status_views_tests.js
+++ b/test/enforce_status_views_tests.js
@@ -1,18 +1,18 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const path = require('path')
 const request = require('supertest')
 const nock = require('nock')
 const cheerio = require('cheerio')
 const {expect} = require('chai')
 
-// local dependencies
+// Local dependencies
 const app = require(path.join(__dirname, '/../server.js')).getApp()
 const helper = require(path.join(__dirname, '/test_helpers/test_helpers.js'))
 const cookie = require(path.join(__dirname, '/test_helpers/session.js'))
 
-// constants
+// Constants
 const chargeId = '23144323'
 const frontendCardDetailsPath = '/card_details'
 

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -24,7 +24,8 @@ module.exports = {
       gateway_account_ids: serviceData.gateway_account_ids || [random.randomInt(1, 9999999)],
       custom_branding: serviceData.custom_branding || defaultCustomBranding,
       merchant_details: serviceData.merchant_details || defaultMerchantDetails,
-      redirect_to_service_immediately_on_terminal_state: serviceData.redirect_to_service_immediately_on_terminal_state === true
+      redirect_to_service_immediately_on_terminal_state: serviceData.redirect_to_service_immediately_on_terminal_state === true,
+      collect_billing_address: typeof serviceData.collect_billing_address === 'undefined' || serviceData.collect_billing_address
     }
 
     return {

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -1,10 +1,10 @@
 'use strict'
 
-// local dependencies
+// Local dependencies
 const pactBase = require('./pact_base')
 const random = require('../../app/utils/random')
 
-// global setup
+// Global setup
 const pactServices = pactBase({array: ['service_ids']})
 
 module.exports = {

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -1,10 +1,10 @@
 'use strict'
 
-// Local dependencies
+// local dependencies
 const pactBase = require('./pact_base')
 const random = require('../../app/utils/random')
 
-// Global setup
+// global setup
 const pactServices = pactBase({array: ['service_ids']})
 
 module.exports = {

--- a/test/integration/charge_billing_address_ft_tests.js
+++ b/test/integration/charge_billing_address_ft_tests.js
@@ -1,0 +1,223 @@
+'use strict'
+
+// npm dependencies
+const lodash = require('lodash')
+const nock = require('nock')
+const chai = require('chai')
+const cheerio = require('cheerio')
+const winston = require('winston')
+const expect = chai.expect
+const proxyquire = require('proxyquire')
+const AWSXRay = require('aws-xray-sdk')
+
+// local dependencies
+const cookie = require('../test_helpers/session')
+const helper = require('../test_helpers/test_helpers')
+const {
+  getChargeRequest,
+  postChargeRequest,
+  defaultConnectorResponseForGetCharge,
+  defaultAdminusersResponseForGetService
+} = helper
+const State = require('../../config/state')
+
+// constants
+const app = proxyquire('../../server', {
+  'aws-xray-sdk': {
+    enableManualMode: () => {},
+    setLogger: () => {},
+    middleware: {
+      setSamplingRules: () => {}
+    },
+    config: () => {},
+    express: {
+      openSegment: () => (req, res, next) => next(),
+      closeSegment: () => (req, rest, next) => next()
+    },
+    captureAsyncFunc: (name, callback) => callback(new AWSXRay.Segment('stub-subsegment')),
+    '@global': true
+  },
+  'continuation-local-storage': {
+    getNamespace: function () {
+      return {
+        get: () => new AWSXRay.Segment('stub-segment'),
+        bindEmitter: () => {},
+        run: callback => callback(),
+        set: () => {}
+      }
+    },
+    '@global': true
+  }
+}).getApp()
+
+const gatewayAccount = {
+  gatewayAccountId: '12345',
+  paymentProvider: 'sandbox',
+  analyticsId: 'test-1234',
+  type: 'test'
+}
+
+let mockServer
+
+const mockSuccessCardIdResponse = function (data) {
+  nock(process.env.CARDID_HOST)
+    .post('/v1/api/card', () => {
+      return true
+    })
+    .reply(200, data)
+}
+
+describe('chargeTests - billing address', function () {
+  const localServer = process.env.CONNECTOR_HOST
+
+  const connectorChargePath = '/v1/frontend/charges/'
+  const chargeId = '23144323'
+  const frontendCardDetailsPath = '/card_details'
+  const frontendCardDetailsPostPath = '/card_details/' + chargeId
+  const gatewayAccountId = gatewayAccount.gatewayAccountId
+
+  const connectorAuthUrl = localServer + connectorChargePath + chargeId + '/cards'
+  const enteringCardDetailsState = 'ENTERING CARD DETAILS'
+  const RETURN_URL = 'http://www.example.com/service'
+
+  function connectorExpects (data) {
+    return mockServer.post(connectorChargePath + chargeId + '/cards', body => {
+      // Strip non body data (header data) before comparing
+      delete body.accept_header
+      delete body.user_agent_header
+      console.log('COMPARING: ')
+      console.log(JSON.stringify(body))
+      console.log('WITH: ')
+      console.log(JSON.stringify(data))
+      console.log('RETURNING: ' + lodash.isEqual(body, data))
+      return lodash.isEqual(body, data)
+    })
+  }
+
+  function minimumConnectorCardData (cardNumber, cardType = 'DEBIT', corporate = false, cardBrand = 'visa') {
+    return {
+      card_number: cardNumber,
+      cvc: '234',
+      card_brand: cardBrand,
+      expiry_date: '11/99',
+      cardholder_name: 'Jimi Hendrix',
+      card_type: cardType,
+      corporate_card: corporate,
+      address: {
+        line1: '32 Whip Ma Whop Ma Avenue',
+        city: 'Willy wonka',
+        postcode: 'Y1 1YN',
+        country: 'GB'
+      }
+    }
+  }
+
+  function connectorCardDataWithoutAddress (cardNumber, cardType = 'DEBIT', corporate = false, cardBrand = 'visa') {
+    const connectorCardData = minimumConnectorCardData(cardNumber, cardType, corporate, cardBrand)
+    delete connectorCardData.address
+    return connectorCardData
+  }
+
+  function minimumFormCardData (cardNumber) {
+    return {
+      'returnUrl': RETURN_URL,
+      'cardUrl': connectorAuthUrl,
+      'chargeId': chargeId,
+      'cardNo': cardNumber,
+      'cvc': '234',
+      'expiryMonth': '11',
+      'expiryYear': '99',
+      'cardholderName': 'Jimi Hendrix',
+      'addressLine1': '32 Whip Ma Whop Ma Avenue',
+      'addressPostcode': 'Y1 1YN',
+      'addressCity': 'Willy wonka',
+      'email': 'willy@wonka.com',
+      'addressCountry': 'GB'
+    }
+  }
+
+  beforeEach(function () {
+    nock.cleanAll()
+    mockServer = nock(localServer)
+  })
+
+  before(function () {
+    // Disable logging.
+    winston.level = 'none'
+  })
+
+  describe('The /charge endpoint', function () {
+    it('should not send address property to connector for services not wanting to capture it', function (done) {
+      const cookieValue = cookie.create(chargeId)
+      nock(process.env.CONNECTOR_HOST)
+        .patch('/v1/frontend/charges/23144323')
+        .reply(200)
+      defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
+      defaultAdminusersResponseForGetService(gatewayAccountId, {
+        collect_billing_address: false
+      })
+      mockSuccessCardIdResponse({brand: 'visa', label: 'visa', type: 'D', corporate: true})
+
+      connectorExpects(connectorCardDataWithoutAddress('4000180000000002', 'DEBIT', true, 'visa'))
+        .reply(200, {status: State.AUTH_SUCCESS})
+
+      postChargeRequest(app, cookieValue, minimumFormCardData('4000 1800 0000 0002'), chargeId)
+        .expect(303)
+        .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/confirm')
+        .end(done)
+    })
+  })
+
+  describe('The /card_details/charge_id endpoint', function () {
+    it('should not show billing address for services not wanting to capture it', function (done) {
+      const cookieValue = cookie.create(chargeId)
+      nock(process.env.CONNECTOR_HOST)
+        .put('/v1/frontend/charges/' + chargeId + '/status').reply(200)
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(enteringCardDetailsState, 'http://www.example.com/service', gatewayAccountId))
+      defaultAdminusersResponseForGetService(gatewayAccountId, {
+        collect_billing_address: false
+      })
+
+      getChargeRequest(app, cookieValue, chargeId)
+        .expect(200)
+        .expect(function (res) {
+          const $ = cheerio.load(res.text)
+          expect($('#govuk-script-charge')[0].children[0].data).to.contains(chargeId)
+          expect($('#card-details #csrf').attr('value')).to.not.be.empty // eslint-disable-line
+          expect($('.payment-summary #amount').text()).to.eql('£23.45')
+          expect($('.payment-summary #payment-description').text()).to.contain('Payment Description')
+          expect($('#card-details').attr('action')).to.eql(frontendCardDetailsPostPath)
+          expect($('.withdrawal-text').text()).to.contains('Accepted credit and debit card types')
+          expect($('#address-country').length).to.equal(0)
+        })
+        .end(done)
+    })
+  })
+
+  describe('The /card_details/charge_id/confirm endpoint', function () {
+    it('should not show billing address for services not wanting to capture it', function (done) {
+      nock(process.env.CONNECTOR_HOST)
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge('AUTHORISATION SUCCESS', 'http://www.example.com/service', gatewayAccountId))
+      defaultAdminusersResponseForGetService(gatewayAccountId, {
+        collect_billing_address: false
+      })
+      const cookieValue = cookie.create(chargeId)
+
+      getChargeRequest(app, cookieValue, chargeId, '/confirm')
+        .expect(200)
+        .expect(function (res) {
+          const $ = cheerio.load(res.text)
+          expect($('#confirmation #csrf').attr('value')).to.not.be.empty // eslint-disable-line
+          expect($('#card-number').text()).to.contains('************1234')
+          expect($('#expiry-date').text()).to.contains('11/99')
+          expect($('#cardholder-name').text()).to.contains('Test User')
+          expect($('#address').length).to.equal(0)
+          expect($('.payment-summary #amount').text()).to.eql('£23.45')
+          expect($('.payment-summary #payment-description').text()).to.contain('Payment Description')
+          expect($('#payment-summary-breakdown-amount').length > 0).to.equal(false)
+          expect($('#payment-summary-corporate-card-fee').length > 0).to.equal(false)
+        })
+        .end(done)
+    })
+  })
+})

--- a/test/integration/charge_billing_address_ft_tests.js
+++ b/test/integration/charge_billing_address_ft_tests.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const lodash = require('lodash')
 const nock = require('nock')
 const chai = require('chai')
@@ -10,7 +10,7 @@ const expect = chai.expect
 const proxyquire = require('proxyquire')
 const AWSXRay = require('aws-xray-sdk')
 
-// local dependencies
+// Local dependencies
 const cookie = require('../test_helpers/session')
 const helper = require('../test_helpers/test_helpers')
 const {
@@ -21,7 +21,7 @@ const {
 } = helper
 const State = require('../../config/state')
 
-// constants
+// Constants
 const app = proxyquire('../../server', {
   'aws-xray-sdk': {
     enableManualMode: () => {},

--- a/test/integration/charge_ft_tests.js
+++ b/test/integration/charge_ft_tests.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const _ = require('lodash')
 const request = require('supertest')
 const nock = require('nock')
@@ -12,7 +12,7 @@ const proxyquire = require('proxyquire')
 const AWSXRay = require('aws-xray-sdk')
 const should = chai.should()
 
-// local dependencies
+// Local dependencies
 const cookie = require('../test_helpers/session')
 const helper = require('../test_helpers/test_helpers')
 const {
@@ -26,7 +26,7 @@ const State = require('../../config/state')
 const serviceFixtures = require('../fixtures/service_fixtures')
 const random = require('../../app/utils/random')
 
-// constants
+// Constants
 const app = proxyquire('../../server', {
   'aws-xray-sdk': {
     enableManualMode: () => {},

--- a/test/integration/charge_ft_tests.js
+++ b/test/integration/charge_ft_tests.js
@@ -125,12 +125,6 @@ describe('chargeTests', function () {
     }
   }
 
-  function connectorCardDataWithoutAddress (cardNumber, cardType = 'DEBIT', corporate = false, cardBrand = 'visa') {
-    const connectorCardData = minimumConnectorCardData(cardNumber, cardType, corporate, cardBrand)
-    delete connectorCardData.address
-    return connectorCardData
-  }
-
   function fullConnectorCardData (cardNumber) {
     const cardData = minimumConnectorCardData(cardNumber)
     cardData.address.line2 = 'bla bla'
@@ -342,26 +336,6 @@ describe('chargeTests', function () {
         mockSuccessCardIdResponse({brand: 'visa', label: 'visa', type: 'D', corporate: true})
 
         connectorExpects(minimumConnectorCardData('4000180000000002', 'DEBIT', true, 'visa'))
-          .reply(200, {status: State.AUTH_SUCCESS})
-
-        postChargeRequest(app, cookieValue, minimumFormCardData('4000 1800 0000 0002'), chargeId)
-          .expect(303)
-          .expect('Location', frontendCardDetailsPath + '/' + chargeId + '/confirm')
-          .end(done)
-      })
-
-      it('should not send address property to connector for services not wanting to capture it', function (done) {
-        const cookieValue = cookie.create(chargeId)
-        nock(process.env.CONNECTOR_HOST)
-          .patch('/v1/frontend/charges/23144323')
-          .reply(200)
-        defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
-        defaultAdminusersResponseForGetService(gatewayAccountId, {
-          collect_billing_address: false
-        })
-        mockSuccessCardIdResponse({brand: 'visa', label: 'visa', type: 'D', corporate: true})
-
-        connectorExpects(connectorCardDataWithoutAddress('4000180000000002', 'DEBIT', true, 'visa'))
           .reply(200, {status: State.AUTH_SUCCESS})
 
         postChargeRequest(app, cookieValue, minimumFormCardData('4000 1800 0000 0002'), chargeId)
@@ -797,30 +771,6 @@ describe('chargeTests', function () {
         .end(done)
     })
 
-    it('should not show billing address for services not wanting to capture it', function (done) {
-      const cookieValue = cookie.create(chargeId)
-      nock(process.env.CONNECTOR_HOST)
-        .put('/v1/frontend/charges/' + chargeId + '/status').reply(200)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge(enteringCardDetailsState, 'http://www.example.com/service', gatewayAccountId))
-      defaultAdminusersResponseForGetService(gatewayAccountId, {
-        collect_billing_address: false
-      })
-
-      getChargeRequest(app, cookieValue, chargeId)
-        .expect(200)
-        .expect(function (res) {
-          const $ = cheerio.load(res.text)
-          expect($('#govuk-script-charge')[0].children[0].data).to.contains(chargeId)
-          expect($('#card-details #csrf').attr('value')).to.not.be.empty // eslint-disable-line
-          expect($('.payment-summary #amount').text()).to.eql('£23.45')
-          expect($('.payment-summary #payment-description').text()).to.contain('Payment Description')
-          expect($('#card-details').attr('action')).to.eql(frontendCardDetailsPostPath)
-          expect($('.withdrawal-text').text()).to.contains('Accepted credit and debit card types')
-          expect($('#address-country').length).to.equal(0)
-        })
-        .end(done)
-    })
-
     it('It should show card details page with correct text for credit card only', function (done) {
       const cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)
@@ -944,31 +894,6 @@ describe('chargeTests', function () {
           expect($('.payment-summary #payment-description').text()).to.contain('Payment Description')
           expect($('.payment-summary #payment-summary-breakdown #payment-summary-breakdown-amount').text()).to.contain('£23.45')
           expect($('.payment-summary #payment-summary-breakdown #payment-summary-corporate-card-fee').text()).to.contain('£2.50')
-        })
-        .end(done)
-    })
-
-    it('should not show billing address for services not wanting to capture it', function (done) {
-      nock(process.env.CONNECTOR_HOST)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge('AUTHORISATION SUCCESS', 'http://www.example.com/service', gatewayAccountId))
-      defaultAdminusersResponseForGetService(gatewayAccountId, {
-        collect_billing_address: false
-      })
-      const cookieValue = cookie.create(chargeId)
-
-      getChargeRequest(app, cookieValue, chargeId, '/confirm')
-        .expect(200)
-        .expect(function (res) {
-          const $ = cheerio.load(res.text)
-          expect($('#confirmation #csrf').attr('value')).to.not.be.empty // eslint-disable-line
-          expect($('#card-number').text()).to.contains('************1234')
-          expect($('#expiry-date').text()).to.contains('11/99')
-          expect($('#cardholder-name').text()).to.contains('Test User')
-          expect($('#address').length).to.equal(0)
-          expect($('.payment-summary #amount').text()).to.eql('£23.45')
-          expect($('.payment-summary #payment-description').text()).to.contain('Payment Description')
-          expect($('#payment-summary-breakdown-amount').length > 0).to.equal(false)
-          expect($('#payment-summary-corporate-card-fee').length > 0).to.equal(false)
         })
         .end(done)
     })

--- a/test/integration/charge_ft_tests.js
+++ b/test/integration/charge_ft_tests.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// NPM dependencies
+// npm dependencies
 const _ = require('lodash')
 const request = require('supertest')
 const nock = require('nock')
@@ -12,8 +12,22 @@ const proxyquire = require('proxyquire')
 const AWSXRay = require('aws-xray-sdk')
 const should = chai.should()
 
-// Local dependencies
-const app = proxyquire('../../server.js', {
+// local dependencies
+const cookie = require('../test_helpers/session')
+const helper = require('../test_helpers/test_helpers')
+const {
+  getChargeRequest,
+  postChargeRequest,
+  defaultConnectorResponseForGetCharge,
+  defaultAdminusersResponseForGetService,
+  connectorResponseForPutCharge
+} = helper
+const State = require('../../config/state')
+const serviceFixtures = require('../fixtures/service_fixtures')
+const random = require('../../app/utils/random')
+
+// constants
+const app = proxyquire('../../server', {
   'aws-xray-sdk': {
     enableManualMode: () => {},
     setLogger: () => {},
@@ -40,16 +54,7 @@ const app = proxyquire('../../server.js', {
     '@global': true
   }
 }).getApp()
-const cookie = require('../test_helpers/session.js')
-const helper = require('../test_helpers/test_helpers.js')
-const {getChargeRequest, postChargeRequest} = require('../test_helpers/test_helpers.js')
-const connectorResponseForPutCharge = require('../test_helpers/test_helpers.js').connectorResponseForPutCharge
-const {defaultConnectorResponseForGetCharge, defaultAdminusersResponseForGetService} = require('../test_helpers/test_helpers.js')
-const State = require('../../config/state.js')
-const serviceFixtures = require('../fixtures/service_fixtures')
-const random = require('../../app/utils/random')
 
-// Constants
 const EMPTY_BODY = ''
 const defaultCorrelationHeader = {
   reqheaders: {'x-request-id': 'some-unique-id'}

--- a/test/integration/util_cookies_ft_tests.js
+++ b/test/integration/util_cookies_ft_tests.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const {expect} = require('chai')
 const proxyquire = require('proxyquire').noPreserveCache()
 

--- a/test/middleware/resolve_language_test.js
+++ b/test/middleware/resolve_language_test.js
@@ -3,10 +3,10 @@ const path = require('path')
 const i18n = require('i18n')
 const assert = require('assert')
 
-// local dependencies
+// Local dependencies
 const resolveLanguage = require('../../app/middleware/resolve_language.js')
 
-// local constants
+// Local constants
 const res = {
   locals: {}
 }

--- a/test/middleware/retrieve_charge_test.js
+++ b/test/middleware/retrieve_charge_test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const path = require('path')
 const assert = require('assert')
 const sinon = require('sinon')

--- a/test/models/card_test.js
+++ b/test/models/card_test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const path = require('path')
 const assert = require('assert')
 const nock = require('nock')
@@ -8,7 +8,7 @@ const {unexpectedPromise} = require(path.join(__dirname, '/../test_helpers/test_
 const proxyquire = require('proxyquire')
 const AWSXRay = require('aws-xray-sdk')
 
-// local dependencies
+// Local dependencies
 require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
 
 const CardModel = proxyquire(path.join(__dirname, '/../../app/models/card.js'), {
@@ -28,7 +28,7 @@ const CardModel = proxyquire(path.join(__dirname, '/../../app/models/card.js'), 
   }
 })
 
-// constants
+// Constants
 const aRequestId = 'unique-request-id'
 const aCorrelationHeader = {
   reqheaders: {

--- a/test/models/charge_test.js
+++ b/test/models/charge_test.js
@@ -1,18 +1,18 @@
 'use strict'
 
-// core dependencies
+// Core dependencies
 const path = require('path')
 
-// npm dependencies
+// NPM dependencies
 const assert = require('assert')
 const nock = require('nock')
 
-// local dependencies
+// Local dependencies
 require(path.join(__dirname, '/../test_helpers/html_assertions.js'))
 const Charge = require(path.join(__dirname, '/../../app/models/charge.js'))
 const {unexpectedPromise} = require(path.join(__dirname, '/../test_helpers/test_helpers.js'))
 
-// constants
+// Constants
 const originalHost = process.env.CONNECTOR_HOST
 
 describe('updateStatus', function () {

--- a/test/test_helpers/html_assertions.js
+++ b/test/test_helpers/html_assertions.js
@@ -1,4 +1,4 @@
-// npm dependencies
+// NPM dependencies
 const cheerio = require('cheerio')
 const chai = require('chai')
 const nunjucks = require('nunjucks')

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -269,8 +269,9 @@ module.exports = {
     connectorMock.put(mockPath, payload).reply(statusCode, responseBody)
   },
 
-  defaultAdminusersResponseForGetService: function (gatewayAccountId) {
-    const serviceResponse = serviceFixtures.validServiceResponse({gateway_account_ids: [gatewayAccountId]}).getPlain()
+  defaultAdminusersResponseForGetService: function (gatewayAccountId, serviceData = {}) {
+    serviceData.gateway_account_ids = [gatewayAccountId]
+    const serviceResponse = serviceFixtures.validServiceResponse(serviceData).getPlain()
     adminusersRespondsWith(gatewayAccountId, serviceResponse)
   },
 

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -1,17 +1,17 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const request = require('supertest')
 const _ = require('lodash')
 const chaiExpect = require('chai').expect
 const csrf = require('csrf')
 const nock = require('nock')
 
-// local dependencies
+// Local dependencies
 const serviceFixtures = require('../fixtures/service_fixtures')
 const frontendCardDetailsPath = '/card_details'
 
-// constants
+// Constants
 const connectorChargePath = '/v1/frontend/charges/'
 const adminusersServicePath = '/v1/api/services'
 const defaultCorrelationId = 'some-unique-id'

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// NPM dependencies
+// npm dependencies
 const request = require('supertest')
 const _ = require('lodash')
 const chaiExpect = require('chai').expect

--- a/test/unit/cookies_test.js
+++ b/test/unit/cookies_test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const {expect} = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire').noPreserveCache()

--- a/test/utils/ab_test.js
+++ b/test/utils/ab_test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const {expect} = require('chai')
 
-// local dependencies
+// Local dependencies
 const abTest = require('../../app/utils/ab_test')
 
 describe('ab test helper', function () {

--- a/test/utils/add_proxy_test.js
+++ b/test/utils/add_proxy_test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const {expect} = require('chai')
 const urlParse = require('url').parse
 const proxyquire = require('proxyquire').noPreserveCache()

--- a/test/utils/response_router_test.js
+++ b/test/utils/response_router_test.js
@@ -1,17 +1,17 @@
 'use strict'
 
-// npm dependencies
+// NPM dependencies
 const {expect} = require('chai')
 const sinon = require('sinon')
 const lodash = require('lodash')
 
-// local dependencies
+// Local dependencies
 const serviceFixtures = require('../fixtures/service_fixtures')
 const Service = require('../../app/models/Service.class')
 const responseRouter = require('../../app/utils/response_router')
 const testHelpers = require('../test_helpers/test_helpers')
 
-// constants
+// Constants
 const nonTerminalActions = [
   'auth_3ds_required',
   'auth_3ds_required_in',


### PR DESCRIPTION
## WHAT

Do not show billing address on "enter card details" and "confirmation" pages.

## HOW

- Modified `Service.class` to have new `collectBillingAddress` property
- Modified `charge_controller` to ignore and not send `address` property when
  calling connector's `/v1/frontend/charges/{chargeId}/cards` endpoint and
  when `collectBillingAddress` is `false`
- Modified `charge.njk` and `confirm.njk` to not show billing address
  when `service.collectBillingAddress` is `false`
- Modified tests

with @danworth