### PR TITLE
PP-4901 - Log error when Google Pay availablity check fails

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/index.js
+++ b/app/assets/javascripts/browsered/web-payments/index.js
@@ -28,6 +28,8 @@ const initGooglePayIfAvailable = () => {
           standardMethodContainer.classList.add('hidden')
           document.getElementById('payment-method-google-pay').parentNode.style.display = 'block'
         }
+      }).catch(err => {
+        ga('send', 'event', 'Google Pay', 'Error', 'Failed to check if Google Pay available')
       })
   }
 }


### PR DESCRIPTION
We have seen intermitant behaviour where Google Pay fails to check if
it’s available, this seems related to this

`Unable to download payment manifest
"https://pay.google.com/gp/p/payment_method_manifest.json"`

So going to log to Google Anayltics to we can see how often this
happens, Google have given us no indication why this happens except to
tell us that we should use their 3rd party API (which adds at least 10
tracking scripts to the page)  as opposed to the open
standard payment request API.