### PR TITLE
PP-5015 - add new custom translation function

### DIFF
--- a/app/views/auth_3ds_required.njk
+++ b/app/views/auth_3ds_required.njk
@@ -1,12 +1,12 @@
 {% extends "layout.njk" %}
 
-{% block pageTitle %}{{ __("commonHeadings.inProgress") }}{% endblock %}
+{% block pageTitle %}{{ __p("commonHeadings.inProgress") }}{% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l form-title">{{ __("commonHeadings.inProgress") }}</h1>
-    <p class="govuk-body-l lede">{{ __("authorisation.extraSteps") }}</p>
+    <h1 class="govuk-heading-l form-title">{{ __p("commonHeadings.inProgress") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("authorisation.extraSteps") }}</p>
     <iframe class="iframe-3ds" src="3ds_required_out">
     </iframe>
   </div>

--- a/app/views/auth_3ds_required_in.njk
+++ b/app/views/auth_3ds_required_in.njk
@@ -5,7 +5,7 @@
 {% endblock %}
 <body OnLoad="OnLoadEvent();">
 <noscript>
-    <p class="govuk-body-l lede">{{ __("authorisation.approved") }}</p>
+    <p class="govuk-body-l lede">{{ __p("authorisation.approved") }}</p>
 </noscript>
 <form name="three_ds_required" method="post" action="{{ threeDsHandlerUrl }}" target="_top">
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
@@ -19,7 +19,7 @@
         <input type="hidden" name="MD" value="{{ md }}"/>
     {% endif %}
     <noscript>
-        <button id="confirm" class="govuk-button">{{ __("commonButtons.continueButton") }}</button>
+        <button id="confirm" class="govuk-button">{{ __p("commonButtons.continueButton") }}</button>
     </noscript>
 </form>
 

--- a/app/views/auth_3ds_required_out.njk
+++ b/app/views/auth_3ds_required_out.njk
@@ -5,14 +5,14 @@
 {% endblock %}
 <body OnLoad="OnLoadEvent();">
 <noscript>
-  <p class="govuk-body-l lede">{{ __("authorisation.approvalNeeded") }}</p>
+  <p class="govuk-body-l lede">{{ __p("authorisation.approvalNeeded") }}</p>
 </noscript>
 <form name="three_ds_required" method="post" action="{{ issuerUrl }}">
   <input type="hidden" name="PaReq" value="{{ paRequest }}"/>
   <input type="hidden" name="MD" value="{{ md }}"/>
   <input type="hidden" name="TermUrl" value="{{ threeDSReturnUrl }}"/>
   <noscript>
-    <button id="confirm" class="govuk-button">{{ __("commonButtons.continueButton") }}</button>
+    <button id="confirm" class="govuk-button">{{ __p("commonButtons.continueButton") }}</button>
   </noscript>
 </form>
 

--- a/app/views/auth_waiting.njk
+++ b/app/views/auth_waiting.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("authorisation.processingPayment") }}
+  {{ __p("authorisation.processingPayment") }}
 {% endblock %}
 
 {% block head %}
@@ -30,10 +30,10 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l form-title">{{ __("authorisation.checkingDetails") }}</h1>
-    <p class="govuk-body-l lede">{{ __("authorisation.checkingDetailsDescription") }}</p>
+    <h1 class="govuk-heading-l form-title">{{ __p("authorisation.checkingDetails") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("authorisation.checkingDetailsDescription") }}</p>
     <div id="spinner">
-      <img src="/images/spinner.gif" alt="{{ __("authorisation.spinnerAltText") }}"/>
+      <img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/>
     </div>
   </div>
 </div>

--- a/app/views/capture_waiting.njk
+++ b/app/views/capture_waiting.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("authorisation.processingPayment") }}
+  {{ __p("authorisation.processingPayment") }}
 {% endblock %}
 
 {% block head %}
@@ -30,10 +30,10 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l form-title">{{ __("authorisation.processing") }}</h1>
-    <p class="govuk-body-l lede">{{ __("authorisation.processingPayment") }}</p>
+    <h1 class="govuk-heading-l form-title">{{ __p("authorisation.processing") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("authorisation.processingPayment") }}</p>
     <div id="spinner">
-      <img src="/images/spinner.gif" alt="{{ __("authorisation.spinnerAltText") }}"/>
+      <img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/>
     </div>
   </div>
 </div>

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -3,7 +3,7 @@
 {% from "components/button/macro.njk" import govukButton %}
 
 {% block pageTitle %}
-  {{ __("cardDetails.title") }}
+  {{ __p("cardDetails.title") }}
 {% endblock %}
 
 {% set bodyClasses = "google-pay-unavailable" %}
