### PR TITLE
PP-4917 - Validate email after payment authorised

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -41,6 +41,12 @@ module.exports = () => {
     const { payment } = event
     toggleWaiting()
 
+    if (!rfc822Validator(payment.shippingContact.emailAddress)) {
+      toggleWaiting()
+      showErrorSummary(i18n.fieldErrors.summary, i18n.fieldErrors.fields.email.message)
+      return new ApplePayError('shippingContactInvalid', 'emailAddress', i18n.fieldErrors.fields.email.message)
+    }
+
     return fetch(`/web-payments-auth-request/apple/${window.paymentDetails.chargeID}`, {
       method: 'POST',
       credentials: 'same-origin',
@@ -68,13 +74,6 @@ module.exports = () => {
       ga('send', 'event', 'Apple Pay', 'Error', 'Couldn’t post to /web-payments-auth-request/apple/{chargeId}')
       return err
     })
-  }
-
-  session.onshippingcontactselected = function (event) {
-    console.log(event)
-    const { email } = event.shippingContact
-
-    session.completeShippingContactSelection(rfc822Validator(email) ? ApplePaySession.STATUS_SUCCESS : ApplePaySession.STATUS_INVALID_SHIPPING_CONTACT)
   }
 
   session.begin()

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
       "i18n",
       "PaymentRequest",
       "ApplePaySession",
+      "ApplePayError",
       "ga",
       "fetch"
     ],


### PR DESCRIPTION
I tried to validate the email before payment authorisation but Apple
won’t hand over any personally identifiable information before
authorisation, will only give things like contry and postcode.

So we have to do this after authorisation. I have refactored the test so
that we can construct an Apple Pay Session that returns a bad email

Have written test to confirm this behaviour