### PR TITLE
PP-5259 - Use correct classes to size the CVV and expiry inputs

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -188,7 +188,7 @@
               value="{{expiryYear}}"
               minlength="2"
               maxlength="4"
-              class="govuk-input govuk-date-input__input govuk-input--width-2"
+              class="govuk-input govuk-date-input__input govuk-input--width-4"
               autocomplete="cc-exp-year"
               data-last-of-form-group
               data-required
@@ -248,7 +248,7 @@
                 type="number"
                 value="{{cvc}}"
                 name="cvc"
-                class="govuk-input govuk-!-width-one-quarter cvc"
+                class="govuk-input govuk-input--width-3 cvc"
                 maxlength="4"
                 autocomplete="cc-csc"/>
         <img src="/images/security-code.png" class="generic-cvc" alt="{{ __p("cardDetails.cvcTip") }}"/>


### PR DESCRIPTION
The CVV defaulted to 100% width on mobile which pushed the card icon
down onto the line below which looks bad.

Also year should be wide enough for 4 digits as some people may enter
the full year and it makes it easier to read if that happens