### PR TITLE
PP-4784 - use new web payment flags

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -40,8 +40,8 @@ const appendChargeForNewView = (charge, req, chargeId) => {
   charge.post_card_action = routeFor('create', chargeId)
   charge.id = chargeId
   charge.post_cancel_action = routeFor('cancel', chargeId)
-  charge.allowApplePay = charge.gatewayAccount.allowWebPayments
-  charge.allowGooglePay = charge.gatewayAccount.allowWebPayments
+  charge.allowApplePay = charge.gatewayAccount.allow_apple_pay
+  charge.allowGooglePay = charge.gatewayAccount.allow_google_pay
   charge.stubsUrl = process.env.APPLE_PAY_STUBS_URL
 }
 

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -42,6 +42,7 @@ const appendChargeForNewView = (charge, req, chargeId) => {
   charge.post_cancel_action = routeFor('cancel', chargeId)
   charge.allowApplePay = charge.gatewayAccount.allow_apple_pay
   charge.allowGooglePay = charge.gatewayAccount.allow_google_pay
+  charge.googlePayGatewayMerchantID = charge.gatewayAccount.gateway_merchant_id
   charge.stubsUrl = process.env.APPLE_PAY_STUBS_URL
 }
 

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -48,15 +48,15 @@
     } else if (mainWrap.classList.contains('confirm-page')) {
       analyticsTrackConfirmClick().init('{{analytics.analyticsId}}', '{{analytics.type}}', '{{analytics.paymentProvider}}', '{{analytics.amount}}', '{{hitPage}}');
     }
-    {% if allowGooglePay %}
+    {% if allowGooglePay and googlePayGatewayMerchantID%}
       window.googlePayGatewayMerchantID = '{{ googlePayGatewayMerchantID }}';
       window.googlePayMerchantID = '{{ googlePayMerchantID }}';
     {% endif %}
-    {% if allowApplePay and allowGooglePay %}
+    {% if allowApplePay and allowGooglePay and googlePayGatewayMerchantID%}
       window.payScripts.webPayments.init('all');
     {% elif allowApplePay %}
       window.payScripts.webPayments.init('apple');
-    {% elif allowGooglePay  %}
+    {% elif allowGooglePay and googlePayGatewayMerchantID %}
       window.payScripts.webPayments.init('google');
     {% endif %}
   });

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ const session = require('./app/utils/session')
 const i18nConfig = require('./config/i18n')
 
 // Global constants
-const { NODE_ENV, PORT, ANALYTICS_TRACKING_ID, GOOGLE_PAY_GATEWAY_MERCHANT_ID, GOOGLE_PAY_MERCHANT_ID } = process.env
+const { NODE_ENV, PORT, ANALYTICS_TRACKING_ID, GOOGLE_PAY_MERCHANT_ID } = process.env
 const CSS_PATH = '/stylesheets/application.css'
 const JAVASCRIPT_PATH = '/javascripts/application.js'
 const argv = require('minimist')(process.argv.slice(2))
@@ -53,7 +53,6 @@ function initialiseGlobalMiddleware (app) {
 
   app.use(function (req, res, next) {
     res.locals.asset_path = '/public/'
-    res.locals.googlePayGatewayMerchantID = GOOGLE_PAY_GATEWAY_MERCHANT_ID
     res.locals.googlePayMerchantID = GOOGLE_PAY_MERCHANT_ID
     if (typeof ANALYTICS_TRACKING_ID === 'undefined') {
       logger.warn('Google Analytics Tracking ID [ANALYTICS_TRACKING_ID] is not set')


### PR DESCRIPTION
fcd9a30 - use new separate flags for Apple Pay and Google Pay
e403141 - Gateway Merchant ID is set per service
> Whilst the Google Pay Merchant ID is set by GOV.UK Pay, the merchant ID
that Google need to encrypt the payload with is set per service.
> So this now comes from the charge object.
> Once we integrate digital wallets into selfservice you won’t be
able to switch on Google Pay without providing a Merchant ID, it seems
prudent to add checks that will stop Google Pay initiating without it.