### PR TITLE
PP-4641 - Integrate Google Pay with Payment Request API 

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { prepareRequestObject, showErrorSummary } = require('./helpers')
+const { prepareAppleRequestObject, showErrorSummary } = require('./helpers')
 
 function validateMerchantSession(url) {
   console.log('dialling...', url)
@@ -23,7 +23,7 @@ function validateMerchantSession(url) {
 }
 
 module.exports = () => {
-  const session = new ApplePaySession(3, prepareRequestObject('apple'))
+  const session = new ApplePaySession(3, prepareAppleRequestObject())
 
   session.onvalidatemerchant = event => {
     const validationURL = event.validationURL
@@ -32,7 +32,7 @@ module.exports = () => {
         console.log('validated merchant', response.signature)
         session.completeMerchantValidation(response)
       }).catch(err => {
-        showErrorSummary('There was an error contacting Apple Pay, please try again')
+        showErrorSummary(i18n.fieldErrors.webPayments.apple)
         return err
       })
   }

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -1,37 +1,55 @@
 'use strict'
 
-const { prepareRequestObject } = require('./helpers')
+const { getGooglePaymentsConfiguration, showErrorSummary } = require('./helpers')
+const { email_collection_mode } = window.Charge
 
-module.exports = () => {
-  const { supportedInstruments, details, options } = prepareRequestObject('standard')
-  const request = new PaymentRequest(supportedInstruments, details, options)
 
-  request.show()
-    .then(result => {
-      const payload = result.toJSON()
-      payload.csrfToken = document.getElementById('csrf').value
-      payload.chargeId = window.paymentDetails.chargeID
-      return fetch(`/payment-request/${window.paymentDetails.chargeID}`, {
-        method: 'POST',
-        redirect: 'follow',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(payload)
-      }).then(response => {
-        if (response.status === 200) {
-          result.complete('success')
-          return window.location.href = response.url
-        } else {
-          result.complete('fail')
-          return window.location.href = response.url
-        }
-      }).catch(() => {
-        result.complete('fail')
-        return window.location.href = response.url
-      })
-    }).catch(err => {
-      return err
+const processPayment = paymentData => {
+  // show returned data in developer console for debugging
+  console.log(paymentData);
+  // @todo pass payment token to your gateway to process payment
+  const paymentToken = paymentData.details.paymentMethodData.tokenizationData.token;
+  console.log('paymentToken', paymentToken);
+}
+
+const createGooglePaymentRequest = () => {
+  const methodData = [{
+    supportedMethods: 'https://google.com/pay',
+    data: getGooglePaymentsConfiguration()
+  }];
+
+  const details = {
+    total: {
+      label: window.paymentDetails.description,
+      amount: {
+        currency: 'GBP',
+        value: window.paymentDetails.amount
+      }
+    }
+  };
+
+  const options = {
+    requestPayerEmail: email_collection_mode !== 'OFF',
+    requestPayerName: true
+  };
+
+  return new PaymentRequest(methodData, details, options);
+}
+
+const googlePayNow = () => {
+  createGooglePaymentRequest()
+    .show()
+    .then(response => {
+      response.complete('success');
+      console.log('payment data', response)
+      processPayment(response);
     })
+    .catch(err => {
+      console.error('uh oh', err)
+    })
+}
+
+module.exports = {
+  createGooglePaymentRequest,
+  googlePayNow
 }

--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -1,36 +1,46 @@
 'use strict'
 
-const allowedCardTypes = window.Card || {}
+const allowedCardTypes = window.Card.allowed || {}
 const { email_collection_mode } = window.Charge || {}
+const { collect_billing_address } = window.Charge || {}
 
 const showErrorSummary = title => {
-const errorSummary = document.getElementById('error-summary')
-
-errorSummary.classList.remove('hidden')
-errorSummary.querySelectorAll('h2')[0].innerText = title
+  const errorSummary = document.getElementById('error-summary')
+  errorSummary.classList.remove('hidden')
+  errorSummary.querySelectorAll('h2')[0].innerText = title
 }
 
 const clearErrorSummary = () => {
   const errorSummary = document.getElementById('error-summary')
-
   errorSummary.classList.add('hidden')
 }
 
-const prepareRequestObject = brand => {
-  const supportedNetworks = allowedCardTypes.allowed.map(type => {
+const supportedNetworksFormattedByProvider = provider => {
+  const availableNetworks = allowedCardTypes.map(type => {
     if (type.debit || type.credit) {
       return type.brand
     }
   })
+  return availableNetworks
+    .filter(brand => brand !== 'diners-club')
+    .filter(brand => brand !== 'unionpay')
+    .map(brand => {
+      let formattedBrand = brand
+      if (brand === 'master-card') formattedBrand = 'masterCard'
+      if (brand === 'american-express') formattedBrand = 'amex'
+      return provider === 'google' ? formattedBrand.toUpperCase() : formattedBrand
+    })
+}
 
+const prepareAppleRequestObject = () => {
   let supportedTypes = []
   let merchantCapabilities = []
-  if (!allowedCardTypes.allowed.every(type => type.debit === false)) {
+  if (!allowedCardTypes.every(type => type.debit === false)) {
     supportedTypes.push('debit')
     merchantCapabilities.push('supportsDebit')
   }
 
-  if (!allowedCardTypes.allowed.every(type => type.credit === false)) {
+  if (!allowedCardTypes.every(type => type.credit === false)) {
     supportedTypes.push('credit')
     merchantCapabilities.push('supportsCredit')
   }
@@ -38,7 +48,7 @@ const prepareRequestObject = brand => {
   const supportedInstruments = [{
     supportedMethods: ['basic-card'],
     data: {
-      supportedNetworks,
+      supportedNetworks: supportedNetworksFormattedByProvider('apple'),
       supportedTypes
     }
   }]
@@ -57,44 +67,62 @@ const prepareRequestObject = brand => {
     requestPayerEmail: email_collection_mode !== 'OFF'
   }
 
-  if (brand === 'apple') {
-    const supportedNetworksAppleFormatted = supportedNetworks.map(brand => {
-      if (brand === 'master-card') return 'masterCard'
-      if (brand === 'american-express') return 'amex'
-      return brand
-    }).filter(brand => brand !== 'diners-club')
-      .filter(brand => brand !== 'unionpay')
-
-    if (merchantCapabilities.length < 2) {
-      merchantCapabilities.push('supports3DS')
-    } else {
-      merchantCapabilities = ['supports3DS']
-    }
-
-    const requiredShippingContactFields = email_collection_mode !== 'OFF' ? ['email'] : []
-
-    return {
-      countryCode: 'GB',
-      currencyCode: details.total.amount.currency,
-      total: {
-        label: details.total.label,
-        amount: details.total.amount.value,
-      },
-      supportedNetworks: supportedNetworksAppleFormatted,
-      merchantCapabilities,
-      requiredShippingContactFields,
-    }
+  if (merchantCapabilities.length < 2) {
+    merchantCapabilities.push('supports3DS')
   } else {
-    return {
-      supportedInstruments,
-      details,
-      options
+    merchantCapabilities = ['supports3DS']
+  }
+
+  const requiredShippingContactFields = email_collection_mode !== 'OFF' ? ['email'] : []
+
+  return {
+    countryCode: 'GB',
+    currencyCode: details.total.amount.currency,
+    total: {
+      label: details.total.label,
+      amount: details.total.amount.value,
+    },
+    supportedNetworks: supportedNetworksFormattedByProvider('apple'),
+    merchantCapabilities,
+    requiredShippingContactFields,
+  }
+}
+
+const getGooglePaymentsConfiguration = () => {
+  const allowedCardNetworks = supportedNetworksFormattedByProvider('google')
+  const allowedCardAuthMethods = ['PAN_ONLY', 'CRYPTOGRAM_3DS']
+  const tokenizationSpecification = {
+    type: 'PAYMENT_GATEWAY',
+    parameters: {
+      gateway: 'worldpay',
+      gatewayMerchantId: window.googlePayGatewayMerchantID
     }
+  }
+
+  const cardPaymentMethod = {
+    type: 'CARD',
+    parameters: {
+      allowedAuthMethods: allowedCardAuthMethods,
+      allowedCardNetworks: allowedCardNetworks,
+    },
+    tokenizationSpecification
+  }
+
+  return {
+    environment: 'TEST',
+    apiVersion: 2,
+    apiVersionMinor: 0,
+    merchantInfo: {
+      merchantId: window.googlePayMerchantID,
+      merchantName: 'GOV.UK Pay'
+    },
+    allowedPaymentMethods: [cardPaymentMethod]
   }
 }
 
 module.exports = {
   showErrorSummary,
   clearErrorSummary,
-  prepareRequestObject
+  prepareAppleRequestObject,
+  getGooglePaymentsConfiguration
 }

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -40,14 +40,13 @@
         },
         items: [
           {
-            id: "payment-method-payment-request-apple",
-            value: "payment-request-apple",
-            checked: true,
+            id: "payment-method-apple-pay",
+            value: "apple-pay",
             html: "<img alt='Apple Pay logo' class='payment-request-logo' src='/images/apple-pay-mark.svg'/> Apple Pay"
           },
           {
-            id: "payment-method-payment-request",
-            value: "payment-request",
+            id: "payment-method-google-pay",
+            value: "google-pay",
             html: "<img alt='Google Pay logo' class='payment-request-logo' src='/images/google-pay-mark.svg'/> Google Pay"
           },
           {

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -51,6 +51,10 @@
       analyticsTrackConfirmClick().init('{{analytics.analyticsId}}', '{{analytics.type}}', '{{analytics.paymentProvider}}', '{{analytics.amount}}', '{{hitPage}}');
     }
   });
+  {% if allowWebPayments %}
+    window.googlePayGatewayMerchantID = '{{ googlePayGatewayMerchantID }}';
+    window.googlePayMerchantID = '{{ googlePayMerchantID }}';
+  {% endif %}
 </script>
 {% if isDevelopment %}
 {# <script src="public/javascripts/apple-pay-js-stubs.js"></script> #}

--- a/locales/en.json
+++ b/locales/en.json
@@ -157,6 +157,10 @@
 				"name": "country or territory",
 				"message": "Enter a valid country or territory"
 			}
+		},
+		"webPayments": {
+			"apple": "There was an error contacting Apple Pay, please try again",
+			"google": "There was an error contacting Google Pay, please try again"
 		}
 	}
 }

--- a/server.js
+++ b/server.js
@@ -25,10 +25,9 @@ const session = require('./app/utils/session')
 const i18nConfig = require('./config/i18n')
 
 // Global constants
+const { NODE_ENV, PORT, ANALYTICS_TRACKING_ID, GOOGLE_PAY_GATEWAY_MERCHANT_ID, GOOGLE_PAY_MERCHANT_ID } = process.env
 const CSS_PATH = '/stylesheets/application.css'
 const JAVASCRIPT_PATH = '/javascripts/application.js'
-const PORT = process.env.PORT || 3000
-const { NODE_ENV } = process.env
 const argv = require('minimist')(process.argv.slice(2))
 const unconfiguredApp = express()
 const oneYear = 86400000 * 365
@@ -54,11 +53,13 @@ function initialiseGlobalMiddleware (app) {
 
   app.use(function (req, res, next) {
     res.locals.asset_path = '/public/'
-    if (typeof process.env.ANALYTICS_TRACKING_ID === 'undefined') {
+    res.locals.googlePayGatewayMerchantID = GOOGLE_PAY_GATEWAY_MERCHANT_ID
+    res.locals.googlePayMerchantID = GOOGLE_PAY_MERCHANT_ID
+    if (typeof ANALYTICS_TRACKING_ID === 'undefined') {
       logger.warn('Google Analytics Tracking ID [ANALYTICS_TRACKING_ID] is not set')
       res.locals.analyticsTrackingId = '' // to not break the app
     } else {
-      res.locals.analyticsTrackingId = process.env.ANALYTICS_TRACKING_ID
+      res.locals.analyticsTrackingId = ANALYTICS_TRACKING_ID
     }
     res.locals.session = function () {
       return session.retrieve(req, req.chargeId)
@@ -134,8 +135,8 @@ function initialiseRoutes (app) {
 
 function listen () {
   const app = initialise()
-  app.listen(PORT)
-  logger.log('Listening on port ' + PORT)
+  app.listen(PORT || 3000)
+  logger.log('Listening on port ' + PORT || 3000)
 }
 
 /**

--- a/test/browsered/payment-request.test.js
+++ b/test/browsered/payment-request.test.js
@@ -16,6 +16,6 @@ describe('The charge view', () => {
     }
     const body = render('charge', templateData)
     const $ = cheerio.load(body)
-    $('label[for="payment-method-payment-request-apple"]').text().should.contain('Apple Pay')
+    $('label[for="payment-method-apple-pay"]').text().should.contain('Apple Pay')
   })
 })

--- a/test/test.env
+++ b/test/test.env
@@ -9,3 +9,5 @@ CARDID_HOST=http://cardid.pymnt.localdomain:65530
 APPLE_PAY_STUBS_URL=http://stubs.pymnt.localdomain:65530
 APPLE_PAY_MERCHANT_ID=merchant.uk.gov.service.payments.test
 APPLE_PAY_MERCHANT_DOMAIN=www.pymnt.uk
+GOOGLE_PAY_GATEWAY_MERCHANT_ID=exampleGatewayMerchantId
+GOOGLE_PAY_MERCHANT_ID=01234567890123456789


### PR DESCRIPTION
Previously google pay was really just a vanilla payment request API call.

Refactored to use Google Pay as the payment method using - https://developers.google.com/pay/api/web/guides/paymentrequest/tutorial

Extended helper.js to build the Google request and moved out the common bits to keep things DRY

I’ve gone as far as initiating an Google Pay payment and getting auth and a token back from Google but I haven’t done anything with yet

Also tidied up a few things in the markup to make the definition between
google and apple clearer.
