### PR TITLE
BAU: Fix reliance on assert.strict

### DIFF
--- a/test/middleware/action_name_test.js
+++ b/test/middleware/action_name_test.js
@@ -16,7 +16,7 @@ describe('actionName', function () {
     }
     actionName(req, {}, next)
     expect(next.calledOnce).to.be.true // eslint-disable-line
-    assert.strict.equal(req.actionName, 'card.create')
+    assert.strictEqual(req.actionName, 'card.create')
   })
 
   it('should not append the viewname to the request if it cannot match', function () {
@@ -29,6 +29,6 @@ describe('actionName', function () {
     }
     actionName(req, {}, next)
     expect(next.calledOnce).to.be.true // eslint-disable-line
-    assert.strict.equal(req.actionName, undefined)
+    assert.strictEqual(req.actionName, undefined)
   })
 })

--- a/test/middleware/csrf_test.js
+++ b/test/middleware/csrf_test.js
@@ -102,7 +102,7 @@ describe('retrieve param test', function () {
     csrfCheck(validPost, resp, next)
     csrfTokenGeneration(validGetRequest, resp, next)
     assertValidRequest(next, resp, status, render)
-    assert.strict.equal(validPost.frontend_state.ch_foo.csrfTokens[0], validPost.body.csrfToken)
+    assert.strictEqual(validPost.frontend_state.ch_foo.csrfTokens[0], validPost.body.csrfToken)
   })
 
   it('should be unsuccessful on post if token is already used', function () {

--- a/test/models/charge_test.js
+++ b/test/models/charge_test.js
@@ -30,7 +30,7 @@ describe('updateStatus', function () {
       const chargeModel = Charge('')
       return chargeModel.updateStatus(1, 'ENTERING CARD DETAILS').then(unexpectedPromise,
         function rejected (error) {
-          assert.strict.equal(error.message, 'CLIENT_UNAVAILABLE')
+          assert.strictEqual(error.message, 'CLIENT_UNAVAILABLE')
         })
     })
   })
@@ -46,7 +46,7 @@ describe('updateStatus', function () {
     it('should return update_failed', function () {
       const chargeModel = Charge('')
       return chargeModel.updateStatus(1, 'ENTERING CARD DETAILS').catch(err => {
-        assert.strict.equal(err.message, 'UPDATE_FAILED')
+        assert.strictEqual(err.message, 'UPDATE_FAILED')
       })
     })
   })
@@ -66,7 +66,7 @@ describe('updateStatus', function () {
       const chargeModel = Charge('')
       return chargeModel.updateStatus(1, 'ENTERING CARD DETAILS')
         .then(function (data, response) {
-          assert.strict.equal(data.success, 'OK')
+          assert.strictEqual(data.success, 'OK')
         }, unexpectedPromise)
     })
   })
@@ -82,7 +82,7 @@ describe('find', function () {
       const chargeModel = Charge('')
       return chargeModel.find(1).then(unexpectedPromise,
         function rejected (error) {
-          assert.strict.equal(error.message, 'CLIENT_UNAVAILABLE')
+          assert.strictEqual(error.message, 'CLIENT_UNAVAILABLE')
         })
     })
   })
@@ -100,7 +100,7 @@ describe('find', function () {
       const chargeModel = Charge('')
       return chargeModel.find(1).then(unexpectedPromise,
         function rejected (error) {
-          assert.strict.equal(error.message, 'GET_FAILED')
+          assert.strictEqual(error.message, 'GET_FAILED')
         })
     })
   })
@@ -117,7 +117,7 @@ describe('find', function () {
     it('should return get_failed', function () {
       const chargeModel = Charge('')
       return chargeModel.find(1).then(function (data) {
-        assert.strict.equal(data.foo, 'bar')
+        assert.strictEqual(data.foo, 'bar')
       }, unexpectedPromise)
     })
   })
@@ -150,7 +150,7 @@ describe('capture', function () {
       const chargeModel = Charge('')
       return chargeModel.capture(1).then(unexpectedPromise,
         function rejected (error) {
-          assert.strict.equal(error.message, 'CLIENT_UNAVAILABLE')
+          assert.strictEqual(error.message, 'CLIENT_UNAVAILABLE')
         })
     })
   })
