### PR TITLE
bau: set JAVA_HOME to 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
   environment {
     RUN_END_TO_END_ON_PR = "${params.runEndToEndTestsOnPR}"
     RUN_ZAP_ON_PR = "${params.runZapTestsOnPR}"
+    JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
   }
 
   stages {


### PR DESCRIPTION
This is needed as frontend runs java pact provider tests for selfservice and
adminusers
