### PR TITLE
PP-4939 Fix error when service has organisation name but not address

### DIFF
--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -1,8 +1,5 @@
 'use strict'
 
-// NPM dependencies
-const lodash = require('lodash')
-
 // Local dependencies
 const countries = require('../services/countries')
 
@@ -38,29 +35,15 @@ class Service {
       addressLine2: serviceData.merchant_details.address_line2,
       city: serviceData.merchant_details.address_city,
       postcode: serviceData.merchant_details.address_postcode,
-      countryName: countries.translateCountryISOtoName(serviceData.merchant_details.address_country)
+      countryName: serviceData.merchant_details.address_country ? countries.translateCountryISOtoName(serviceData.merchant_details.address_country) : undefined
     } : undefined
-  }
 
-  /**
-   * @method hasCustomBranding
-   * @returns {boolean} if the service got a non-GOV.UK branding
-   */
-  hasCustomBranding () {
-    return !lodash.isEmpty(this.customBranding)
-  }
-
-  /**
-   * @method hasMerchantDetails
-   *
-   * All services must have merchant details defined for all gateway accounts
-   * This will be kept as backward compatibility until merchant details are
-   * enforced.
-   *
-   * @returns {boolean} if the service got merchant details specified
-   */
-  hasMerchantDetails () {
-    return !lodash.isEmpty(this.merchantDetails)
+    this.hasCompleteMerchantDetailsAddress = !!(
+      this.merchantDetails &&
+      this.merchantDetails.addressLine1 &&
+      this.merchantDetails.city &&
+      this.merchantDetails.postcode &&
+      this.merchantDetails.countryName)
   }
 }
 

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -88,12 +88,12 @@
               </a>
             </li>
           </ul>
-          {% if service and service.merchantDetails %}
+          {% if service and service.merchantDetails and service.merchantDetails.name %}
             <ul class="govuk-footer__inline-list merchant-details">
               <li class="govuk-footer__inline-list-item merchant-details-line-1">Service provided by {{ service.merchantDetails.name }}</li>
