### PR TITLE
PP-5205 - Nest spans so the clauses can sit together without CSS

### DIFF
--- a/app/assets/sass/modules/_cvc.scss
+++ b/app/assets/sass/modules/_cvc.scss
@@ -2,43 +2,40 @@
   display: none;
 }
 
-body:not(.js-enabled) .govuk-form-group.cvc .hidden {
-  display: block;
-  visibility: visible;
-  margin-right: 3px;
-  float: left;
-}
+body:not(.js-enabled) {
+  .generic-cvc {
+    display: block;
+  }
 
-body:not(.js-enabled) .govuk-form-group.cvc .amex-cvc {
-  text-transform: lowercase;
-}
+  .govuk-form-group.cvc .hidden {
+    display: inline;
+  }
 
-body:not(.js-enabled) .govuk-form-group.cvc .amex-cvc {
-  margin-left: 10px;
+  .no-js-lowercase {
+    display: inline;
+    text-transform: lowercase;
+  }
 }
 
 .govuk-form-group.cvc {
   .cvc {
-    margin-right: govuk-spacing(3);
     float: left;
+    margin-right: govuk-spacing(3);
   }
 
   img {
     position: relative;
     top: -1px;
     max-height: 38px;
-    margin-right: govuk-spacing(3);
     float: left;
+    margin-right: govuk-spacing(3);
   }
 
   .either {
-    margin-right: govuk-spacing(3);
-    float: left;
+    @include govuk-font($size: 19);
+    line-height: 37px!important;
     color: $govuk-secondary-text-colour;
-    line-height: 38px;
-  }
-
-  .form-hint {
-    overflow: hidden;
+    float: left;
+    margin-right: govuk-spacing(3);
   }
 }

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -22,13 +22,13 @@
       {% if allowGooglePay %}
           if (window.PaymentRequest) {
             var googleAvailableRequest = new PaymentRequest({{ googlePayRequestMethodData | dump | safe }}, {{ googlePayRequestDetails | dump | safe }}).canMakePayment()
-            googleAvailableRequest.then(function (canMakeGooglePayPayment) { 
+            googleAvailableRequest.then(function (canMakeGooglePayPayment) {
               if (canMakeGooglePayPayment) {
                 document.body.classList.add('google-pay-available')
               } else {
                 document.body.classList.add('google-pay-unavailable')
               }
-            }) 
+            })
           }
       {% endif %}
       {% if allowApplePay or allowGooglePay %}
@@ -246,11 +246,13 @@
               <span class="generic-cvc">
                 {{ __p("cardDetails.cvcTip") }}
               </span>
-              <span class="hidden">
-                {{ __p("cardDetails.amexcvcNonjs") }}
-              </span>
               <span class="amex-cvc hidden">
-                {{ __p("cardDetails.amexcvcTip") }}
+                <span class="hidden">
+                  {{ __p("cardDetails.amexcvcNonjs") }}
+                </span>
+                <span class="no-js-lowercase">
+                  {{ __p("cardDetails.amexcvcTip") }}
+                </span>
               </span>
             </span>
             {% if highlightErrorFields.cvc %}


### PR DESCRIPTION
We have 3 scenearios here:
- Default - 3 digit CVC hint
- AmEx - 4 digit CVC hint
- No-js - both hints togother. With 'For American Express' clause to make it read better.

These spans were all siblings and we're smushed together with floats and margins, this is convoluted and cause the flow to break because the CVC input floated to the end.

We can do it more simlpy by nesting them and using `display:inline`. But because HTML will automatically put a space if there is a whitespace between spans, we have to smush it together in the markup so it‘s all one line.

## Before

![Screen Shot 2019-05-13 at 14 38 49](https://user-images.githubusercontent.com/440503/57626023-f488fb80-758c-11e9-83d0-21055df3beda.png)

## After

![Screen Shot 2019-05-13 at 14 53 56](https://user-images.githubusercontent.com/440503/57627431-e8eb0400-758f-11e9-9eef-14e68666b93e.png)
