### PR TITLE
PP-5181 - Adding line for if service only accepts credit cards

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -164,6 +164,9 @@
             {% if withdrawalText === 'debit' %}
               {{ __p("cardDetails.withdrawalText").debit }}
             {% endif %}
+            {% if withdrawalText === 'credit' %}
+              {{ __p("cardDetails.withdrawalText").credit }}
+            {% endif %}
           </p>
           <div class="govuk-inset-text hidden" id="corporate-card-surcharge-message"></div>
         </div>

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -7,7 +7,8 @@
 		},
 		"withdrawalText": {
 			"debit_credit": "Math o gardiau credyd a debyd y derbynnir",
-			"debit": "Ni dderbynnir taliadau cerdyn credyd. Defnyddiwch gerdyn debyd os gwelwch yn dda."
+			"debit": "Ni dderbynnir taliadau cerdyn credyd. Defnyddiwch gerdyn debyd os gwelwch yn dda.",
+			"credit": "Ni dderbynnir taliadau cerdyn debyd. Defnyddiwch gerdyn credyd os gwelwch yn dda."
 		},
 		"title": "Rhowch fanylion y cerdyn",
 		"expiry": "Dyddiad dod i ben",

--- a/locales/en.json
+++ b/locales/en.json
@@ -7,7 +7,8 @@
 		},
 		"withdrawalText": {
 			"debit_credit": "Accepted credit and debit card types",
-			"debit": "Credit card payments are not accepted. Please use a debit card."
+			"debit": "Credit card payments are not accepted. Please use a debit card.",
+			"credit": "Debit card payments are not accepted. Please use a credit card."
 		},
 		"title": "Enter card details",
 		"expiry": "Expiry date",


### PR DESCRIPTION
This is unlikely and has always been technically possible but
selfservice didn’t allow you to set it up, soon [it will](https://github.com/alphagov/pay-selfservice/pull/1453)
So this makes sure we have messaging for it.

I have winged the Welsh using my innate ability as 50% Welsh and the
fact it looks like the nouns and words around dont change, I tried it
out in Google Translate too 🏴󠁧󠁢󠁷󠁬󠁳󠁿