-              <li class="govuk-footer__inline-list-item merchant-details-line-2">{{ service.merchantDetails.addressLine1 }},
-                {% if service.merchantDetails.addressLine2 %} {{ service.merchantDetails.addressLine2 }}, {% endif %}
-                {{ service.merchantDetails.city }} {{ service.merchantDetails.postcode }} {{ service.merchantDetails.countryName }}</li>
+              {% if service.hasCompleteMerchantDetailsAddress %}
+              <li class="govuk-footer__inline-list-item merchant-details-line-2">{{ service.merchantDetails.addressLine1 }}, {% if service.merchantDetails.addressLine2 -%} {{ service.merchantDetails.addressLine2 }}, {% endif -%} {{ service.merchantDetails.city }} {{ service.merchantDetails.postcode }} {{ service.merchantDetails.countryName }}</li>
+              {% endif %}
             </ul>
           {% endif %}
           <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -12,7 +12,6 @@ const renderTemplate = require(path.join(__dirname, '/test_helpers/html_assertio
 // Constants
 const customBrandingData = {
   service: {
-    hasCustomBranding: true,
     customBranding: {
       cssUrl: 'css url',
       imageUrl: 'image url'

--- a/test/cypress/integration/card/footer.spec.js
+++ b/test/cypress/integration/card/footer.spec.js
@@ -1,0 +1,106 @@
+const lodash = require('lodash')
+const cardPaymentStubs = require('../../utils/card-payment-stubs')
+
+describe('The footer displayed on payment pages', () => {
+  const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
+  const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
+
+  beforeEach(() => {
+    cy.sessionCookie(chargeId)
+  })
+
+  it('should display the service name and address when service has full organisation details', () => {
+    // use a unique gateway account id per test as services are cached
+    const gatewayAccountId = lodash.random(999999999)
+    const serviceOpts = {
+      gateway_account_ids: [gatewayAccountId],
+      merchant_details: {
+        name: 'Org',
+        address_line1: 'Street',
+        address_line2: 'Borough',
+        address_city: 'City',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
+      }
+    }
+
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.visit(`/secure/${tokenId}`)
+
+    cy.get('.merchant-details').should('exist')
+    cy.get('.merchant-details-line-1').should('have.text', 'Service provided by Org')
+    cy.get('.merchant-details-line-2').should('have.text', 'Street, Borough, City AW1H 9UX United Kingdom')
+  })
+
+  it('should display the service name and address when service does not have a second line', () => {
+    const gatewayAccountId = lodash.random(999999999)
+    const serviceOpts = {
+      gateway_account_ids: [gatewayAccountId],
+      merchant_details: {
+        name: 'Org',
+        address_line1: 'Street',
+        address_city: 'City',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
+      }
+    }
+
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.visit(`/secure/${tokenId}`)
+
+    cy.get('.merchant-details').should('exist')
+    cy.get('.merchant-details-line-1').should('have.text', 'Service provided by Org')
+    cy.get('.merchant-details-line-2').should('have.text', 'Street, City AW1H 9UX United Kingdom')
+  })
+
+  it('should display just the service name when mandatory address fields are missing', () => {
+    const gatewayAccountId = lodash.random(999999999)
+    const serviceOpts = {
+      gateway_account_ids: [gatewayAccountId],
+      merchant_details: {
+        name: 'Org',
+        address_city: 'City',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
+      }
+    }
+
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.visit(`/secure/${tokenId}`)
+
+    cy.get('.merchant-details').should('exist')
+    cy.get('.merchant-details-line-1').should('have.text', 'Service provided by Org')
+    cy.get('.merchant-details-line-2').should('not.exist')
+  })
+
+  it('should not display the service details if there are no organisation for the service', () => {
+    const gatewayAccountId = lodash.random(999999999)
+    const serviceOpts = {
+      gateway_account_ids: [gatewayAccountId],
+      merchant_details: null
+    }
+
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.visit(`/secure/${tokenId}`)
+
+    cy.get('.merchant-details').should('not.exist')
+  })
+
+  it('should not display the service details if there is an organisation address but no organisation name', () => {
+    const gatewayAccountId = lodash.random(999999999)
+    const serviceOpts = {
+      gateway_account_ids: [gatewayAccountId],
+      merchant_details: {
+        address_line1: 'Street',
+        address_city: 'City',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
+      }
+    }
+
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.visit(`/secure/${tokenId}`)
+
+    cy.get('.merchant-details').should('not.exist')
+  })
+})

--- a/test/cypress/integration/card/payment.spec.js
+++ b/test/cypress/integration/card/payment.spec.js
@@ -1,3 +1,5 @@
+const cardPaymentStubs = require('../../utils/card-payment-stubs')
+
 describe('Standard card payment flow', () => {
   const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
   const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
@@ -14,21 +16,7 @@ describe('Standard card payment flow', () => {
     email: 'validpayingemail@example.com'
   }
 
-  const createPaymentChargeStubs = [
-    { name: 'connectorCreateChargeFromToken', opts: { tokenId } },
-    { name: 'connectorDeleteToken', opts: { tokenId } },
-    { name: 'connectorGetChargeDetails',
-      opts: {
-        chargeId,
-        status: 'CREATED',
-        state: { finished: false, status: 'created' }
-      }
-    },
-    { name: 'connectorUpdateChargeStatus', opts: { chargeId } },
-
-    // @TODO(sfount) this should pass the service to be queried relative to the charge - right now it just returns a default service
-    { name: 'adminUsersGetService' }
-  ]
+  const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId)
 
   const checkCardDetailsStubs = [
     { name: 'connectorGetChargeDetails',

--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -1,4 +1,5 @@
 const paymentFixtures = require('./../../fixtures/payment_fixtures')
+const serviceFixtures = require('./../../fixtures/service_fixtures')
 
 const JSONRequestHeader = { 'Accept': 'application/json' }
 const JSONResponseHeader = { 'Content-Type': 'application/json' }
@@ -45,7 +46,7 @@ module.exports = {
   // @TODO(sfount) this should only match the query string with the - service ID provided
   adminUsersGetService: (opts = {}) => {
     const path = '/v1/api/services'
-    const body = paymentFixtures.validService()
+    const body = serviceFixtures.validServiceResponse(opts).getPlain()
 
     return simpleStubBuilder('GET', 200, path, body)
   },

--- a/test/cypress/utils/card-payment-stubs.js
+++ b/test/cypress/utils/card-payment-stubs.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const buildCreatePaymentChargeStubs = function buildCreatePaymentChargeStubs (tokenId, chargeId, gatewayAccountId = 42, serviceOpts = {}) {
+  return [
+    { name: 'connectorCreateChargeFromToken', opts: { tokenId, gatewayAccountId } },
+    { name: 'connectorDeleteToken', opts: { tokenId } },
+    {
+      name: 'connectorGetChargeDetails',
+      opts: {
+        chargeId,
+        gatewayAccountId,
+        status: 'CREATED',
+        state: { finished: false, status: 'created' }
+      }
+    },
+    { name: 'connectorUpdateChargeStatus', opts: { chargeId } },
+
+    // @TODO(sfount) this should pass the service to be queried relative to the charge - right now it just returns a default service
+    { name: 'adminUsersGetService', opts: serviceOpts }
+  ]
+}
+
+module.exports = { buildCreatePaymentChargeStubs }

--- a/test/fixtures/payment_fixtures.js
+++ b/test/fixtures/payment_fixtures.js
@@ -163,31 +163,6 @@ const buildChargeDetails = function buildChargeDetails (opts) {
   return structure
 }
 
-const buildService = function buildService (opts = {}) {
-  const gatewayAccountIds = opts.gateway_account_ids || [ '6' ]
-  const externalId = opts.external_id || 'c0e046482d034c2e8392e543d5f4914e'
-  const structure = {
-    'id': opts.id || 6,
-    external_id: externalId,
-    'name': 'System Generated',
-    gateway_account_ids: gatewayAccountIds,
-    '_links': [
-      {
-        'rel': 'self',
-        'method': 'GET',
-        'href': `http://localhost:8080/v1/api/services/${externalId}`
-      }
-    ],
-    'service_name': {
-      'en': (opts.service_name && opts.service_name.en) || 'Default fixture service'
-    },
-    'redirect_to_service_immediately_on_terminal_state': false,
-    'collect_billing_address': true,
-    'current_go_live_stage': 'NOT_STARTED'
-  }
-  return structure
-}
-
 const fixtures = {
   // intitial charge details returned have different API surface than charge others
   validChargeCreatedByToken: (opts = {}) => {
@@ -220,7 +195,6 @@ const fixtures = {
   },
 
   validChargeDetails: (opts = {}) => buildChargeDetails(opts),
-  validService: (opts = {}) => buildService(opts),
   validChargeCardDetailsAuthorised: () => ({ 'status': 'AUTHORISATION SUCCESS' }),
 
   validCardDetails: () => {

--- a/test/fixtures/service_fixtures.js
+++ b/test/fixtures/service_fixtures.js
@@ -1,31 +1,55 @@
 'use strict'
 
+// NPM dependencies
+const lodash = require('lodash')
+
 // Local dependencies
 const pactBase = require('./pact_base')
-const random = require('../../app/utils/random')
 
 // Global setup
 const pactServices = pactBase({ array: ['service_ids'] })
 
 module.exports = {
-  validServiceResponse: (serviceData = {}) => {
-    const defaultCustomBranding = { css_url: 'css url', image_url: 'image url' }
-    const defaultMerchantDetails = {
-      name: 'Give Me Your Money',
-      address_line1: 'Clive House',
-      address_line2: '10 Downing Street',
-      address_city: 'London',
-      address_postcode: 'AW1H 9UX',
-      address_country: 'GB'
-    }
+  validServiceResponse: (opts = {}) => {
+    let defaultServiceName = 'service name'
     const data = {
-      external_id: serviceData.external_id || random.randomUuid(),
-      name: serviceData.name || 'service name',
-      gateway_account_ids: serviceData.gateway_account_ids || [random.randomInt(1, 9999999)],
-      custom_branding: serviceData.custom_branding || defaultCustomBranding,
-      merchant_details: serviceData.merchant_details || defaultMerchantDetails,
-      redirect_to_service_immediately_on_terminal_state: serviceData.redirect_to_service_immediately_on_terminal_state === true,
-      collect_billing_address: typeof serviceData.collect_billing_address === 'undefined' || serviceData.collect_billing_address
+      external_id: opts.external_id || 'external-id',
+      name: opts.name || defaultServiceName,
+      gateway_account_ids: opts.gateway_account_ids || [lodash.random(9999999)],
+      service_name: {
+        'en': { en: opts.name || defaultServiceName }
+      },
+      redirect_to_service_immediately_on_terminal_state: opts.redirect_to_service_immediately_on_terminal_state === true,
+      collect_billing_address: typeof opts.collect_billing_address === 'undefined' || opts.collect_billing_address
+    }
+
+    if (opts.merchant_details === undefined) {
+      data.merchant_details = {
+        name: 'Give Me Your Money',
+        address_line1: 'Clive House',
+        address_line2: '10 Downing Street',
+        address_city: 'London',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
+      }
+    } else if (opts.merchant_details !== null) {
+      data.merchant_details = lodash.pick(opts.merchant_details, [
+        'name',
+        'address_line1',
+        'address_line2',
+        'address_city',
+        'address_postcode',
+        'address_country',
+        'email',
+        'telephone_number'
+      ])
+    }
+
+    if (opts.custom_branding) {
+      data.custom_branding = {
+        css_url: opts.custom_branding.css_url,
+        image_url: opts.custom_branding.image_url
+      }
     }
 
     return {

--- a/test/models/service_test.js
+++ b/test/models/service_test.js
@@ -8,8 +8,8 @@ const expect = require('chai').expect
 const Service = require(path.join(__dirname, '/../../app/models/Service.class'))
 const serviceFixtures = require('../fixtures/service_fixtures')
 
-describe('Service model from service raw data', function () {
-  it('should contain expected merchant details country name', function () {
+describe('Service model from service raw data', () => {
+  it('should contain expected merchant details country name', () => {
     const serviceModel = new Service(serviceFixtures.validServiceResponse({
       merchant_details: {
         name: 'Give Me Your Money',
@@ -24,7 +24,35 @@ describe('Service model from service raw data', function () {
     expect(serviceModel.merchantDetails.countryName).to.equal('United Kingdom')
   })
 
-  it('should return merchant details as undefined when not in raw data', function () {
+  it('hasCompleteMerchantDetailsAddress should be false when all mandatory merchant details address fields are not present', () => {
+    const serviceModel = new Service(serviceFixtures.validServiceResponse({
+      merchant_details: {
+        name: 'Give Me Your Money',
+        address_line2: '10 Downing Street',
+        address_city: 'London',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
+      }
+    }).getPlain())
+
+    expect(serviceModel.hasCompleteMerchantDetailsAddress).to.equal(false)
+  })
+
+  it('hasCompleteMerchantDetailsAddress should be true when all address details except line 2 are present', () => {
+    const serviceModel = new Service(serviceFixtures.validServiceResponse({
+      merchant_details: {
+        name: 'Give Me Your Money',
+        address_line1: '10 Downing Street',
+        address_city: 'London',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
+      }
+    }).getPlain())
+
+    expect(serviceModel.hasCompleteMerchantDetailsAddress).to.equal(true)
+  })
+
+  it('should return merchant details as undefined when not in raw data', () => {
     const data = {
       external_id: '1234',
       name: 'service name',


### PR DESCRIPTION
- It is possible to set individual elements of the merchant details
- Previously service model was assuming that if the merchant_details field was present in the get service response, it had a full address and so attempted to resolve the country from the country code without checking whether it was present. This commit fixes this.
- Handle the case where there is an organisation name but no address or an incomplete address by displaying just the organisation name in the footer of the payment pages.

Co-authored-by: Yancoba Thompson <yancoba.thompson@digital.cabinet-office.gov.uk>
