### PR TITLE
PP-4939 Propagate service middleware errors

### DIFF
--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -7,15 +7,18 @@ const lodash = require('lodash')
 
 // Local dependencies
 const responseRouter = require('../utils/response_router')
-const CORRELATION_HEADER = require('../../config/correlation_header').CORRELATION_HEADER
-const withAnalyticsError = require('../utils/analytics').withAnalyticsError
+const { CORRELATION_HEADER } = require('../../config/correlation_header')
+const { withAnalyticsError } = require('../utils/analytics')
 const getAdminUsersClient = require('../services/clients/adminusers_client')
 
 // Constants
 const SERVICE_CACHE_MAX_AGE = parseInt(process.env.SERVICE_CACHE_MAX_AGE || 15 * 60 * 1000) // default to 15 mins
 const serviceCache = new Cache()
 
-module.exports = (req, res, next) => {
+// @FIXME(sfount) we should NOT return directly from this middleware if something
+//                is an issue in favour of correctly passing an new Error object
+//                through to `next`
+module.exports = function resolveServiceMiddleware (req, res, next) {
   const gatewayAccountId = lodash.get(req, 'chargeData.gateway_account.gateway_account_id')
   if (!req.chargeId && !req.chargeData) return responseRouter.response(req, res, 'UNAUTHORISED', withAnalyticsError())
   const cachedService = serviceCache.get(gatewayAccountId)
@@ -23,7 +26,7 @@ module.exports = (req, res, next) => {
     res.locals.service = cachedService
     next()
   } else {
-    return getAdminUsersClient({ correlationId: req.headers[CORRELATION_HEADER] })
+    getAdminUsersClient({ correlationId: req.headers[CORRELATION_HEADER] })
       .findServiceBy({ gatewayAccountId })
       .then(service => {
         serviceCache.put(gatewayAccountId, service, SERVICE_CACHE_MAX_AGE)

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -26,7 +26,9 @@ module.exports = function resolveServiceMiddleware (req, res, next) {
     res.locals.service = cachedService
     next()
   } else {
-    getAdminUsersClient({ correlationId: req.headers[CORRELATION_HEADER] })
+    // @FIXME(sfount) tests shouldn't rely on middleware returning a value if
+    //                it is not used by the middleware stack - revisit this structure
+    return getAdminUsersClient({ correlationId: req.headers[CORRELATION_HEADER] })
       .findServiceBy({ gatewayAccountId })
       .then(service => {
         serviceCache.put(gatewayAccountId, service, SERVICE_CACHE_MAX_AGE)

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -4,7 +4,7 @@
 const baseClient = require('./base_client/base_client')
 const requestLogger = require('../../utils/request_logger')
 const Service = require('../../models/Service.class')
-const createCallbackToPromiseConverter = require('../../utils/response_converter').createCallbackToPromiseConverter
+const { createCallbackToPromiseConverter } = require('../../utils/response_converter')
 
 // Constants
 const SERVICE_NAME = 'adminusers'
@@ -14,7 +14,7 @@ const responseBodyToServiceTransformer = body => new Service(body)
 let baseUrl
 let correlationId
 
-const findServiceBy = (findOptions) => {
+const findServiceBy = function findServiceBy (findOptions) {
   return new Promise(function (resolve, reject) {
     const servicesResource = `${baseUrl}/v1/api/services`
     const params = {
@@ -24,6 +24,10 @@ const findServiceBy = (findOptions) => {
       }
     }
     const startTime = new Date()
+
+    // @FIXME(sfount) we should NOT be passing the resolve/ reject of a promise
+    //                down through 'cotext' - this tightly couples the code and
+    //                gives us no control of when our code handles errors
     const context = {
       url: servicesResource,
       defer: { resolve, reject },

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -9,7 +9,14 @@ const { createCallbackToPromiseConverter } = require('../../utils/response_conve
 // Constants
 const SERVICE_NAME = 'adminusers'
 
-const responseBodyToServiceTransformer = body => new Service(body)
+const responseBodyToServiceTransformer = function responseBodyToServiceTransformer (body) {
+  try {
+    const service = new Service(body)
+    return Promise.resolve(service)
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}
 
 let baseUrl
 let correlationId


### PR DESCRIPTION
Service middleware admin users base client resolves a callback method
that doesn't handle errors - ensure that errors are thrown correctly in
a Promise chain when the callback is resolved.

Should follow after PP-4939 checking to see if properties on service exists.