### PR TITLE
BAU - Generate assets before running Cypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "standard --fix",
     "watch-live-reload": "./node_modules/.bin/grunt watch",
     "test": "rm -rf ./pacts && DISABLE_APPMETRICS=true node ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(_test|_tests|.test)'.js",
-    "cypress:server": "mb | DISABLE_APPMETRICS=true node -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
+    "cypress:server": "npm run compile && mb | DISABLE_APPMETRICS=true node -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",
     "snyk-protect": "snyk protect",


### PR DESCRIPTION
Me and a few others have got caught out spinning up Cypress and there
being issues because the JS/CSS are out of date (or missing altogether).
This makes sure that doesn’t happen by running it just before.