### PR TITLE
PP-4651 Improve testing

### DIFF
--- a/app/middleware/state_enforcer.js
+++ b/app/middleware/state_enforcer.js
@@ -15,12 +15,13 @@ module.exports = (req, res, next) => {
   let correctStates = stateService.resolveStates(req.actionName)
   const currentState = req.chargeData.status
 
-  if (req.chargeData.gateway_account.payment_provider === 'stripe' &&
-    currentState === State.AUTH_3DS_READY) {
+  const paymentProvider = req.chargeData.gateway_account.payment_provider
+  if (paymentProvider === 'stripe' && currentState === State.AUTH_3DS_READY) {
     correctStates.push(State.AUTH_3DS_READY)
   }
   if (!correctStates.includes(currentState)) {
-    logger.error(`State enforcer status doesn't match : current charge state from connector [${currentState}], expected [${correctStates}]'`)
+    logger.error(`State enforcer status doesn't match: current charge state from connector [${currentState}], expected [${correctStates}] 
+      for charge [${req.chargeId}] with payment provider [${paymentProvider}]`)
     const stateName = currentState.toUpperCase().replace(/\s/g, '_')
     responseRouter.response(req, res, stateName, {
       chargeId: req.chargeId,

--- a/test/middleware/state_enforcer_test.js
+++ b/test/middleware/state_enforcer_test.js
@@ -1,18 +1,20 @@
-var path = require('path')
-var assert = require('assert')
-var expect = require('chai').expect
-var stateEnforcer = require(path.join(__dirname, '/../../app/middleware/state_enforcer.js'))
+'use strict'
 
-var sinon = require('sinon')
+const path = require('path')
+const assert = require('assert')
+const expect = require('chai').expect
+const stateEnforcer = require(path.join(__dirname, '/../../app/middleware/state_enforcer.js'))
+
+const sinon = require('sinon')
 
 describe('state enforcer', function () {
-  var response = {
+  const response = {
     status: function () {},
     render: function () {}
   }
-  var status
-  var render
-  var next
+  let status
+  let render
+  let next
 
   beforeEach(function () {
     status = sinon.stub(response, 'status')
@@ -29,6 +31,14 @@ describe('state enforcer', function () {
     stateEnforcer({
       actionName: 'card.new',
       chargeData: {status: 'ENTERING CARD DETAILS', gateway_account: {payment_provider: 'Test Provider'}}
+    }, {}, next)
+    expect(next.calledOnce).to.be.true // eslint-disable-line
+  })
+
+  it('should call next when Stripe charge is in AUTH_3DS_READY', function () {
+    stateEnforcer({
+      actionName: 'card.auth3dsHandler',
+      chargeData: {status: 'AUTHORISATION 3DS READY', gateway_account: {payment_provider: 'stripe'}}
     }, {}, next)
     expect(next.calledOnce).to.be.true // eslint-disable-line
   })

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -106,7 +106,11 @@ function rawSuccessfulGetChargeDebitCardOnly (status, returnUrl, chargeId, gatew
   return charge
 }
 
-function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, emailSettings, disableBillingAddress, paymentProvider = 'sandbox') {
+function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, emailSettings, disableBillingAddress) {
+  return rawSuccessfulGetChargeWithPaymentProvider(status, returnUrl, chargeId, gatewayAccountId, auth3dsData, 'sandbox', emailSettings, disableBillingAddress)
+}
+
+function rawSuccessfulGetChargeWithPaymentProvider (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, paymentProvider = 'sandbox', emailSettings, disableBillingAddress) {
   const charge = {
     'amount': 2345,
     'description': 'Payment Description',
@@ -297,6 +301,8 @@ module.exports = {
   rawSuccessfulGetChargeDebitCardOnly,
 
   rawSuccessfulGetChargeCorporateCardOnly,
+
+  rawSuccessfulGetChargeWithPaymentProvider,
 
   templateValue: function (res, key, value) {
     const body = JSON.parse(res.text)


### PR DESCRIPTION
## WHAT
- Added functional test for state enforcer when payment provider is
Stripe. Stripe charges with status AUTH_3DS_READY from connector should
go to auth_waiting page
- Improved logging to have the payment provider and charge id in case
other charges fail from the same reason
- Updated code syntax

with @kbottla



