### PR TITLE
PP-4917 Log unrecognised Apple Pay card brand in error message

### DIFF
--- a/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
+++ b/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
@@ -12,7 +12,7 @@ const normaliseCardName = cardName => {
     case 'visa':
       return 'visa'
     default:
-      throw new Error('Unrecognised card brand in apple pay payload')
+      throw new Error('Unrecognised card brand in Apple Pay payload: ' + cardName)
   }
 }
 const nullable = word => {


### PR DESCRIPTION
When normalising an Apple Pay payload, if the card brand doesn’t match one of the ones we recognise, log what what it was in the error message.