### PR TITLE
PP-4784 init Google / Apple Pay only if configured

### DIFF
--- a/app/assets/javascripts/browsered/form-input-confirm.js
+++ b/app/assets/javascripts/browsered/form-input-confirm.js
@@ -3,7 +3,7 @@
 // Polyfills introduced as a temporary fix to make Smoketests pass. See PP-3489
 require('./polyfills')
 
-module.exports = () => {
+const init = () => {
   const inputs = Array.prototype.slice.call(document.querySelectorAll('[data-confirmation]'))
 
   inputs.forEach(input => {
@@ -43,4 +43,8 @@ module.exports = () => {
       confirmationText[0].innerText = confirmationPrepend + value
     }
   }
+}
+
+module.exports = {
+  init
 }

--- a/app/assets/javascripts/browsered/web-payments/index.js
+++ b/app/assets/javascripts/browsered/web-payments/index.js
@@ -4,7 +4,7 @@ const { clearErrorSummary } = require('./helpers')
 const makeApplePayRequest = require('./apple-pay')
 const { createGooglePaymentRequest, googlePayNow } = require('./google-pay')
 
-module.exports = () => {
+const init = () => {
   const paymentMethodForm = document.getElementById('payment-request-container')
   const standardMethodContainer = document.getElementById('enter-card-details-container')
 
@@ -44,4 +44,8 @@ module.exports = () => {
       }
     }, false)
   }
+}
+
+module.exports = {
+  init
 }

--- a/app/assets/javascripts/browsered/web-payments/index.js
+++ b/app/assets/javascripts/browsered/web-payments/index.js
@@ -1,33 +1,41 @@
 'use strict'
 
+// Local dependencies
 const { clearErrorSummary } = require('./helpers')
 const makeApplePayRequest = require('./apple-pay')
 const { createGooglePaymentRequest, googlePayNow } = require('./google-pay')
 
