### PR TITLE
PP-5225 - styling for disabled web payments button

### DIFF
--- a/app/assets/sass/modules/_web-payments.scss
+++ b/app/assets/sass/modules/_web-payments.scss
@@ -25,6 +25,10 @@
   &:hover {
     background: black;
   }
+
+  &[disabled] {
+    background: $govuk-secondary-text-colour;
+  }
 }
 
 .web-payments-logo {


### PR DESCRIPTION
After a person submits a Apple/Google Pay payment we disabled the
button, we didn’t have any default styling so it went green. This
overrides it to match the styling better