@@ -33,7 +33,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div id="error-summary" class="govuk-error-summary {% if not hasError %}hidden{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
-        {{ __("fieldErrors.summary") }}
+        {{ __p("fieldErrors.summary") }}
       </h2>
       <div class="govuk-error-summary__body">
         <ul class="govuk-list govuk-error-summary__list">
@@ -85,12 +85,12 @@
           }
         })
       }}
-      <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __("authorisation.spinnerAltText") }}"/></div>
+      <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
     </form>
   {% endif %}
 
     <div id="enter-card-details-container">
-      <h1 class="govuk-heading-l">{{ __("cardDetails.title") }}</h1>
+      <h1 class="govuk-heading-l">{{ __p("cardDetails.title") }}</h1>
 
       <form id="card-details" name="cardDetails" method="POST" action="{{ post_card_action }}">
         <input id="charge-id" name="chargeId" type="hidden" value="{{ id }}"/>
@@ -104,8 +104,8 @@
                 <span
                     class="card-no-label"
                     data-label-replace="cardNo"
-                    data-original-label="{{ __("cardDetails.cardNo") }}">
-                  {{ __("cardDetails.cardNo") }}
+                    data-original-label="{{ __p("cardDetails.cardNo") }}">
+                  {{ __p("cardDetails.cardNo") }}
                 </span>
             {% if highlightErrorFields.cardNo %}
               <p class="govuk-error-message" id="error-card-no">
@@ -139,10 +139,10 @@
           </ul>
           <p class="govuk-body-s accepted-cards-hint withdrawal-text">
             {% if withdrawalText === 'debit_credit' %}
-              {{ __("cardDetails.withdrawalText").debit_credit }}
+              {{ __p("cardDetails.withdrawalText").debit_credit }}
             {% endif %}
             {% if withdrawalText === 'debit' %}
-              {{ __("cardDetails.withdrawalText").debit }}
+              {{ __p("cardDetails.withdrawalText").debit }}
             {% endif %}
           </p>
           <div class="govuk-inset-text hidden" id="corporate-card-surcharge-message"></div>
@@ -151,19 +151,19 @@
           <label class="govuk-label govuk-label--s" id="expiry-date-lbl" for="expiry-month">
             <span class="expiry-date-label"
               data-label-replace="expiryMonth"
-              data-original-label="{{ __("cardDetails.expiry") }}">
-              {{ __("cardDetails.expiry") }}
+              data-original-label="{{ __p("cardDetails.expiry") }}">
+              {{ __p("cardDetails.expiry") }}
             </span>
           </label>
           <span class="govuk-hint govuk-!-margin-bottom-2">
-            {{ __("cardDetails.expiryHint") }}</span>
+            {{ __p("cardDetails.expiryHint") }}</span>
           {% if highlightErrorFields.expiryMonth %}
             <p class="govuk-error-message" id="error-expiry-date">
               {{ highlightErrorFields.expiryMonth }}
             </p>
           {% endif %}
           <div class="govuk-date-input__item govuk-date-input__item--month govuk-date-input__item--with-separator">
-              <label class="govuk-label govuk-date-input__label" for="expiry-month">{{ __("cardDetails.expiryMonth") }}</label>
+              <label class="govuk-label govuk-date-input__label" for="expiry-month">{{ __p("cardDetails.expiryMonth") }}</label>
               <input
                 id="expiry-month"
                 type="number"
@@ -177,7 +177,7 @@
                 autocomplete="cc-exp-month"/>
           </div>
           <div class="govuk-date-input__item govuk-date-input__item--year">
-              <label for="expiry-year" class="govuk-label govuk-date-input__label">{{ __("cardDetails.expiryYear") }}</label>
+              <label for="expiry-year" class="govuk-label govuk-date-input__label">{{ __p("cardDetails.expiryYear") }}</label>
               <input
                 id="expiry-year"
                 type="number"
@@ -196,9 +196,9 @@
           <label id="cardholder-name-lbl" for="cardholder-name" class="govuk-label govuk-label--s">
                 <span
                     data-label-replace="cardholderName"
-                    data-original-label="{{ __("cardDetails.cardholderName") }}"
+                    data-original-label="{{ __p("cardDetails.cardholderName") }}"
                     class="card-holder-name-label">
-                  {{ __("cardDetails.cardholderName") }}
+                  {{ __p("cardDetails.cardholderName") }}
                 </span>
             {% if highlightErrorFields.cardholderName %}
               <p class="govuk-error-message" id="error-cardholder-name">
@@ -219,18 +219,18 @@
             <span
               class="cvc-label"
               data-label-replace="cvc"
