### PR TITLE
PP-5212 - Replace .after() function for compatibility

### DIFF
--- a/app/assets/javascripts/browsered/form-input-confirm.js
+++ b/app/assets/javascripts/browsered/form-input-confirm.js
@@ -13,7 +13,7 @@ const init = () => {
   const addFor = (input, confirmation) => {
     const formGroup = input.closest('.govuk-form-group')
 
-    formGroup.after(confirmation)
+    formGroup.parentNode.insertBefore(confirmation, formGroup.nextSibling)
   }
 
   function update (e) {


### PR DESCRIPTION
`.after()` is not compatible with IE as described here - https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/after
so replacing with something more robust