### PR TITLE
PP-5191 Allow auth success for auth handler

### DIFF
--- a/app/services/state_service.js
+++ b/app/services/state_service.js
@@ -14,7 +14,7 @@ module.exports = (function () {
     'card.confirm': [State.AUTH_SUCCESS],
     'card.auth3dsRequired': [State.AUTH_3DS_REQUIRED],
     'card.auth3dsRequiredIn': [State.AUTH_3DS_REQUIRED],
-    'card.auth3dsHandler': [State.AUTH_3DS_REQUIRED],
+    'card.auth3dsHandler': [State.AUTH_3DS_REQUIRED, State.AUTH_SUCCESS],
     'card.auth3dsRequiredOut': [State.AUTH_3DS_REQUIRED],
     'card.authWaiting': [State.AUTH_READY, State.AUTH_3DS_REQUIRED, State.AUTH_3DS_READY, State.AUTH_SUCCESS],
     'card.create': [State.AUTH_READY, State.ENTERING_CARD_DETAILS],

--- a/test/services/state_service_test.js
+++ b/test/services/state_service_test.js
@@ -40,7 +40,6 @@ describe('state service', function () {
     expect(stateService.resolveActionName(State.AUTH_3DS_REQUIRED, 'get')).to.eql('card.auth3dsRequired')
     expect(stateService.resolveActionName(State.AUTH_3DS_READY, 'get')).to.eql('card.authWaiting')
 
-    expect(stateService.resolveActionName(State.AUTH_SUCCESS, 'post')).to.eql('card.capture')
     expect(stateService.resolveActionName(State.CREATED, 'get')).to.eql('card.new')
 
     expect(stateService.resolveActionName(State.CAPTURE_READY, 'get')).to.eql('card.captureWaiting')


### PR DESCRIPTION
With stripe 3ds authorisations, the actual authorisation is triggered by
a notification, so has nothing to do with what the browser is up to. For
this reason, if there is some network slowness you can end up with the
user being returned after the payment has been authorised. Currently
this ends up with the user having the 'payment in progress' screen
displayed, because the state enforcer did not like that combination of route
and status. This PR allows this combination.