### PR TITLE
PP-4373 Separate 3DS controller

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -23,7 +23,7 @@ const connectorClient = require('../services/clients/connector_client')
 
 // constants
 const clsXrayConfig = require('../../config/xray-cls')
-const {views, threeDsEPDQResults, preserveProperties} = require('../../config/charge_controller')
+const {views, preserveProperties} = require('../../config/charge_controller')
 const {CORRELATION_HEADER} = require('../../config/correlation_header')
 
 const appendChargeForNewView = (charge, req, chargeId) => {
@@ -51,26 +51,6 @@ const redirect = res => {
     toNew: (chargeId) => res.redirect(303, routeFor('new', chargeId)),
     toReturn: (chargeId) => res.redirect(303, routeFor('return', chargeId))
   }
-}
-
-const build3dsPayload = req => {
-  let auth3dsPayload = {}
-  const paRes = _.get(req, 'body.PaRes')
-  if (!_.isUndefined(paRes)) {
-    auth3dsPayload.pa_response = paRes
-  }
-
-  const providerStatus = threeDsEPDQResults[_.get(req, 'body.providerStatus', '')]
-  if (!_.isUndefined(providerStatus)) {
-    auth3dsPayload.auth_3ds_result = providerStatus
-  }
-
-  const md = _.get(req, 'body.MD')
-  if (!_.isUndefined(md)) {
-    auth3dsPayload.md = md
-  }
-
-  return auth3dsPayload
 }
 
 const handleCreateResponse = (req, res, charge) => response => {
@@ -128,24 +108,6 @@ const handleAuthResponse = (req, res, charge) => response => {
       break
     default:
       redirect(res).toNew(req.chargeId)
-  }
-}
-
-const handleThreeDsResponse = (req, res, charge) => response => {
-  switch (response.statusCode) {
-    case 200:
-    case 400:
-      redirect(res).toConfirm(charge.id)
-      break
-    case 202:
-    case 409:
-      redirect(res).toAuthWaiting(charge.id)
-      break
-    case 500:
-      responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalytics(charge))
-      break
-    default:
-      responseRouter.response(req, res, 'ERROR', withAnalytics(charge))
   }
 }
 
@@ -314,60 +276,6 @@ module.exports = {
       default:
         redirect(res).toConfirm(req.chargeId)
     }
-  },
-  auth3dsHandler (req, res) {
-    const charge = normalise.charge(req.chargeData, req.chargeId)
-    const correlationId = req.headers[CORRELATION_HEADER] || ''
-    const payload = build3dsPayload(req)
-    connectorClient({correlationId}).threeDs({chargeId: charge.id, payload})
-      .then(handleThreeDsResponse(req, res, charge))
-      .catch(() => {
-        responseRouter.response(req, res, 'ERROR', withAnalytics(charge))
-      })
-  },
-  auth3dsRequired: (req, res) => {
-    const charge = normalise.charge(req.chargeData, req.chargeId)
-    responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_VIEW, withAnalytics(charge))
-  },
-  auth3dsRequiredOut: (req, res) => {
-    const charge = normalise.charge(req.chargeData, req.chargeId)
-    const issuerUrl = _.get(charge, 'auth3dsData.issuerUrl')
-    const paRequest = _.get(charge, 'auth3dsData.paRequest')
-    const md = _.get(charge, 'auth3dsData.md')
-    const htmlOut = _.get(charge, 'auth3dsData.htmlOut')
-
-    if (issuerUrl && paRequest) {
-      let data = {
-        issuerUrl: issuerUrl,
-        paRequest: paRequest,
-        threeDSReturnUrl: `${req.protocol}://${req.hostname}${paths.generateRoute('external.card.auth3dsRequiredIn', {chargeId: charge.id})}`
-      }
-      if (md) {
-        data.md = md
-      }
-      responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_OUT_VIEW, data)
-    } else if (htmlOut) {
-      responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_HTML_OUT_VIEW, {
-        htmlOut: Buffer.from(htmlOut, 'base64').toString('utf8')
-      })
-    } else {
-      responseRouter.response(req, res, 'ERROR', withAnalytics(charge))
-    }
-  },
-  auth3dsRequiredIn: (req, res) => {
-    const charge = normalise.charge(req.chargeData, req.chargeId)
-    responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_IN_VIEW, {
-      threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
-      paResponse: _.get(req, 'body.PaRes'),
-      md: _.get(req, 'body.MD')
-    })
-  },
-  auth3dsRequiredInEpdq: (req, res) => {
-    const charge = normalise.charge(req.chargeData, req.chargeId)
-    responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_IN_VIEW, {
-      threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
-      providerStatus: _.get(req, 'query.status', 'success')
-    })
   },
   confirm: (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)