-              data-original-label="{{ __("cardDetails.cvc") }}">
-              {{ __("cardDetails.cvc") }}
+              data-original-label="{{ __p("cardDetails.cvc") }}">
+              {{ __p("cardDetails.cvc") }}
             </span>
             <span class="govuk-hint govuk-!-margin-bottom-2">
               <span class="generic-cvc">
-                {{ __("cardDetails.cvcTip") }}
+                {{ __p("cardDetails.cvcTip") }}
               </span>
               <span class="hidden">
-                {{ __("cardDetails.amexcvcNonjs") }}
+                {{ __p("cardDetails.amexcvcNonjs") }}
               </span>
               <span class="amex-cvc hidden">
-                {{ __("cardDetails.amexcvcTip") }}
+                {{ __p("cardDetails.amexcvcTip") }}
               </span>
             </span>
             {% if highlightErrorFields.cvc %}
@@ -246,23 +246,23 @@
                   class="govuk-input govuk-!-width-one-quarter cvc"
                   maxlength="4"
                   autocomplete="cc-csc"/>
-          <img src="/images/security-code.png" class="generic-cvc" alt="{{ __("cardDetails.cvcTip") }}"/>
+          <img src="/images/security-code.png" class="generic-cvc" alt="{{ __p("cardDetails.cvcTip") }}"/>
           <span class="either hidden">
-            {{ __("commonConjunctions.or") }}
+            {{ __p("commonConjunctions.or") }}
           </span>
-          <img src="/images/amex-security-code.png" class="amex-cvc hidden" alt="{{ __("cardDetails.amexcvcTip") }}"/>
+          <img src="/images/amex-security-code.png" class="amex-cvc hidden" alt="{{ __p("cardDetails.amexcvcTip") }}"/>
         </div>
         {% if service.collectBillingAddress %}
         <div class="govuk-form-group govuk-!-width-two-thirds {% if highlightErrorFields.addressCountry %} govuk-form-group--error{% endif %}" data-validation="addressCountry">
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-1">{{ __("cardDetails.billingAddress") }}</h2>
-          <span class="govuk-hint govuk-!-margin-bottom-2">{{ __("cardDetails.billingAddressHint") }}</span>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-1">{{ __p("cardDetails.billingAddress") }}</h2>
+          <span class="govuk-hint govuk-!-margin-bottom-2">{{ __p("cardDetails.billingAddressHint") }}</span>
 
           <label id="address-country-lbl" for="address-country" class="govuk-label govuk-label--s">
                 <span
                     class="address-country-label"
                     data-label-replace="addressCountry"
-                    data-original-label="{{ __("cardDetails.country") }}">
-                  {{ __("cardDetails.country") }}
+                    data-original-label="{{ __p("cardDetails.country") }}">
+                  {{ __p("cardDetails.country") }}
                 </span>
             {% if highlightErrorFields.addressCountry %}
               <p class="govuk-error-message" id="error-address-country">
@@ -283,8 +283,8 @@
                 <span
                     class="address-line-1-label"
                     data-label-replace="addressLine1"
-                    data-original-label="{{ __("cardDetails.building") }}">
-                  {{ __("cardDetails.building") }}
+                    data-original-label="{{ __p("cardDetails.building") }}">
+                  {{ __p("cardDetails.building") }}
                 </span>
 
             {% if highlightErrorFields.addressLine1 %}
@@ -315,8 +315,8 @@
                 <span
                     class="address-city-label"
                     data-label-replace="addressCity"
-                    data-original-label="{{ __("cardDetails.city") }}">
-                  {{ __("cardDetails.city") }}
+                    data-original-label="{{ __p("cardDetails.city") }}">
+                  {{ __p("cardDetails.city") }}
                 </span>
             {% if highlightErrorFields.addressCity %}
               <p class="govuk-error-message" id="error-address-city">
@@ -337,8 +337,8 @@
                 <span
                     class="address-postcode-label"
                     data-label-replace="addressPostcode"
-                    data-original-label="{{ __("cardDetails.postcode") }}">
-                  {{ __("cardDetails.postcode") }}
+                    data-original-label="{{ __p("cardDetails.postcode") }}">
+                  {{ __p("cardDetails.postcode") }}
                 </span>
 
             {% if highlightErrorFields.addressPostcode %}
@@ -362,10 +362,10 @@
                 <span
                     class="email-label"
                     data-label-replace="email"
-                    data-original-label="{{ __("cardDetails.email") }}">
-                  {{ __("cardDetails.email") }}
+                    data-original-label="{{ __p("cardDetails.email") }}">
+                  {{ __p("cardDetails.email") }}
                 </span>
