### PR TITLE
BAU - Remove Cypress dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "watch-live-reload": "./node_modules/.bin/grunt watch",
     "test": "rm -rf ./pacts && DISABLE_APPMETRICS=true node ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(_test|_tests|.test)'.js",
     "cypress:server": "mb | DISABLE_APPMETRICS=true node -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
-    "cypress:test": "cypress run",
-    "cypress:test-headed": "cypress open",
+    "cypress:test": "./scripts/run-cypress",
+    "cypress:test-headed": "./scripts/run-cypress headed",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect",
     "publish-pacts": "./bin/publish-pacts.js"
@@ -114,7 +114,6 @@
     "chai-string": "^1.4.0",
     "cheerio": "^1.0.0-rc.3",
     "chokidar-cli": "latest",
-    "cypress": "^3.1.5",
     "dotenv": "^7.0.0",
     "envfile": "^3.0.0",
     "eslint": "^5.16.0",

--- a/scripts/run-cypress
+++ b/scripts/run-cypress
@@ -1,0 +1,15 @@
+#!/bin/sh
+if ! [ -x "$(command -v cypress)" ]; then 
+  echo "Cypress not found in this environment"
+  echo "For development, Cypress can be added with \`npm i -g cypress\`"
+  echo "For CI Cypress should be available through the container node"
+  exit 1
+fi
+
+if [ "$1" == "headed" ]; then
+  echo "Cypress found in environment, executing open"
+  cypress open --project $PWD
+else
+  echo "Cypress found in environment, executing run"
+  cypress run
+fi


### PR DESCRIPTION
Cypress takes a significant amount of time to both download and unzip in
CI/ build processes - it should only be used via pre-compiled containers
during the build pipeline so having the developer set up their own
envrionment is the lesser of two evils.

A copy of — https://github.com/alphagov/pay-toolbox/pull/53