### PR TITLE
PP-4291 Display surcharge for prepaid corporate cards on card details page

### DIFF
--- a/app/assets/javascripts/modules/form-validation.js
+++ b/app/assets/javascripts/modules/form-validation.js
@@ -177,10 +177,14 @@ var formValidation = function () {
 
   var updateCorporateCardSurchargeInformation = function (card) {
     if (window.Card && window.Card.corporate_card_surcharge_amounts && card.corporate) {
-      if (card.type === 'CREDIT' && window.Card.corporate_card_surcharge_amounts.credit > 0) {
+      if (card.type === 'CREDIT' && card.prepaid === 'NOT_PREPAID' && window.Card.corporate_card_surcharge_amounts.credit > 0) {
         showCorporateCardSurchargeInformation(card.type, window.Card.corporate_card_surcharge_amounts.credit)
-      } else if (card.type === 'DEBIT' && window.Card.corporate_card_surcharge_amounts.debit > 0) {
+      } else if (card.type === 'DEBIT' && card.prepaid === 'NOT_PREPAID' && window.Card.corporate_card_surcharge_amounts.debit > 0) {
         showCorporateCardSurchargeInformation(card.type, window.Card.corporate_card_surcharge_amounts.debit)
+      } else if (card.type === 'CREDIT' && card.prepaid === 'PREPAID' && window.Card.corporate_card_surcharge_amounts.prepaidCredit > 0) {
+        showCorporateCardSurchargeInformation(card.type, window.Card.corporate_card_surcharge_amounts.prepaidCredit)
+      } else if (card.type === 'DEBIT' && card.prepaid === 'PREPAID' && window.Card.corporate_card_surcharge_amounts.prepaidDebit > 0) {
+        showCorporateCardSurchargeInformation(card.type, window.Card.corporate_card_surcharge_amounts.prepaidDebit)
       }
     }
   }

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -33,7 +33,9 @@ const appendChargeForNewView = (charge, req, chargeId) => {
   charge.cardsAsStrings = JSON.stringify(cardModel.allowed)
   charge.corporateCardSurchargeAmountsAsStrings = JSON.stringify({
     credit: charge.gatewayAccount.corporateCreditCardSurchargeAmount,
-    debit: charge.gatewayAccount.corporateDebitCardSurchargeAmount
+    debit: charge.gatewayAccount.corporateDebitCardSurchargeAmount,
+    prepaidCredit: charge.gatewayAccount.corporatePrepaidCreditCardSurchargeAmount,
+    prepaidDebit: charge.gatewayAccount.corporatePrepaidDebitCardSurchargeAmount
   })
   charge.post_card_action = routeFor('create', chargeId)
   charge.id = chargeId
@@ -259,7 +261,8 @@ module.exports = {
             return res.json({
               accepted: true,
               type: card.type,
-              corporate: card.corporate
+              corporate: card.corporate,
+              prepaid: card.prepaid
             })
           },
           error => {

--- a/app/models/card.js
+++ b/app/models/card.js
@@ -49,7 +49,8 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
           const card = {
             brand: changeCase.paramCase(body.brand),
             type: normaliseCardType(body.type),
-            corporate: body.corporate
+            corporate: body.corporate,
+            prepaid: body.prepaid
           }
 
           logger.debug(`[${correlationId}] Checking card brand - `, {

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -25,7 +25,9 @@
         {% else %}
           {
             credit: 0,
-            debit: 0
+            debit: 0,
+            prepaidCredit: 0,
+            prepaidDebit: 0
           }
         {% endif %}
     };

--- a/test/controllers/charge_controller_test.js
+++ b/test/controllers/charge_controller_test.js
@@ -239,7 +239,8 @@ describe('check card endpoint', function () {
     let card = {
       brand: 'VISA',
       type: 'CREDIT',
-      corporate: true
+      corporate: true,
+      prepaid: 'NOT_PREPAID'
     }
 
     return {
@@ -288,7 +289,7 @@ describe('check card endpoint', function () {
     }
     response = {
       json: (data) => {
-        expect(data).to.deep.equal({accepted: true, corporate: true, type: 'CREDIT'})
+        expect(data).to.deep.equal({accepted: true, corporate: true, type: 'CREDIT', prepaid: 'NOT_PREPAID'})
         done()
       }
     }

--- a/test/models/card_test.js
+++ b/test/models/card_test.js
@@ -134,15 +134,16 @@ describe('card', function () {
         nock.cleanAll()
         nock(process.env.CARDID_HOST)
           .post('/v1/api/card')
-          .reply(200, {brand: 'bar', label: 'bar', type: 'C', corporate: true})
+          .reply(200, {brand: 'bar', label: 'bar', type: 'C', corporate: true, prepaid: 'NOT_PREPAID'})
       })
 
-      it('should resolve with correct card brand, type and corporate status', function () {
+      it('should resolve with correct card brand, type, corporate status and prepaid status', function () {
         return CardModel([{brand: 'bar', label: 'bar', type: 'CREDIT', id: 'id-0'}])
           .checkCard(1234).then((card) => {
             assert.strictEqual(card.brand, 'bar')
             assert.strictEqual(card.type, 'CREDIT')
             assert.strictEqual(card.corporate, true)
+            assert.strictEqual(card.prepaid, 'NOT_PREPAID')
           }, unexpectedPromise)
       })
     })
@@ -152,15 +153,16 @@ describe('card', function () {
         nock.cleanAll()
         nock(process.env.CARDID_HOST)
           .post('/v1/api/card')
-          .reply(200, {brand: 'bar', label: 'bar', type: 'D', corporate: false})
+          .reply(200, {brand: 'bar', label: 'bar', type: 'D', corporate: false, prepaid: 'PREPAID'})
       })
 
-      it('should resolve with correct card brand, type and corporate status', function () {
+      it('should resolve with correct card brand, type, corporate status and prepaid status', function () {
         return CardModel([{brand: 'bar', label: 'bar', type: 'DEBIT', id: 'id-0'}])
           .checkCard(1234).then((card) => {
             assert.strictEqual(card.brand, 'bar')
             assert.strictEqual(card.type, 'DEBIT')
             assert.strictEqual(card.corporate, false)
+            assert.strictEqual(card.prepaid, 'PREPAID')
           }, unexpectedPromise)
       })
     })


### PR DESCRIPTION
## WHAT
- Obtain the prepaid status from the card id check card
  endpoint.
- Obtain the prepaid debit and prepaid credit surcharge amounts on the
  gateway account.
- Use these values in the browser-side javascript to decide whether to
  display a corporate surcharge, and calculate it if so.

with @SandorArpa