-            <span class="govuk-hint govuk-!-margin-bottom-2">{{ __("cardDetails.emailHint") }}</span>
+            <span class="govuk-hint govuk-!-margin-bottom-2">{{ __p("cardDetails.emailHint") }}</span>
 
             {% if highlightErrorFields.email %}
               <p class="govuk-error-message" id="error-email">
@@ -381,14 +381,14 @@
                   value="{{ email }}"
                   autocomplete="email"
                   data-confirmation="true"
-                  data-confirmation-label="{{ __("cardDetails.emailConfirmation") }} "/>
+                  data-confirmation-label="{{ __p("cardDetails.emailConfirmation") }} "/>
         </div>
         {% endif %}
         {% if typos %}
           <div class="govuk-form-group form-group-email-typo govuk-form-group--error">
             <legend for="email-typo" id="email-typo-lbl" class="govuk-label govuk-label--s error-label">
               <p class="govuk-error-message" id="error-typo">
-                {{ __("fieldErrors.fields.email.typo") }}
+                {{ __p("fieldErrors.fields.email.typo") }}
               </p>
             </legend>
             <div class="govuk-radios">
@@ -404,7 +404,7 @@
           </div>
         {% endif %}
         <div>
-          <input id="submit-card-details" type="submit" class="govuk-button" value="{{ __("commonButtons.continueButton") }}" name="submitCardDetails"
+          <input id="submit-card-details" type="submit" class="govuk-button" value="{{ __p("commonButtons.continueButton") }}" name="submitCardDetails"
           {% if typos %}
           data-click-events
           data-click-category="Typo made"
@@ -415,7 +415,7 @@
       </form>
       <form id="cancel" name="cancel" method="POST" action="{{ post_cancel_action }}" class="form">
         <div>
-          <input id="cancel-payment" type="submit" class="button-reset" value="{{ __("commonButtons.cancelButton") }}" name="cancel">
+          <input id="cancel-payment" type="submit" class="button-reset" value="{{ __p("commonButtons.cancelButton") }}" name="cancel">
           <input id="csrf2" name="csrfToken" type="hidden" value="{{ csrf }}"/>
         </div>
       </form>
@@ -423,16 +423,16 @@
   </div>
   <div class="govuk-grid-column-one-third payment-summary-wrap">
     <aside class="payment-summary">
-      <h2 class="govuk-heading-m">{{ __("paymentSummary.title") }}</h2>
+      <h2 class="govuk-heading-m">{{ __p("paymentSummary.title") }}</h2>
       <p id="payment-description" class="govuk-body govuk-!-font-weight-bold">
         {{ description }}
       </p>
       <p class="govuk-body hidden" id="payment-summary-breakdown">
-        {{ __("paymentSummary.amount") }} <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount"></span><br/>
-        {{ __("paymentSummary.corporateCardFee") }} <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee"></span>
+        {{ __p("paymentSummary.amount") }} <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount"></span><br/>
+        {{ __p("paymentSummary.corporateCardFee") }} <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee"></span>
       </p>
       <p class="govuk-body govuk-!-margin-bottom-0">
-        {{ __("paymentSummary.totalAmount") }}
+        {{ __p("paymentSummary.totalAmount") }}
         <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold" data-amount="{{ amount }}">£{{ amount }}</span>
       </p>
     </aside>

--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -1,7 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("confirmDetails.title") }}
+  {{ __p("confirmDetails.title") }}
 {% endblock %}
 
 {% set mainClasses = "confirm-page" %}
@@ -9,13 +9,13 @@
 {% block content %}
 <div class="govuk-grid-row govuk-!-margin-bottom-9">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ __("confirmDetails.title") }}</h1>
+    <h1 class="govuk-heading-l">{{ __p("confirmDetails.title") }}</h1>
 
     <table class="govuk-table">
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ __("confirmDetails.card") }}
+            {{ __p("confirmDetails.card") }}
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="card-number">
             {{ charge.cardDetails.cardNumber }}
@@ -23,7 +23,7 @@
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ __("confirmDetails.expiry") }}
+            {{ __p("confirmDetails.expiry") }}
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="expiry-date">
             {{ charge.cardDetails.expiryDate }}
@@ -31,7 +31,7 @@
         </tr>
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ __("confirmDetails.name") }}
+            {{ __p("confirmDetails.name") }}
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="cardholder-name">
             {{ charge.cardDetails.cardholderName }}
@@ -40,7 +40,7 @@
         {% if charge.cardDetails.billingAddress %}
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ __("confirmDetails.address") }}
+            {{ __p("confirmDetails.address") }}
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="address">
             {{ charge.cardDetails.billingAddress }}
