### PR TITLE
PP-4824 - Cypress tests for Google Pay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ pacts
 /cypress
 /test/cypress/screenshots
 /test/cypress/videos
-
+mb.pid

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -21,7 +21,8 @@ const processPayment = paymentData => {
     }
   })
   .catch(err => {
-    console.log('something went wrong', err)
+    showErrorSummary(i18n.fieldErrors.webPayments.failureTitle, i18n.fieldErrors.webPayments.failureBody)
+    ga('send', 'event', 'Google Pay', 'Error', 'During authorisation/capture');
   })
 }
 
@@ -54,11 +55,10 @@ const googlePayNow = () => {
     .show()
     .then(response => {
       response.complete('success');
-      console.log('payment data', response)
       processPayment(response);
     })
-    .catch(err => {
-      console.error('uh oh', err)
+    .catch(dismissed => {
+      ga('send', 'event', 'Google Pay', 'Aborted', 'by user');
     })
 }
 

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -12,13 +12,15 @@ const processPayment = paymentData => {
       'Content-Type': 'application/json'
     },
     body: JSON.stringify(paymentData)
-  }).then(response => {
+  })
+  .then(response => {
     if (response.status >= 200 && response.status < 300) {
       return response.json().then(data => {
         window.location.href = data.url
       })
     }
-  }).catch(err => {
+  })
+  .catch(err => {
     console.log('something went wrong', err)
   })
 }

--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -4,10 +4,15 @@ const allowedCardTypes = window.Card.allowed || {}
 const { email_collection_mode } = window.Charge || {}
 const { collect_billing_address } = window.Charge || {}
 
