### PR TITLE
PP-4914 - abort session when merchant validation fails

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -30,6 +30,7 @@ module.exports = () => {
       .then(response => {
         session.completeMerchantValidation(response)
       }).catch(err => {
+        session.abort()
         showErrorSummary(i18n.fieldErrors.webPayments.apple)
         ga('send', 'event', 'Apple Pay', 'Error', 'Error completing Merchant validation')
         return err
@@ -57,5 +58,6 @@ module.exports = () => {
       }
     })
   }
+
   session.begin()
 }


### PR DESCRIPTION
When merchant validation fails under certain cicumstances the Apple Pay dialog didnt disappear, this is confusing and a waste of time for the user. Added in a line to abort the session when this happens (which it shouldnt once we sort out the certs issue a la #697 