-const init = () => {
-  const paymentMethodForm = document.getElementById('payment-request-container')
-  const standardMethodContainer = document.getElementById('enter-card-details-container')
+// Browser elements
+const paymentMethodForm = document.getElementById('payment-request-container')
+const standardMethodContainer = document.getElementById('enter-card-details-container')
 
-  if (window.PaymentRequest && paymentMethodForm) {
-    if (window.ApplePaySession && ApplePaySession.canMakePayments()) {
-      paymentMethodForm.classList.remove('hidden')
-      standardMethodContainer.classList.add('hidden')
-      document.getElementById('payment-method-apple-pay').parentNode.style.display = 'block'
-      document.getElementById('payment-method-apple-pay').checked = true
-    } else {
-      console.log('payment request API is available')
-      const request = createGooglePaymentRequest();
-      request.canMakePayment()
-        .then(result => {
-          if (result) {
-            console.log('Google Pay is available')
-            paymentMethodForm.classList.remove('hidden')
-            standardMethodContainer.classList.add('hidden')
-            document.getElementById('payment-method-google-pay').parentNode.style.display = 'block'
-          }
-        })
-    }
+const initApplePayIfAvailable = () => {
+  if (window.ApplePaySession && ApplePaySession.canMakePayments()) {
+    paymentMethodForm.classList.remove('hidden')
+    standardMethodContainer.classList.add('hidden')
+    document.getElementById('payment-method-apple-pay').parentNode.style.display = 'block'
+    document.getElementById('payment-method-apple-pay').checked = true
+  }
+}
 
+const initGooglePayIfAvailable = () => {
+  if (window.PaymentRequest) {
+    console.log('payment request API is available')
+    const request = createGooglePaymentRequest();
+    request.canMakePayment()
+      .then(result => {
+        if (result) {
+          console.log('Google Pay is available')
+          paymentMethodForm.classList.remove('hidden')
+          standardMethodContainer.classList.add('hidden')
+          document.getElementById('payment-method-google-pay').parentNode.style.display = 'block'
+        }
+      })
+  }
+}
+
+const setupEventListener = () => {
+  if (window.PaymentRequest) {
     paymentMethodForm.addEventListener('submit', function (e) {
       e.preventDefault()
       clearErrorSummary()
@@ -44,6 +52,22 @@ const init = () => {
       }
     }, false)
   }
+}
+
+const init = provider => {
+  switch (provider) {
+    case 'apple':
+      initApplePayIfAvailable()
+      break;
+    case 'google':
+      initGooglePayIfAvailable()
+      break;
+    default:
+      initApplePayIfAvailable()
+      initGooglePayIfAvailable()
+      break;
+  }
+  setupEventListener()
 }
 
 module.exports = {

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,13 +1,14 @@
-const inputConfim = require('./assets/javascripts/browsered/form-input-confirm')
+const inputConfirm = require('./assets/javascripts/browsered/form-input-confirm')
 const webPayments = require('./assets/javascripts/browsered/web-payments')
 const analytics = require('gaap-analytics')
 
 exports.chargeValidation = require('./utils/charge_validation')
 analytics.eventTracking.init()
 
-if (document.getElementById('main-content').classList.contains('charge-new')) {
-  inputConfim()
-  webPayments()
+// Place functions into scope so can trigger in scripts.njk
+window.payScripts = { // eslint-disable-line no-unused-vars
+  inputConfirm,
+  webPayments
 }
 
 // GA tracking if an email typo is spotted

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -40,7 +40,8 @@ const appendChargeForNewView = (charge, req, chargeId) => {
   charge.post_card_action = routeFor('create', chargeId)
   charge.id = chargeId
   charge.post_cancel_action = routeFor('cancel', chargeId)
-  charge.allowWebPayments = charge.gatewayAccount.allowWebPayments
+  charge.allowApplePay = charge.gatewayAccount.allowWebPayments
+  charge.allowGooglePay = charge.gatewayAccount.allowWebPayments
   charge.stubsUrl = process.env.APPLE_PAY_STUBS_URL
 }
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -26,7 +26,7 @@
       </div>
     </div>
 
-  {% if allowWebPayments %}
+  {% if allowApplePay or allowGooglePay %}
     <form id="payment-request-container" class="hidden">
       {{ govukRadios({
         name: "payment-method",

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -48,10 +48,16 @@
     } else if (mainWrap.classList.contains('confirm-page')) {
       analyticsTrackConfirmClick().init('{{analytics.analyticsId}}', '{{analytics.type}}', '{{analytics.paymentProvider}}', '{{analytics.amount}}', '{{hitPage}}');
     }
-    {% if allowWebPayments %}
+    {% if allowGooglePay %}
       window.googlePayGatewayMerchantID = '{{ googlePayGatewayMerchantID }}';
       window.googlePayMerchantID = '{{ googlePayMerchantID }}';
-      window.payScripts.webPayments.init();
+    {% endif %}
+    {% if allowApplePay and allowGooglePay %}
+      window.payScripts.webPayments.init('all');
+    {% elif allowApplePay %}
+      window.payScripts.webPayments.init('apple');
+    {% elif allowGooglePay  %}
+      window.payScripts.webPayments.init('google');
     {% endif %}
   });
 </script>

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -1,4 +1,3 @@
-{# Javascript #}
 <script id="govuk-script-analytics" type="text/javascript">
   {% if translationStrings %}
   var i18n = {{ translationStrings | safe }}
@@ -45,14 +44,16 @@
     if (mainWrap.classList.contains('charge-new')) {
       formValidation();
       showCardType().init();
+      window.payScripts.inputConfirm.init();
     } else if (mainWrap.classList.contains('confirm-page')) {
       analyticsTrackConfirmClick().init('{{analytics.analyticsId}}', '{{analytics.type}}', '{{analytics.paymentProvider}}', '{{analytics.amount}}', '{{hitPage}}');
     }
+    {% if allowWebPayments %}
+      window.googlePayGatewayMerchantID = '{{ googlePayGatewayMerchantID }}';
+      window.googlePayMerchantID = '{{ googlePayMerchantID }}';
+      window.payScripts.webPayments.init();
+    {% endif %}
   });
-  {% if allowWebPayments %}
-    window.googlePayGatewayMerchantID = '{{ googlePayGatewayMerchantID }}';
-    window.googlePayMerchantID = '{{ googlePayMerchantID }}';
-  {% endif %}
 </script>
 {% if isDevelopment %}
 {# <script src="public/javascripts/apple-pay-js-stubs.js"></script> #}

--- a/test/browsered/payment-request.test.js
+++ b/test/browsered/payment-request.test.js
@@ -10,7 +10,7 @@ const { render } = require('../test_helpers/html_assertions')
 describe('The charge view', () => {
   it('should render apple pay button', () => {
     const templateData = {
-      'allowWebPayments': true,
+      'allowApplePay': true,
       'isDevelopment': true,
       'amount': '50.00'
     }


### PR DESCRIPTION
a7eb620 - PP-4784 - Put scripts into window so can conditionally trigger
4febb7c - PP-4784 - introduce concept of enabling Apple / Google Pay individually
* Using allowApplePay and allowGooglePay so we can toggle individually. This hasn’t been done in connector so fudging with change in charge_controller.js
* Split up the initalisation of web payments into different functions and toggling only if browser has the capability.