### PR TITLE
PP-4517 fix email typo error messaging

### DIFF
--- a/app/assets/sass/modules/_payment-request.scss
+++ b/app/assets/sass/modules/_payment-request.scss
@@ -1,4 +1,4 @@
-.govuk-radios__item:not(:last-child) {
+.payment-request-radios .govuk-radios__item:not(:last-child) {
   display: none;
 }
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -30,6 +30,7 @@
     <form id="payment-request-container" class="hidden">
       {{ govukRadios({
         name: "payment-method",
+        classes: "payment-request-radios",
         fieldset: {
           legend: {
             text: "Choose how you want to pay",

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -11,7 +11,7 @@
 {% block content %}
 <div class="govuk-grid-row govuk-!-margin-bottom-9">
   <div class="govuk-grid-column-two-thirds">
-    <div id="error-summary" class="govuk-error-summary hidden" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+    <div id="error-summary" class="govuk-error-summary {% if not hasError %}hidden{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
         {{ __("fieldErrors.summary") }}
       </h2>


### PR DESCRIPTION
Error summary and email typo suggestion were hidden erroneously. All good now

![screenshot_2018-12-11 enter card details](https://user-images.githubusercontent.com/440503/49797981-009c3300-fd39-11e8-8fab-13bc957627b6.png)