--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -1,0 +1,121 @@
+
+// npm dependencies
+const _ = require('lodash')
+
+// local dependencies
+const responseRouter = require('../utils/response_router')
+const normalise = require('../services/normalise_charge')
+const paths = require('../paths')
+const {withAnalytics} = require('../utils/analytics')
+const connectorClient = require('../services/clients/connector_client')
+
+// constants
+const {views, threeDsEPDQResults} = require('../../config/charge_controller')
+const {CORRELATION_HEADER} = require('../../config/correlation_header')
+
+const routeFor = (resource, chargeId) => paths.generateRoute(`card.${resource}`, {chargeId: chargeId})
+
+const redirect = res => {
+  return {
+    toAuth3dsRequired: (chargeId) => res.redirect(303, routeFor('auth3dsRequired', chargeId)),
+    toAuthWaiting: (chargeId) => res.redirect(303, routeFor('authWaiting', chargeId)),
+    toConfirm: (chargeId) => res.redirect(303, routeFor('confirm', chargeId)),
+    toNew: (chargeId) => res.redirect(303, routeFor('new', chargeId)),
+    toReturn: (chargeId) => res.redirect(303, routeFor('return', chargeId))
+  }
+}
+
+const build3dsPayload = req => {
+  let auth3dsPayload = {}
+  const paRes = _.get(req, 'body.PaRes')
+  if (!_.isUndefined(paRes)) {
+    auth3dsPayload.pa_response = paRes
+  }
+
+  const providerStatus = threeDsEPDQResults[_.get(req, 'body.providerStatus', '')]
+  if (!_.isUndefined(providerStatus)) {
+    auth3dsPayload.auth_3ds_result = providerStatus
+  }
+
+  const md = _.get(req, 'body.MD')
+  if (!_.isUndefined(md)) {
+    auth3dsPayload.md = md
+  }
+
+  return auth3dsPayload
+}
+
+const handleThreeDsResponse = (req, res, charge) => response => {
+  switch (response.statusCode) {
+    case 200:
+    case 400:
+      redirect(res).toConfirm(charge.id)
+      break
+    case 202:
+    case 409:
+      redirect(res).toAuthWaiting(charge.id)
+      break
+    case 500:
+      responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalytics(charge))
+      break
+    default:
+      responseRouter.response(req, res, 'ERROR', withAnalytics(charge))
+  }
+}
+
+module.exports = {
+  auth3dsHandler (req, res) {
+    const charge = normalise.charge(req.chargeData, req.chargeId)
+    const correlationId = req.headers[CORRELATION_HEADER] || ''
+    const payload = build3dsPayload(req)
+    connectorClient({correlationId}).threeDs({chargeId: charge.id, payload})
+      .then(handleThreeDsResponse(req, res, charge))
+      .catch(() => {
+        responseRouter.response(req, res, 'ERROR', withAnalytics(charge))
+      })
+  },
+  auth3dsRequired: (req, res) => {
+    const charge = normalise.charge(req.chargeData, req.chargeId)
+    responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_VIEW, withAnalytics(charge))
+  },
+  auth3dsRequiredOut: (req, res) => {
+    const charge = normalise.charge(req.chargeData, req.chargeId)
+    const issuerUrl = _.get(charge, 'auth3dsData.issuerUrl')
+    const paRequest = _.get(charge, 'auth3dsData.paRequest')
+    const md = _.get(charge, 'auth3dsData.md')
+    const htmlOut = _.get(charge, 'auth3dsData.htmlOut')
+
+    if (issuerUrl && paRequest) {
+      let data = {
+        issuerUrl: issuerUrl,
+        paRequest: paRequest,
+        threeDSReturnUrl: `${req.protocol}://${req.hostname}${paths.generateRoute('external.card.auth3dsRequiredIn', {chargeId: charge.id})}`
+      }
+      if (md) {
+        data.md = md
+      }
+      responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_OUT_VIEW, data)
+    } else if (htmlOut) {
+      responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_HTML_OUT_VIEW, {
+        htmlOut: Buffer.from(htmlOut, 'base64').toString('utf8')
+      })
+    } else {
+      responseRouter.response(req, res, 'ERROR', withAnalytics(charge))
+    }
+  },
+  auth3dsRequiredIn: (req, res) => {
+    const charge = normalise.charge(req.chargeData, req.chargeId)
+    responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_IN_VIEW, {
+      threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
+      paResponse: _.get(req, 'body.PaRes'),
+      md: _.get(req, 'body.MD')
+    })
+  },
+  auth3dsRequiredInEpdq: (req, res) => {
+    const charge = normalise.charge(req.chargeData, req.chargeId)
+    responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_IN_VIEW, {
+      threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
+      providerStatus: _.get(req, 'query.status', 'success')
+    })
+  }
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -7,6 +7,7 @@ const logger = require('winston')
 
 // Local dependencies
 const charge = require('./controllers/charge_controller.js')
