### PR TITLE
PP-4917 - Make card brand normalisation independent of case

### DIFF
--- a/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
+++ b/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
@@ -4,8 +4,9 @@
 const humps = require('humps')
 
 const normaliseCardName = cardName => {
-  switch (cardName) {
-    case 'MasterCard':
+  const lowerCaseCardName = cardName.toLowerCase()
+  switch (lowerCaseCardName) {
+    case 'mastercard':
       return 'master-card'
     case 'amex':
       return 'american-express'
@@ -15,19 +16,21 @@ const normaliseCardName = cardName => {
       throw new Error('Unrecognised card brand in Apple Pay payload: ' + cardName)
   }
 }
+
 const nullable = word => {
   if (word.length === 0 || !word.trim()) {
     return null
   }
   return word
 }
+
 const normaliseLastDigitsCardNumber = displayName => displayName.substr(displayName.length - 4)
 
 module.exports = payload => {
   const paymentInfo = {
     last_digits_card_number: normaliseLastDigitsCardNumber(payload.token.paymentMethod.displayName),
     brand: normaliseCardName(payload.token.paymentMethod.network),
-    card_type: payload.token.paymentMethod.type.toLocaleUpperCase(),
+    card_type: payload.token.paymentMethod.type.toUpperCase(),
     cardholder_name: nullable(payload.shippingContact.givenName + ' ' + payload.shippingContact.familyName),
     email: nullable(payload.shippingContact.emailAddress)
   }


### PR DESCRIPTION
Apple have docs about how to declare which card types you want to accept, but not how it labels those card types coming out, basically it capitalises them, so adding `toLowerCase()` to account for this. 