@@ -50,7 +50,7 @@
         {% if (charge.gatewayAccount.emailCollectionMode === 'MANDATORY') or (charge.gatewayAccount.emailCollectionMode === 'OPTIONAL' and charge.email) %}
         <tr class="govuk-table__row">
           <th class="govuk-table__header govuk-!-font-weight-regular govuk-!-width-one-third govuk-!-padding-top-3 govuk-!-padding-bottom-3" scope="row">
-            {{ __("confirmDetails.email") }}
+            {{ __p("confirmDetails.email") }}
           </th>
           <td class="govuk-table__cell govuk-!-font-weight-bold" id="email">
             {{ charge.email }}
@@ -63,29 +63,29 @@
     <form id="confirmation" method="POST" action="{{ confirmPath }}" class="form">
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       <input id="chargeId" name="chargeId" type="hidden" value="{{ charge.id }}"/>
-      <button id="confirm" class="govuk-button govuk-!-margin-top-6" data-module="stop-double-submit">{{ __("commonButtons.confirmButton") }}</button>
+      <button id="confirm" class="govuk-button govuk-!-margin-top-6" data-module="stop-double-submit">{{ __p("commonButtons.confirmButton") }}</button>
     </form>
     <form id="cancel" name="cancel" method="POST" action="{{ post_cancel_action }}" class="form">
       <div>
-        <input id="cancel-payment" type="submit" class="button-reset" value="{{ __("commonButtons.cancelButton") }}" name="cancel">
+        <input id="cancel-payment" type="submit" class="button-reset" value="{{ __p("commonButtons.cancelButton") }}" name="cancel">
         <input id="csrf2" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       </div>
     </form>
   </div>
   <div class="govuk-grid-column-one-third payment-summary-wrap">
     <aside class="payment-summary">
-      <h2 class="govuk-heading-m">{{ __("paymentSummary.title") }}</h2>
+      <h2 class="govuk-heading-m">{{ __p("paymentSummary.title") }}</h2>
       <p id="payment-description" class="govuk-body govuk-!-font-weight-bold">
         {{ charge.description }}
       </p>
       {% if charge.corporateCardSurcharge %}
       <p class="govuk-body" id="payment-summary-breakdown">
-        {{ __("paymentSummary.amount") }} <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount">£{{ charge.amount }}</span><br/>
-        {{ __("paymentSummary.corporateCardFee") }} <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee">£{{ charge.corporateCardSurcharge }}</span>
+        {{ __p("paymentSummary.amount") }} <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount">£{{ charge.amount }}</span><br/>
+        {{ __p("paymentSummary.corporateCardFee") }} <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee">£{{ charge.corporateCardSurcharge }}</span>
       </p>
       {% endif %}
       <p class="govuk-body govuk-!-margin-bottom-0">
-        {{ __("paymentSummary.totalAmount") }}
+        {{ __p("paymentSummary.totalAmount") }}
         <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold">£{{ charge.totalAmount if charge.totalAmount else charge.amount }}</span>
       </p>
     </aside>