@@ -168,7 +168,7 @@ describe('capture', function () {
       const chargeModel = Charge('')
       return chargeModel.capture(1).then(unexpectedPromise,
         function rejected (error) {
-          assert.strict.equal(error.message, 'CAPTURE_FAILED')
+          assert.strictEqual(error.message, 'CAPTURE_FAILED')
         })
     })
   })
@@ -186,7 +186,7 @@ describe('capture', function () {
       const chargeModel = Charge('')
       return chargeModel.capture(1).then(unexpectedPromise,
         function rejected (error) {
-          assert.strict.equal(error.message, 'POST_FAILED')
+          assert.strictEqual(error.message, 'POST_FAILED')
         })
     })
   })
@@ -202,7 +202,7 @@ describe('findByToken', function () {
       const chargeModel = Charge('')
       return chargeModel.findByToken(1).then(unexpectedPromise,
         function rejected (error) {
-          assert.strict.equal(error.message, 'CLIENT_UNAVAILABLE')
+          assert.strictEqual(error.message, 'CLIENT_UNAVAILABLE')
         })
     })
   })
@@ -220,7 +220,7 @@ describe('findByToken', function () {
       const chargeModel = Charge('')
       return chargeModel.findByToken(1).then(unexpectedPromise,
         function rejected (error) {
-          assert.strict.equal(error.message, 'GET_FAILED')
+          assert.strictEqual(error.message, 'GET_FAILED')
         })
     })
   })
@@ -237,7 +237,7 @@ describe('findByToken', function () {
     it('should return get_failed', function () {
       const chargeModel = Charge('')
       return chargeModel.findByToken(1).then(function (data) {
-        assert.strict.equal(data.foo, 'bar')
+        assert.strictEqual(data.foo, 'bar')
       }, unexpectedPromise)
     })
   })

--- a/test/models/token_test.js
+++ b/test/models/token_test.js
@@ -24,7 +24,7 @@ describe('token model', function () {
       it('should return client unavailable', function () {
         return Token.destroy(1, 'blah').then(wrongPromise,
           function rejected (error) {
-            assert.strict.equal(error.message, 'CLIENT_UNAVAILABLE')
+            assert.strictEqual(error.message, 'CLIENT_UNAVAILABLE')
           })
       })
     })
@@ -43,7 +43,7 @@ describe('token model', function () {
       it('should return delete_failed', function () {
         return Token.destroy(1, 'blah').then(wrongPromise,
           function rejected (error) {
-            assert.strict.equal(error.message, 'DELETE_FAILED')
+            assert.strictEqual(error.message, 'DELETE_FAILED')
           })
       })
     })

--- a/test/services/charge_param_retriever_test.js
+++ b/test/services/charge_param_retriever_test.js
@@ -33,22 +33,22 @@ describe('charge param retreiver', function () {
   }
 
   it('should return false if the charge param is not present in params or body', function () {
-    assert.strict.equal(chargeParam.retrieve(EMPTY_RESPONSE), false)
+    assert.strictEqual(chargeParam.retrieve(EMPTY_RESPONSE), false)
   })
 
   it('should return false if the charge param is in params but not in session', function () {
-    assert.strict.equal(chargeParam.retrieve(NO_SESSION_GET_RESPONSE), false)
+    assert.strictEqual(chargeParam.retrieve(NO_SESSION_GET_RESPONSE), false)
   })
 
   it('should return false if the charge param is in THE BODY but not in session', function () {
-    assert.strict.equal(chargeParam.retrieve(NO_SESSION_POST_RESPONSE), false)
+    assert.strictEqual(chargeParam.retrieve(NO_SESSION_POST_RESPONSE), false)
   })
 
   it('should return THE ID if the charge param is in params and has session', function () {
-    assert.strict.equal(chargeParam.retrieve(VALID_GET_RESPONSE), 'foo')
+    assert.strictEqual(chargeParam.retrieve(VALID_GET_RESPONSE), 'foo')
   })
 
   it('should return false if the charge param is in THE BODY and has session', function () {
-    assert.strict.equal(chargeParam.retrieve(VALID_POST_RESPONSE), 'foo')
+    assert.strictEqual(chargeParam.retrieve(VALID_POST_RESPONSE), 'foo')
   })
 })


### PR DESCRIPTION
`assert.strict` [strict mode](https://nodejs.org/api/assert.html#assert_strict_mode) was introduced in Node v9.9.0. 
The Node version for this repository is
pinned behind this so new features shouldn't be used until this is updated.


