### PR TITLE
BAU log request start at info level

### DIFF
--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -4,7 +4,7 @@
 const logger = require('winston')
 
 exports.logRequestStart = context => {
-  logger.debug(`Calling ${context.service}  ${context.description}-`, {
+  logger.info(`Calling ${context.service}  ${context.description}-`, {
     service: context.service,
     method: context.method,
     url: context.url


### PR DESCRIPTION
it seems useful to log this as well as request completion. It can help
debugging in cases where something goes wrong before the response is received.