### PR TITLE
BAU: Cleanup stubs before instead of after specs

### DIFF
--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -14,7 +14,6 @@ module.exports = (on, config) => {
   on('task', {
     setupStubs (specs) {
       // spec has name and options - passed into stub generator for a given name
-      // @TODO(sfount) clearly define what this method expects, consider how this name lookup works
       const stubs = lodash.flatMap(specs, spec => stubGenerators[spec.name](spec.opts))
 
       return requestPromise({

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -1,3 +1,3 @@
 require('./commands')
 
-afterEach(() => { cy.task('clearStubs') })
+beforeEach(() => { cy.task('clearStubs') })


### PR DESCRIPTION
As per Cypress best practices we should clear up stubs state runners
before running tests rather than after. Ref:
https://docs.cypress.io/guides/references/best-practices.html#Using-after-or-afterEach-hooks

