### PR TITLE
PP-4161 Show billing address on confirmation page depending on the charge value

### DIFF
--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -37,7 +37,7 @@
             {{ charge.cardDetails.cardholderName }}
           </td>
         </tr>
-        {% if service.collectBillingAddress %}
+        {% if charge.cardDetails.billingAddress %}
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
             {{ __("confirmDetails.address") }}

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -30,7 +30,7 @@ const generateConfirmViewTemplateData = (templateData = {}) => {
         cardNumber: '************5100',
         expiryDate: '11/99',
         cardholderName: 'Francisco Blaya-Gonzalvez',
-        billingAddress: '1 street lane, avenue city, AB1 3DF'
+        billingAddress: lodash.get(templateData, 'charge.cardDetails.billingAddress', '1 street lane, avenue city, AB1 3DF')
       },
       amount: templateData.amount || '10.00',
       description: 'Payment Description & <xss attack> assessment'
@@ -169,6 +169,11 @@ describe('The confirm view', function () {
     const body = renderTemplate('confirm', generateConfirmViewTemplateData({
       service: {
         collectBillingAddress: false
+      },
+      charge: {
+        cardDetails: {
+          billingAddress: null
+        }
       }
     }))
     const $ = cheerio.load(body)

--- a/test/integration/charge_billing_address_ft_tests.js
+++ b/test/integration/charge_billing_address_ft_tests.js
@@ -197,7 +197,7 @@ describe('chargeTests - billing address', function () {
   describe('The /card_details/charge_id/confirm endpoint', function () {
     it('should not show billing address for services not wanting to capture it', function (done) {
       nock(process.env.CONNECTOR_HOST)
-        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge('AUTHORISATION SUCCESS', 'http://www.example.com/service', gatewayAccountId))
+        .get('/v1/frontend/charges/' + chargeId).reply(200, helper.rawSuccessfulGetCharge('AUTHORISATION SUCCESS', 'http://www.example.com/service', chargeId, gatewayAccountId, {}, null, true))
       defaultAdminusersResponseForGetService(gatewayAccountId, {
         collect_billing_address: false
       })

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -106,13 +106,13 @@ function rawSuccessfulGetChargeDebitCardOnly (status, returnUrl, chargeId, gatew
   return charge
 }
 
-function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, emailSettings) {
+function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, emailSettings, disableBillingAddress) {
   const charge = {
     'amount': 2345,
     'description': 'Payment Description',
     'status': status,
     'return_url': returnUrl,
-    'email': 'bob@bob.bob',
+    'email': 'bob@example.com',
     'links': [{
       'href': connectorChargeUrl(chargeId),
       'rel': 'self',
@@ -212,6 +212,9 @@ function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, 
   if (emailSettings) {
     charge.gateway_account.email_collection_mode = emailSettings.email_collection_mode
     charge.gateway_account.email_notifications = emailSettings.email_notifications
+  }
+  if (disableBillingAddress) {
+    charge.card_details.billing_address = null
   }
   return charge
 }


### PR DESCRIPTION
## WHAT

Show billing address on confirmation page depending on the charge `cardDetails.billingAddress` value and not depending on the service `collectBillingAddress` setting as the service object is cached and the results can be different on different nodes