--- a/app/views/error.njk
+++ b/app/views/error.njk
@@ -1,18 +1,18 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("errorViews.error") }} - GOV.UK Pay
+  {{ __p("errorViews.error") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
   <main id="content" class="content-wrapper error-pages govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l general-error">
-        {{ __("errorViews.error") }}
+        {{ __p("errorViews.error") }}
       </h1>
       <p id="errorMsg" class="govuk-body-l lede">{{ message }}</p>
       {% if returnUrl %}
-        <p class="govuk-body-l"><a id="return-url" class="govuk-link lede" href="{{ returnUrl }}">{{ __("errorViews.tryAgain") }}</a></p>
+        <p class="govuk-body-l"><a id="return-url" class="govuk-link lede" href="{{ returnUrl }}">{{ __p("errorViews.tryAgain") }}</a></p>
       {% endif %}
     </div>
   </main>

--- a/app/views/error_with_return_url.njk
+++ b/app/views/error_with_return_url.njk
@@ -1,17 +1,17 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("errorViews.error") }} - GOV.UK Pay
+  {{ __p("errorViews.error") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h3 class="govuk-heading-l">
-      {{ __("errorViews.error") }}:
+      {{ __p("errorViews.error") }}:
     </h3>
     <p class="govuk-body-l lede">
-      <a id="return-url" class="govuk-link" href="{{ returnUrl }}">{{ __("commonButtons.goBackToService") }}</a>
+      <a id="return-url" class="govuk-link" href="{{ returnUrl }}">{{ __p("commonButtons.goBackToService") }}</a>
     </p>
     <div class="govuk-body" id="errorMsg">{{ message }}</div>
   </div>

--- a/app/views/errors/charge_confirm_state_completed.njk
+++ b/app/views/errors/charge_confirm_state_completed.njk
@@ -1,16 +1,16 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("errorViews.paymentStatus") }} {{ status }} - GOV.UK Pay
+  {{ __p("errorViews.paymentStatus") }} {{ status }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l {{ status }}">{{ __("errorViews.paymentStatus") }} {{ status }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.toMakeChanges") }}</p>
+    <h1 class="govuk-heading-l {{ status }}">{{ __p("errorViews.paymentStatus") }} {{ status }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.toMakeChanges") }}</p>
     <p class="govuk-body-l lede">
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.viewSummary") }}</a>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __p("errorViews.viewSummary") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/auth_3ds_required.njk
+++ b/app/views/errors/incorrect_state/auth_3ds_required.njk
@@ -1,17 +1,17 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("commonHeadings.inProgress") }} - GOV.UK Pay
+  {{ __p("commonHeadings.inProgress") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ __("commonHeadings.inProgress") }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.either") }}</p>
-    <a class="govuk-body-l lede" href="/card_details/{{ chargeId }}/3ds_required" id="threeds-required-link">{{ __("errorViews.continue") }}</a>
-    <p class="govuk-body-l lede">{{ __("commonConjunctions.or") }}<br/>
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
+    <h1 class="govuk-heading-l">{{ __p("commonHeadings.inProgress") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.either") }}</p>
+    <a class="govuk-body-l lede" href="/card_details/{{ chargeId }}/3ds_required" id="threeds-required-link">{{ __p("errorViews.continue") }}</a>
+    <p class="govuk-body-l lede">{{ __p("commonConjunctions.or") }}<br/>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __p("errorViews.tryAgain") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/auth_failure.njk
+++ b/app/views/errors/incorrect_state/auth_failure.njk
@@ -1,16 +1,16 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("errorViews.problem") }} - GOV.UK Pay
+  {{ __p("errorViews.problem") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l qa-payment-declined">{{ __("errorViews.declined") }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.contactYourBank") }}</p>
+    <h1 class="govuk-heading-l qa-payment-declined">{{ __p("errorViews.declined") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.contactYourBank") }}</p>
 
-    <p class="govuk-body-l lede"><a href="{{ returnUrl }}" id="return-url" role="button" class="govuk-button">{{ __("commonButtons.continueButton") }}</a></p>
+    <p class="govuk-body-l lede"><a href="{{ returnUrl }}" id="return-url" role="button" class="govuk-button">{{ __p("commonButtons.continueButton") }}</a></p>
   </div>
 </div>
 {% endblock %}

--- a/app/views/errors/incorrect_state/auth_success.njk
+++ b/app/views/errors/incorrect_state/auth_success.njk
@@ -1,18 +1,18 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("commonHeadings.inProgress") }} - GOV.UK Pay
+  {{ __p("commonHeadings.inProgress") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ __("commonHeadings.inProgress") }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.either") }}<br/>
-      <a href="/card_details/{{chargeId}}/confirm" id="confirm-link">{{ __("errorViews.continue") }}</a>
+    <h1 class="govuk-heading-l">{{ __p("commonHeadings.inProgress") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.either") }}<br/>
+      <a href="/card_details/{{chargeId}}/confirm" id="confirm-link">{{ __p("errorViews.continue") }}</a>
     </p>
-    <p class="govuk-body-l lede">{{ __("commonConjunctions.or") }}<br/>
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
+    <p class="govuk-body-l lede">{{ __p("commonConjunctions.or") }}<br/>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __p("errorViews.tryAgain") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/auth_waiting.njk
+++ b/app/views/errors/incorrect_state/auth_waiting.njk
@@ -1,18 +1,18 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("commonHeadings.inProgress") }} - GOV.UK Pay
+  {{ __p("commonHeadings.inProgress") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ __("commonHeadings.inProgress") }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.either") }}<br/>
-      <a href="/card_details/{{ chargeId }}/auth_waiting" id="confirm-link">{{ __("errorViews.continue") }}</a>
+    <h1 class="govuk-heading-l">{{ __p("commonHeadings.inProgress") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.either") }}<br/>
+      <a href="/card_details/{{ chargeId }}/auth_waiting" id="confirm-link">{{ __p("errorViews.continue") }}</a>
     </p>
-    <p class="govuk-body-l lede">{{ __("commonConjunctions.or") }}<br/>
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
+    <p class="govuk-body-l lede">{{ __p("commonConjunctions.or") }}<br/>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __p("errorViews.tryAgain") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/capture_failure.njk
+++ b/app/views/errors/incorrect_state/capture_failure.njk
@@ -1,16 +1,16 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("errorViews.paymentStatus") }} {{ status }} - GOV.UK Pay
+  {{ __p("errorViews.paymentStatus") }} {{ status }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ __("errorViews.unsuccessful") }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
+    <h1 class="govuk-heading-l">{{ __p("errorViews.unsuccessful") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.noMoneyTaken") }}</p>
     <p class="govuk-body-l lede">
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __p("errorViews.tryAgain") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/capture_waiting.njk
+++ b/app/views/errors/incorrect_state/capture_waiting.njk
@@ -1,7 +1,7 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("commonHeadings.inProgress") }} - GOV.UK Pay
+  {{ __p("commonHeadings.inProgress") }} - GOV.UK Pay
 {% endblock %}
 
 {% block head %}
@@ -30,10 +30,10 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{ __("authorisation.processing") }}</h1>
-    <p class="govuk-body-l lede">{{ __("authorisation.processingPayment") }}</p>
+    <h1 class="govuk-heading-l">{{ __p("authorisation.processing") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("authorisation.processingPayment") }}</p>
     <div id="spinner">
-      <img src="/images/spinner.gif" alt="{{ __("authorisation.spinnerAltText") }}"/>
+      <img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/>
     </div>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/charge_completed.njk
+++ b/app/views/errors/incorrect_state/charge_completed.njk
@@ -1,16 +1,16 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("errorViews.paymentStatus") }} {{ status }}
+  {{ __p("errorViews.paymentStatus") }} {{ status }}
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l {{ status }}">{{ __("errorViews.paymentStatus") }} {{ status }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.toMakeChanges") }}</p>
+    <h1 class="govuk-heading-l {{ status }}">{{ __p("errorViews.paymentStatus") }} {{ status }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.toMakeChanges") }}</p>
     <p class="govuk-body-l lede">
-      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.viewSummary") }}</a>
+      <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __p("errorViews.viewSummary") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/incorrect_state/session_expired.njk
+++ b/app/views/errors/incorrect_state/session_expired.njk
@@ -1,17 +1,17 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("errorViews.paymentExpired") }} - GOV.UK Pay
+  {{ __p("errorViews.paymentExpired") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l session-expired">{{ __("errorViews.sessionExpired") }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.sessionExpiredNoMoneyTaken") }}</p>
+    <h1 class="govuk-heading-l session-expired">{{ __p("errorViews.sessionExpired") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.sessionExpiredNoMoneyTaken") }}</p>
     {% if returnUrl %}
       <p class="govuk-body-l lede">
-        <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
+        <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __p("errorViews.tryAgain") }}</a>
       </p>
     {% endif %}
   </div>

