### PR TITLE
PP-4292 Send prepaid property to connector in auth request

### DIFF
--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -134,6 +134,7 @@ module.exports = (function () {
       'cardholder_name': req.body.cardholderName,
       'card_type': card.type,
       'corporate_card': card.corporate,
+      'prepaid': card.prepaid,
       'address': addressForApi(req.body),
       'accept_header': req.header('accept'),
       'user_agent_header': req.header('user-agent')

--- a/app/utils/charge_validation_backend.js
+++ b/app/utils/charge_validation_backend.js
@@ -17,7 +17,8 @@ module.exports = (translations, logger, cardModel, chargeOptions) => {
           logger.debug('Card supported - ', {
             cardBrand: card.brand,
             cardType: card.type,
-            cardCorporate: card.corporate
+            cardCorporate: card.corporate,
+            prepaid: card.prepaid
           })
           resolve({validation, card})
         })


### PR DESCRIPTION
## WHAT

- Send prepaid property retrieved from card id in payload for connector
  request to authorise card payment
- Modify tests to check prepaid property is included

with @stephencdaly

## HOW 

The pre-paid property is sent with all requests, NOT_PREPAID is the default value
Alternatives are:
PRE_PAID
UNKNOWN

