### PR TITLE
PP-4747 - JS error blocking rest of scripts

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const allowedCardTypes = window.Card
+const allowedCardTypes = window.Card || {}
 const { email_collection_mode } = window.Charge
 
 const showErrorSummary = title => {

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -5,8 +5,10 @@ const analytics = require('gaap-analytics')
 exports.chargeValidation = require('./utils/charge_validation')
 analytics.eventTracking.init()
 
-inputConfim()
-webPayments()
+if (document.getElementById('main-content').classList.contains('charge-new')) {
+  inputConfim()
+  webPayments()
+}
 
 // GA tracking if an email typo is spotted
 if (document.getElementById('email-uncorrected')) {


### PR DESCRIPTION
This stops it causing errors further down the line.

Noticed becuase the JS wasn’t firing that creates a pseudo pageview we use to count successful transactions