--- a/app/views/errors/incorrect_state/system_cancelled.njk
+++ b/app/views/errors/incorrect_state/system_cancelled.njk
@@ -1,16 +1,16 @@
 {% extends "../../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("errorViews.paymentCancelled") }} - GOV.UK Pay
+  {{ __p("errorViews.paymentCancelled") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l system-cancel">{{ __("errorViews.paymentCancelledTitle") }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.paymentCancelledDescription") }}</p>
+    <h1 class="govuk-heading-l system-cancel">{{ __p("errorViews.paymentCancelledTitle") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.paymentCancelledDescription") }}</p>
     <p class="govuk-body-l lede">
-      <a href="{{ returnUrl }}" id="return-url" role="button" class="govuk-button">{{ __("commonButtons.continueButton") }}</a>
+      <a href="{{ returnUrl }}" id="return-url" role="button" class="govuk-button">{{ __p("commonButtons.continueButton") }}</a>
     </p>
   </div>
 </div>

--- a/app/views/errors/system_error.njk
+++ b/app/views/errors/system_error.njk
@@ -1,20 +1,20 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("errorViews.error") }} - GOV.UK Pay
+  {{ __p("errorViews.error") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l system-error">{{ __("errorViews.technicalProblems") }}</h1>
+    <h1 class="govuk-heading-l system-error">{{ __p("errorViews.technicalProblems") }}</h1>
     {% if returnUrl %}
-      <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
+      <p class="govuk-body-l lede">{{ __p("errorViews.noMoneyTaken") }}</p>
       <p class="govuk-body-l lede">
-        <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __("errorViews.tryAgain") }}</a>
+        <a href="{{ returnUrl }}" id="return-url" class="govuk-link">{{ __p("errorViews.tryAgain") }}</a>
       </p>
     {% else %}
-      <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
+      <p class="govuk-body-l lede">{{ __p("errorViews.noMoneyTaken") }}</p>
     {% endif %}
   </div>
 </div>

--- a/app/views/user_cancelled.njk
+++ b/app/views/user_cancelled.njk
@@ -1,16 +1,16 @@
 {% extends "layout.njk" %}
 
 {% block pageTitle %}