-const showErrorSummary = title => {
+const showErrorSummary = (title, body) => {
   const errorSummary = document.getElementById('error-summary')
   errorSummary.classList.remove('hidden')
   errorSummary.querySelectorAll('h2')[0].innerText = title
+  if (body) {
+    const error = document.createElement('li')
+    error.innerText = body
+    errorSummary.querySelectorAll('ul')[0].appendChild(error)
+  }
 }
 
 const clearErrorSummary = () => {

--- a/app/assets/javascripts/browsered/web-payments/index.js
+++ b/app/assets/javascripts/browsered/web-payments/index.js
@@ -21,8 +21,8 @@ const initApplePayIfAvailable = () => {
 const initGooglePayIfAvailable = () => {
   if (window.PaymentRequest) {
     console.log('payment request API is available')
-    const request = createGooglePaymentRequest();
-    request.canMakePayment()
+    createGooglePaymentRequest()
+      .canMakePayment()
       .then(result => {
         if (result) {
           console.log('Google Pay is available')

--- a/app/assets/javascripts/browsered/web-payments/index.js
+++ b/app/assets/javascripts/browsered/web-payments/index.js
@@ -20,12 +20,10 @@ const initApplePayIfAvailable = () => {
 
 const initGooglePayIfAvailable = () => {
   if (window.PaymentRequest) {
-    console.log('payment request API is available')
     createGooglePaymentRequest()
       .canMakePayment()
       .then(result => {
         if (result) {
-          console.log('Google Pay is available')
           paymentMethodForm.classList.remove('hidden')
           standardMethodContainer.classList.add('hidden')
           document.getElementById('payment-method-google-pay').parentNode.style.display = 'block'

--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -31,7 +31,6 @@ module.exports = payload => {
   }
 
   const paymentData = humps.decamelizeKeys(JSON.parse(payload.details.paymentMethodData.tokenizationData.token))
-  console.log(paymentData)
   delete payload.details.paymentMethodData
 
   return {

--- a/locales/en.json
+++ b/locales/en.json
@@ -160,7 +160,8 @@
 		},
 		"webPayments": {
 			"apple": "There was an error contacting Apple Pay, please try again",
-			"google": "There was an error contacting Google Pay, please try again"
+			"failureTitle": "There was a problem processing your payment.",
+			"failureBody": "No money has been taken from your account, please try again"
 		}
 	}
 }

--- a/test/cypress/integration/web payment/google-pay.spec.js
+++ b/test/cypress/integration/web payment/google-pay.spec.js
@@ -1,0 +1,117 @@
+describe('Google Pay payment flow', () => {
+  const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
+  const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
+  const returnURL = '?success'
+
+  const validPaymentRequestResponse = {
+    details: {
+      apiVersionMinor: 0,
+      apiVersion: 2,
+      paymentMethodData: {
+        description: 'Mastercard •••• 4242',
+        info: {
+          cardNetwork: 'MASTERCARD',
+          cardDetails: '4242'
+        },
+        tokenizationData: {
+          type: 'PAYMENT_GATEWAY',
+          token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+        },
+        type: 'CARD'
+      }
+    },
+    payerEmail: 'name@email.fyi',
+    payerName: 'Some Name',
+    complete: () => true
+  }
+
+  const createPaymentChargeStubs = [
+    { name: 'connectorCreateChargeFromToken', opts: { tokenId } },
+    { name: 'connectorDeleteToken', opts: { tokenId } },
+    { name: 'connectorGetChargeDetails',
+      opts: {
+        chargeId,
+        status: 'CREATED',
+        state: { finished: false, status: 'created' }
+      }
+    },
+    { name: 'connectorUpdateChargeStatus', opts: { chargeId } },
+
+    // @TODO(sfount) this should pass the service to be queried relative to the charge - right now it just returns a default service
+    { name: 'adminUsersGetService' }
+  ]
+
+  const checkCardDetailsStubs = [
+    {
+      name: 'connectorGetChargeDetails',
+      opts: {
+        chargeId,
+        status: 'ENTERING CARD DETAILS',
+        state: { finished: false, status: 'started' },
+        allowGooglePay: true,
+        gatewayMerchantId: 'SMTHG12345UP'
+      }
+    },
+    { name: 'cardIdValidCardDetails' }
+  ]
+
+  const mockPaymentRequest = () => {
+    return {
+      canMakePayment: () => new Promise(resolve => resolve(true)),
+      show: () => new Promise(resolve => resolve(validPaymentRequestResponse))
+    }
+  }
+
+  const mockPaymentAuthResponse = () => {
+    return new Promise(resolve => resolve({
+      status: 200,
+      json: () => new Promise(resolve => resolve({ url: `/${returnURL}` }))
+    }))
+  }
+
+  beforeEach(() => {
+    // this test is for the full process, the session should be maintained
+    // as it would for an actual payment flow
+    Cypress.Cookies.preserveOnce('frontend_state')
+  })
+
+  describe('Secure card payment page', () => {
+    it('Should setup the payment and load the page', () => {
+      cy.task('setupStubs', createPaymentChargeStubs)
+      cy.visit(`/secure/${tokenId}`)
+
+      // 1. Charge will be created using this id as a token (GET)
+      // 2. Token will be deleted (DELETE)
+      // 3. Charge will be fetched (GET)
+      // 4. Service related to charge will be fetched (GET)
+      // 5. Charge status will be updated (PUT)
+      // 6. Client will be redirected to /card_details/:chargeId (304)
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+    })
+
+    it('Should show Google Pay as a payment option', () => {
+      cy.task('setupStubs', checkCardDetailsStubs)
+      cy.visit(`/card_details/${chargeId}`, {
+        onBeforeLoad: win => {
+          // Stub Payment Request API
+          cy.stub(win, 'PaymentRequest', mockPaymentRequest)
+          // Stub fetch so we can simulate auth call to connector
+          cy.stub(win, 'fetch', mockPaymentAuthResponse)
+        }
+      })
+
+      // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Google Pay
+      cy.get('#payment-method-google-pay').should('be.visible')
+      cy.get('#payment-method-google-pay').click()
+      cy.get('#payment-method-submit').should('be.visible')
+      cy.get('#payment-method-submit').click()
+
+      // 8. User clicks though the native payment UI and passes their tokenised card data to the auth request handler
+      // 9. The auth response comes back from connector and frontend sends capture request and redirects the user the success page
+      cy.location().should((loc) => {
+        expect(loc.pathname).to.eq('/')
+        expect(loc.search).to.eq(returnURL)
+      })
+    })
+  })
+})

--- a/test/cypress/integration/web payment/google-pay.spec.js
+++ b/test/cypress/integration/web payment/google-pay.spec.js
@@ -94,7 +94,13 @@ describe('Google Pay payment flow', () => {
       cy.visit(`/card_details/${chargeId}`, {
         onBeforeLoad: win => {
           // Stub Payment Request API
-          cy.stub(win, 'PaymentRequest', mockPaymentRequest)
+          if (win.PaymentRequest) {
+            // If we’re running in headed mode
+            cy.stub(win, 'PaymentRequest', mockPaymentRequest)
+          } else {
+            // else headless
+            win.PaymentRequest = mockPaymentRequest
+          }
           // Stub fetch so we can simulate auth call to connector
           cy.stub(win, 'fetch', mockPaymentAuthResponse)
         }

--- a/test/fixtures/payment_fixtures.js
+++ b/test/fixtures/payment_fixtures.js
@@ -2,9 +2,10 @@
 const buildGatewayAccount = function buildGatewayAccount (opts = {}) {
   const structure = {
     'gateway_account_id': opts.gatewayAccountId || 6,
-    'allowWebPayments': false,
-    'allow_apple_pay': false,
-    'allow_google_pay': false,
+    'allowWebPayments': opts.allowWebPayments || false,
+    'allowApplePay': opts.allowApplePay || false,
+    'allowGooglePay': opts.allowGooglePay || false,
+    'gatewayMerchantId': opts.gatewayMerchantId || '',
     'analytics_id': null,
     card_types: buildStandardSupportedCardTypes(),
     'corporate_credit_card_surcharge_amount': 0, // are these needed?
@@ -199,7 +200,7 @@ const fixtures = {
       'description': opts.description || 'Example fixture payment',
       'email': null,
       'externalId': opts.chargeId || 'ub8de8r5mh4pb49rgm1ismaqfv',
-      gatewayAccount: buildGatewayAccount(opts),
+      'gatewayAccount': buildGatewayAccount(opts),
       'gatewayTransactionId': null,
       'language': 'ENGLISH',
       'paymentGatewayName': 'SANDBOX',


### PR DESCRIPTION
Stubbed out PaymentRequest and Fetch so that I can intercept the native browser methods and return what I expect from them. 

Whilst stubbing PaymentRequest API is neccessary perhaps could it might be nice to not stub fetch and then stub the connector calls the controllers make. But it [turns out you cannot use Cypress’s `route()` method to intercept fetch calls](https://docs.cypress.io/api/commands/route.html) so doing so would be tricky. As unit tests exist for the controllers perhaps the stub is ok after all.

Also made Google Pay specific fixtures editable