### PR TITLE
PP-5142 Remove message from error response in Pact

### DIFF
--- a/test/fixtures/wallet_payment_fixtures.js
+++ b/test/fixtures/wallet_payment_fixtures.js
@@ -39,19 +39,6 @@ const fixtures = {
       }
     }
   },
-  webPaymentFailedResponse: (message) => {
-    const data = {
-      message: message
-    }
-    return {
-      getPactified: () => {
-        return pactBase.pactify(data)
-      },
-      getPlain: () => {
-        return data
-      }
-    }
-  },
   appleAuthRequestDetails: (ops = {}) => {
     const data = {
       payment_info: {

--- a/test/unit/clients/connector_client_apple_authentication_tests.js
+++ b/test/unit/clients/connector_client_apple_authentication_tests.js
@@ -72,7 +72,6 @@ describe('connectors client - apple authentication API', function () {
 
   describe('authorisation declined', function () {
     const appleAuthRequest = fixtures.appleAuthRequestDetails({ lastDigitsCardNumber: '0002' })
-    const authorisationDeclinedResponse = fixtures.webPaymentFailedResponse('This transaction was declined.')
 
     before(() => {
       const builder = new PactInteractionBuilder(APPLE_AUTH_PATH)
@@ -80,7 +79,6 @@ describe('connectors client - apple authentication API', function () {
         .withMethod('POST')
         .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
         .withUponReceiving('a valid apple pay auth request which should be declined')
-        .withResponseBody(authorisationDeclinedResponse.getPactified())
         .withStatusCode(400)
         .build()
       return provider.addInteraction(builder)
@@ -93,8 +91,7 @@ describe('connectors client - apple authentication API', function () {
         chargeId: TEST_CHARGE_ID,
         provider: 'apple',
         payload: appleAuthRequest.getPlain()
-      }).then(res => {
-        expect(res.body.message).to.be.equal('This transaction was declined.')
+      }).then(() => {
         done()
       }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
     })
@@ -102,7 +99,6 @@ describe('connectors client - apple authentication API', function () {
 
   describe('authorisation error', function () {
     const appleAuthRequest = fixtures.appleAuthRequestDetails({ lastDigitsCardNumber: '0119' })
-    const authorisationErrorResponse = fixtures.webPaymentFailedResponse('This transaction could be not be processed.')
 
     before(() => {
       const builder = new PactInteractionBuilder(APPLE_AUTH_PATH)
@@ -110,7 +106,6 @@ describe('connectors client - apple authentication API', function () {
         .withMethod('POST')
         .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
         .withUponReceiving('a valid apple pay auth request which should return an error')
-        .withResponseBody(authorisationErrorResponse.getPactified())
         .withStatusCode(400)
         .build()
       return provider.addInteraction(builder)
@@ -123,8 +118,7 @@ describe('connectors client - apple authentication API', function () {
         chargeId: TEST_CHARGE_ID,
         provider: 'apple',
         payload: appleAuthRequest.getPlain()
-      }).then(res => {
-        expect(res.body.message).to.be.equal('This transaction could be not be processed.')
+      }).then(() => {
         done()
       }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
     })

--- a/test/unit/clients/connector_client_google_authentication_tests.js
+++ b/test/unit/clients/connector_client_google_authentication_tests.js
@@ -71,7 +71,6 @@ describe('connectors client - google authentication API', function () {
 
     describe('authorisation declined', function () {
       const declinedGoogleAuthRequest = fixtures.googleAuthRequestDetails({ lastDigitsCardNumber: '0002' })
-      const authorisationDeclinedResponse = fixtures.webPaymentFailedResponse('This transaction was declined.')
 
       before(() => {
         const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
@@ -79,7 +78,6 @@ describe('connectors client - google authentication API', function () {
           .withMethod('POST')
           .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
           .withUponReceiving('a valid google pay auth request which should be declined')
-          .withResponseBody(authorisationDeclinedResponse.getPactified())
           .withStatusCode(400)
           .build()
         return provider.addInteraction(builder)
@@ -92,8 +90,7 @@ describe('connectors client - google authentication API', function () {
           chargeId: TEST_CHARGE_ID,
           provider: 'google',
           payload: declinedGoogleAuthRequest.getPlain()
-        }).then(res => {
-          expect(res.body.message).to.be.equal('This transaction was declined.')
+        }).then(() => {
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })
@@ -101,7 +98,6 @@ describe('connectors client - google authentication API', function () {
 
     describe('authorisation error', function () {
       const errorGoogleAuthRequest = fixtures.googleAuthRequestDetails({ lastDigitsCardNumber: '0119' })
-      const authorisationErrorResponse = fixtures.webPaymentFailedResponse('This transaction could be not be processed.')
 
       before(() => {
         const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
@@ -109,7 +105,6 @@ describe('connectors client - google authentication API', function () {
           .withMethod('POST')
           .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
           .withUponReceiving('a valid google pay auth request which should return an error')
-          .withResponseBody(authorisationErrorResponse.getPactified())
           .withStatusCode(400)
           .build()
         return provider.addInteraction(builder)
@@ -122,8 +117,7 @@ describe('connectors client - google authentication API', function () {
           chargeId: TEST_CHARGE_ID,
           provider: 'google',
           payload: errorGoogleAuthRequest.getPlain()
-        }).then(res => {
-          expect(res.body.message).to.be.equal('This transaction could be not be processed.')
+        }).then(() => {
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })


### PR DESCRIPTION
The structure of error responses is changing so the message field will be an array. We should remove the field from the pact entirely as we don't consume it, so shouldn't be asserting on it.