-  {{ __("authorisation.userCancelledPayment") }} - GOV.UK Pay
+  {{ __p("authorisation.userCancelledPayment") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l user-cancel">{{ __("authorisation.userCancelledPayment") }}</h1>
-    <p class="govuk-body-l lede">{{ __("errorViews.noMoneyTaken") }}</p>
+    <h1 class="govuk-heading-l user-cancel">{{ __p("authorisation.userCancelledPayment") }}</h1>
+    <p class="govuk-body-l lede">{{ __p("errorViews.noMoneyTaken") }}</p>
     <p class="govuk-body-l lede">
-      <a id="return-url" role="button" class="govuk-button" href="{{ returnUrl }}">{{ __("commonButtons.continueButton") }}</a>
+      <a id="return-url" role="button" class="govuk-button" href="{{ returnUrl }}">{{ __p("commonButtons.continueButton") }}</a>
     </p>
   </div>
 </div>

--- a/config/pay-translation.js
+++ b/config/pay-translation.js
@@ -1,0 +1,21 @@
+'use strict'
+// i18n’s built in translation function `__()` returns the key
+// if it can’t find a translation. This is problematic as we show
+// something gross like 'cardDetails.title' to the user.
+// So this is a custom function that will check that the string
+// doesn’t equal the key. And if it does throw an error so the
+// template fails to render but with a nice helpful error message.
+
+// NPM dependencies
+const i18n = require('i18n')
+
+module.exports = function (req, res, next) {
+  res.locals.__p = res.__p = function () {
+    const translation = i18n.__.apply(req, arguments)
+    if (arguments[0] === translation) {
+      throw new Error(`Template is missing a translation with ID: ${translation}`)
+    }
+    return translation
+  }
+  next()
+}

--- a/config/pay-translation.js
+++ b/config/pay-translation.js
@@ -10,7 +10,7 @@
 const i18n = require('i18n')
 
 module.exports = function payGetTranslation (req, res, next) {
-  res.locals.__p = res.__p = function () {
+  res.locals.__p = function safelyTranslateKeys () {
     const translation = i18n.__.apply(req, arguments)
     if (arguments[0] === translation) {
       throw new Error(`Template is missing a translation with ID: ${translation}`)

--- a/config/pay-translation.js
+++ b/config/pay-translation.js
@@ -9,7 +9,7 @@
 // NPM dependencies
 const i18n = require('i18n')
 
-module.exports = function (req, res, next) {
+module.exports = function payGetTranslation (req, res, next) {
   res.locals.__p = res.__p = function () {
     const translation = i18n.__.apply(req, arguments)
     if (arguments[0] === translation) {

--- a/server.js
+++ b/server.js
@@ -23,6 +23,7 @@ const cookies = require('./app/utils/cookies')
 const noCache = require('./app/utils/no_cache')
 const session = require('./app/utils/session')
 const i18nConfig = require('./config/i18n')
+const i18nPayTranslation = require('./config/pay-translation')
 
 // Global constants
 const { NODE_ENV, PORT, ANALYTICS_TRACKING_ID, GOOGLE_PAY_MERCHANT_ID } = process.env
@@ -82,6 +83,7 @@ function initialiseGlobalMiddleware (app) {
 function initialisei18n (app) {
   i18n.configure(i18nConfig)
   app.use(i18n.init)
+  app.use(i18nPayTranslation)
 }
 
 function initialiseProxy (app) {

--- a/test/test_helpers/html_assertions.js
+++ b/test/test_helpers/html_assertions.js
@@ -9,7 +9,11 @@ const views = ['./app/views', './node_modules/govuk-frontend']
 const environment = nunjucks.configure(views)
 const strings = require('./../../locales/en.json')
 
-// Shim for i18n to make it recognise the __() function and return the English string
+// Shim for i18n to make it recognise the `__p()`` and `__()` function and return the English string
+environment.addGlobal('__p', string => {
+  return lodash.get(strings, string)
+})
+
 environment.addGlobal('__', string => {
   return lodash.get(strings, string)
 })


### PR DESCRIPTION
i18n’s built in translation function `__()` returns the key
if it can’t find a translation. This is problematic as we show
something gross like 'cardDetails.title' to the user.
So this is a custom function that will check that the string
doesn’t equal the key. And if it does throw an error so the
template fails to render but with a nice helpful error message.

The error looks like this:
![Screen Shot 2019-03-21 at 16 05 52](https://user-images.githubusercontent.com/440503/54767536-4187cb80-4bf5-11e9-909c-aa734545cb93.png)

Which is how all the other Nunjucks errors look and it would mean you could never get your PR through tests