### PR TITLE
PP-4921 Don't attempt to cancel CAPTURE_READY charges

### DIFF
--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -14,7 +14,6 @@ const CANCELABLE_STATES = [
   StateModel.ENTERING_CARD_DETAILS,
   StateModel.AUTH_SUCCESS,
   StateModel.AUTH_READY,
-  StateModel.CAPTURE_READY,
   StateModel.AUTH_3DS_REQUIRED,
   StateModel.AUTH_3DS_READY
 ]


### PR DESCRIPTION
The return controller was attempting to cancel charges that are in the CAPTURE_READY state. As far as frontend is concerned, this is a terminal state so it should never attempt to cancel charges in this state.

with @cobainc0
