### PR TITLE
BAU Invoke cleanup script from Jenkins library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,13 @@ pipeline {
       steps {
         cypress('frontend')
       }
+      post { 
+        always { 
+          script { 
+            cypress.cleanUp()
+          }
+        }
+      }
     }
     stage('Contract Tests') {
       steps {


### PR DESCRIPTION
Cleanup code exists in the Cypress groovy jenkins library to clean up
docker-compose, however it looks like this is never run, meaning that
Docker containers and networks are left hanging after job completion.


