### PR TITLE
PP-4876 Make address line 1 autocomplete be “address-line1”

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -278,7 +278,7 @@
                   maxlength="100"
                   class="govuk-input govuk-!-width-two-thirds"
                   value="{{ addressLine1 }}"
-                  autocomplete="billing street-address"/>
+                  autocomplete="billing address-line1"/>
           <input id="address-line-2"
                   type="text"
                   name="addressLine2"


### PR DESCRIPTION
On the card details page, change the autocomplete attribute for the first address line from `street-address` to `address-line1`.

Currently, we have `street-address` for the first line of the address and `address-line2` for the second line of the address. This can make Google Chrome duplicate data when auto-filling (e.g. putting “1 Foo Street, Barton” in the first address line and “Barton” in the second address line).

with @alexbishop1

