### PR TITLE
PP-5057 do not post to card_id when card no is less than 11 digits

### DIFF
--- a/app/assets/javascripts/modules/form-card-type.js
+++ b/app/assets/javascripts/modules/form-card-type.js
@@ -139,8 +139,7 @@ var showCardType = function() {
     return new Promise(function (resolve, reject) {
       var request = new XMLHttpRequest();
       var card = getCardType();
-      // this should already be picked up by the other validations
-      if (card.length !== 1) return
+      if (card.length !== 1 && cardInput.value.replace(/\D/g,'').length < 11) return
       request.open('POST', '/check_card/' + chargeId, true);
       request.setRequestHeader('Content-type', 'application/json');
       request.onload = function () {

--- a/app/models/card.js
+++ b/app/models/card.js
@@ -31,6 +31,10 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
     }
 
     AWSXRay.captureAsyncFunc('cardIdClient_post', function (postSubsegment) {
+      if (cardNo.length > 0 && cardNo.length < 11) {
+        postSubsegment.close()
+        return reject(new Error(i18n.__('fieldErrors.fields.cardNo.numberIncorrectLength')))
+      }
       cardIdClient.post({ payload: data, correlationId: correlationId }, postSubsegment)
         .then((response) => {
           postSubsegment.close()

--- a/test/cypress/integration/card/footer.spec.js
+++ b/test/cypress/integration/card/footer.spec.js
@@ -4,6 +4,7 @@ const cardPaymentStubs = require('../../utils/card-payment-stubs')
 describe('The footer displayed on payment pages', () => {
   const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
   const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
+  const language = 'en'
 
   beforeEach(() => {
     cy.sessionCookie(chargeId)
@@ -24,7 +25,7 @@ describe('The footer displayed on payment pages', () => {
       }
     }
 
-    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
     cy.get('.merchant-details').should('exist')
@@ -45,7 +46,7 @@ describe('The footer displayed on payment pages', () => {
       }
     }
 
-    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
     cy.get('.merchant-details').should('exist')
@@ -65,7 +66,7 @@ describe('The footer displayed on payment pages', () => {
       }
     }
 
-    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
     cy.get('.merchant-details').should('exist')
@@ -80,7 +81,7 @@ describe('The footer displayed on payment pages', () => {
       merchant_details: null
     }
 
-    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
     cy.get('.merchant-details').should('not.exist')
@@ -98,7 +99,7 @@ describe('The footer displayed on payment pages', () => {
       }
     }
 
-    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, gatewayAccountId, serviceOpts))
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
     cy.get('.merchant-details').should('not.exist')

--- a/test/cypress/utils/card-payment-stubs.js
+++ b/test/cypress/utils/card-payment-stubs.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const buildCreatePaymentChargeStubs = function buildCreatePaymentChargeStubs (tokenId, chargeId, gatewayAccountId = 42, serviceOpts = {}) {
+const buildCreatePaymentChargeStubs = function buildCreatePaymentChargeStubs (tokenId, chargeId, language, gatewayAccountId = 42, serviceOpts = {}) {
   return [
     { name: 'connectorCreateChargeFromToken', opts: { tokenId, gatewayAccountId } },
     { name: 'connectorDeleteToken', opts: { tokenId } },
@@ -10,7 +10,8 @@ const buildCreatePaymentChargeStubs = function buildCreatePaymentChargeStubs (to
         chargeId,
         gatewayAccountId,
         status: 'CREATED',
-        state: { finished: false, status: 'created' }
+        state: { finished: false, status: 'created' },
+        language: language || 'en'
       }
     },
     { name: 'connectorUpdateChargeStatus', opts: { chargeId } },

--- a/test/fixtures/payment_fixtures.js
+++ b/test/fixtures/payment_fixtures.js
@@ -132,7 +132,7 @@ const buildChargeDetails = function buildChargeDetails (opts) {
     'amount': opts.amount || 1000,
     'state': opts.state,
     'description': opts.description || 'Example fixture payment',
-    'language': 'en',
+    'language': opts.language || 'en',
     'status': opts.status,
     'links': [{
       'rel': 'self',


### PR DESCRIPTION
## WHAT
- This change stops posting for a card check to card id when the card number is less than 11 digits thus stopping card_id throwing RuntimeException which result in a 500 error.

with @jonheslop
