### PR TITLE
PP-4927 - maintain web payments flow after auth waiting

### DIFF
--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -32,6 +32,9 @@ module.exports = (function () {
     if (charge.total_amount) {
       chargeObj.totalAmount = penceToPounds(charge.total_amount)
     }
+    if (charge.wallet_type) {
+      chargeObj.walletType = charge.wallet_type
+    }
     return chargeObj
   }
 

--- a/test/test_helpers/test_helpers.js
+++ b/test/test_helpers/test_helpers.js
@@ -106,11 +106,11 @@ function rawSuccessfulGetChargeDebitCardOnly (status, returnUrl, chargeId, gatew
   return charge
 }
 
-function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, emailSettings, disableBillingAddress) {
-  return rawSuccessfulGetChargeWithPaymentProvider(status, returnUrl, chargeId, gatewayAccountId, auth3dsData, 'sandbox', emailSettings, disableBillingAddress)
+function rawSuccessfulGetCharge (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, emailSettings, disableBillingAddress, walletType) {
+  return rawSuccessfulGetChargeWithPaymentProvider(status, returnUrl, chargeId, gatewayAccountId, auth3dsData, 'sandbox', emailSettings, disableBillingAddress, walletType)
 }
 
-function rawSuccessfulGetChargeWithPaymentProvider (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, paymentProvider = 'sandbox', emailSettings, disableBillingAddress) {
+function rawSuccessfulGetChargeWithPaymentProvider (status, returnUrl, chargeId, gatewayAccountId, auth3dsData = {}, paymentProvider = 'sandbox', emailSettings, disableBillingAddress, walletType) {
   const charge = {
     'amount': 2345,
     'description': 'Payment Description',
@@ -220,6 +220,9 @@ function rawSuccessfulGetChargeWithPaymentProvider (status, returnUrl, chargeId,
   if (disableBillingAddress) {
     charge.card_details.billing_address = null
   }
+  if (walletType) {
+    charge.wallet_type = walletType
+  }
   return charge
 }
 
@@ -290,9 +293,9 @@ module.exports = {
     adminusersRespondsWith(gatewayAccountId, serviceResponse)
   },
 
-  defaultConnectorResponseForGetCharge: function (chargeId, status, gatewayAccountId, returnUrl = 'http://www.example.com/service') {
+  defaultConnectorResponseForGetCharge: function (chargeId, status, gatewayAccountId, returnUrl = 'http://www.example.com/service', walletType = null) {
     initConnectorUrl()
-    const rawResponse = rawSuccessfulGetCharge(status, returnUrl, chargeId, gatewayAccountId)
+    const rawResponse = rawSuccessfulGetCharge(status, returnUrl, chargeId, gatewayAccountId, {}, '', '', walletType)
     connectorRespondsWith(chargeId, rawResponse)
   },
 


### PR DESCRIPTION
Sometimes a card cannot be auth’d immediately, in this case 202/409 is return and [we wait](https://github.com/alphagov/pay-frontend/blob/master/app/views/auth_waiting.njk#L27).

Once the auth is complete the flow went back to non Apple/Google Pay flow which meant users would see the confirm page, which we dont want.

This adds logic to check if it’s a digital wallet payment and if so immediately does the auth and then redirects to the service’s returnURL