### PR TITLE
PP-5176: Fix client side async Google pay check

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -21,12 +21,14 @@
       {% endif %}
       {% if allowGooglePay %}
           if (window.PaymentRequest) {
-            var canMakeGooglePayPayment = new PaymentRequest({{ googlePayRequestMethodData | dump | safe }}, {{ googlePayRequestDetails | dump | safe }}).canMakePayment()
-            if (canMakeGooglePayPayment) {
-              document.body.classList.add('google-pay-available')
-            } else {
-              document.body.classList.add('google-pay-unavailable')
-            }
+            var googleAvailableRequest = new PaymentRequest({{ googlePayRequestMethodData | dump | safe }}, {{ googlePayRequestDetails | dump | safe }}).canMakePayment()
+            googleAvailableRequest.then(function (canMakeGooglePayPayment) { 
+              if (canMakeGooglePayPayment) {
+                document.body.classList.add('google-pay-available')
+              } else {
+                document.body.classList.add('google-pay-unavailable')
+              }
+            }) 
           }
       {% endif %}
       {% if allowApplePay or allowGooglePay %}


### PR DESCRIPTION
Google Pay async check ::

* Currently checks if(Promise) -- this will always be true
* Update to use Promise.then

Before merging/ testing:

This will introduce a wait before we know if Google Pay is available -- the user experience should be validated

Supersedes https://github.com/alphagov/pay-frontend/pull/841