### PR TITLE
PP-4644 - Android complaining about missing object that docs said we …

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -110,12 +110,18 @@ const getGooglePaymentsConfiguration = () => {
   }
 
   return {
+    // environment: window.googlePayMerchantID.length > 0 ? 'PRODUCTION' : 'TEST',
     environment: 'TEST',
     apiVersion: 2,
     apiVersionMinor: 0,
     merchantInfo: {
       merchantId: window.googlePayMerchantID,
       merchantName: 'GOV.UK Pay'
+    },
+    transactionInfo: {
+      totalPriceStatus: 'FINAL',
+      totalPrice: window.paymentDetails.amount,
+      currencyCode: 'GBP'
     },
     allowedPaymentMethods: [cardPaymentMethod]
   }


### PR DESCRIPTION
…shouldnt include

Google state here that the transactionInfo object is required —  https://developers.google.com/pay/api/web/guides/tutorial#paymentdatarequest
But here they say it isnt https://developers.google.com/pay/api/web/guides/paymentrequest/tutorial#parameter-reference

Whilst testing on an Android device we got this error
> WalletMerchantError: Error in loadWebPaymentData: PaymentDataRequest.transactionInfo is required!

So we’re adding it anyway to see if this fixes it, it doesn’t break it
on Chrome on desktop
