### PR TITLE
PP-4651 State enforcer - Allow AUTH_3DS_READY for Stripe

### DIFF
--- a/test/middleware/state_enforcer_test.js
+++ b/test/middleware/state_enforcer_test.js
@@ -28,7 +28,7 @@ describe('state enforcer', function () {
   it('should call next when everything is in the correct state', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: {status: 'ENTERING CARD DETAILS'}
+      chargeData: {status: 'ENTERING CARD DETAILS', gateway_account: {payment_provider: 'Test Provider'}}
     }, {}, next)
     expect(next.calledOnce).to.be.true // eslint-disable-line
   })
@@ -36,7 +36,7 @@ describe('state enforcer', function () {
   it('should NOT call next when an invalid state is called and render an error', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: {status: 'INVALID STATE'}
+      chargeData: {status: 'INVALID STATE', gateway_account: {payment_provider: 'Test Provider'}}
     }, response, next)
     expect(next.notCalled).to.be.true // eslint-disable-line
     assert(status.calledWith(500))

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -106,7 +106,7 @@ function rawSuccessfulGetChargeDebitCardOnly (status, returnUrl, chargeId, gatew
   return charge
 }
 
-function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, emailSettings, disableBillingAddress) {
+function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, emailSettings, disableBillingAddress, paymentProvider = 'sandbox') {
   const charge = {
     'amount': 2345,
     'description': 'Payment Description',
@@ -130,7 +130,7 @@ function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, 
       'gateway_account_id': gatewayAccountId || defaultGatewayAccountId,
       'analytics_id': 'test-1234',
       'type': 'test',
-      'payment_provider': 'sandbox',
+      'payment_provider': paymentProvider,
       'service_name': 'Pranks incorporated',
       'card_types': [
         {


### PR DESCRIPTION
- Allow AUTH_3DS_READY state when payment provider is stripe