+const threeDS = require('./controllers/three_d_secure_controller.js')
 const secure = require('./controllers/secure_controller.js')
 const statik = require('./controllers/static_controller.js')
 const applePay = require('./controllers/apple-pay/merchant-validation-controller')
@@ -68,13 +69,6 @@ exports.bind = function (app) {
 
   app.get(card.new.path, middlewareStack, charge.new)
   app.get(card.authWaiting.path, middlewareStack, charge.authWaiting)
-  app.get(card.auth3dsRequired.path, middlewareStack, charge.auth3dsRequired)
-  app.get(card.auth3dsRequiredOut.path, middlewareStack, charge.auth3dsRequiredOut)
-  app.post(card.auth3dsRequiredInEpdq.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], charge.auth3dsRequiredInEpdq)
-  app.get(card.auth3dsRequiredInEpdq.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], charge.auth3dsRequiredInEpdq)
-  app.post(card.auth3dsRequiredIn.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], charge.auth3dsRequiredIn)
-  app.get(card.auth3dsRequiredIn.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], charge.auth3dsRequiredIn)
-  app.post(card.auth3dsHandler.path, middlewareStack, charge.auth3dsHandler)
   app.get(card.captureWaiting.path, middlewareStack, charge.captureWaiting)
   app.post(card.create.path, middlewareStack, charge.create)
   app.post(card.createPaymentRequest.path, middlewareStack, charge.createPaymentRequest)
@@ -83,6 +77,14 @@ exports.bind = function (app) {
   app.post(card.cancel.path, middlewareStack, charge.cancel)
   app.post(card.checkCard.path, xraySegmentCls, retrieveCharge, resolveLanguage, charge.checkCard)
   app.get(card.return.path, xraySegmentCls, retrieveCharge, resolveLanguage, returnCont.return)
+
+  app.get(card.auth3dsRequired.path, middlewareStack, threeDS.auth3dsRequired)
+  app.get(card.auth3dsRequiredOut.path, middlewareStack, threeDS.auth3dsRequiredOut)
+  app.post(card.auth3dsRequiredInEpdq.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredInEpdq)
+  app.get(card.auth3dsRequiredInEpdq.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredInEpdq)
+  app.post(card.auth3dsRequiredIn.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredIn)
+  app.get(card.auth3dsRequiredIn.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredIn)
+  app.post(card.auth3dsHandler.path, middlewareStack, threeDS.auth3dsHandler)
 
   // Apple Pay endpoints
   app.post(paths.applePay.session.path, applePay)


### PR DESCRIPTION
Separates out 3DS controller from charge controller, as its
a fairly self contained unit. I have not made any other changes
other than lifting and shifting, and amending the necessary routes.