### PR TITLE
PP-4349 Changes button text on unsuccessful payment screens for auth failure/system_cancelled/user_cancelled to 'Continue'

### DIFF
--- a/app/views/errors/incorrect_state/auth_failure.njk
+++ b/app/views/errors/incorrect_state/auth_failure.njk
@@ -10,7 +10,7 @@
     <h1 class="govuk-heading-l qa-payment-declined">{{ __("errorViews.declined") }}</h1>
     <p class="govuk-body-l lede">{{ __("errorViews.contactYourBank") }}</p>
 
-    <p class="govuk-body-l lede"><a href="{{ returnUrl }}" id="return-url" role="button" class="govuk-button">{{ __("errorViews.tryAgain") }}</a></p>
+    <p class="govuk-body-l lede"><a href="{{ returnUrl }}" id="return-url" role="button" class="govuk-button">{{ __("commonButtons.continueButton") }}</a></p>
   </div>
 </div>
 {% endblock %}

--- a/app/views/errors/incorrect_state/system_cancelled.njk
+++ b/app/views/errors/incorrect_state/system_cancelled.njk
@@ -10,7 +10,7 @@
     <h1 class="govuk-heading-l system-cancel">{{ __("errorViews.paymentCancelledTitle") }}</h1>
     <p class="govuk-body-l lede">{{ __("errorViews.paymentCancelledDescription") }}</p>
     <p class="govuk-body-l lede">
-      <a href="{{ returnUrl }}" id="return-url" role="button" class="govuk-button">{{ __("errorViews.tryAgain") }}</a>
+      <a href="{{ returnUrl }}" id="return-url" role="button" class="govuk-button">{{ __("commonButtons.continueButton") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/user_cancelled.njk
+++ b/app/views/user_cancelled.njk
@@ -10,7 +10,7 @@
     <h1 class="govuk-heading-l user-cancel">{{ __("authorisation.userCancelledPayment") }}</h1>
     <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
     <p class="govuk-body-l lede">
-      <a id="return-url" role="button" class="govuk-button" href="{{ returnUrl }}">{{ __("commonButtons.goBackToService") }}</a>
+      <a id="return-url" role="button" class="govuk-button" href="{{ returnUrl }}">{{ __("commonButtons.continueButton") }}</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
## WHAT
Updates failure page button text to simply 'Continue' rather than what was there before


