### PR TITLE
PP-5279 - fix Apple Pay when Google Pay is also availabled

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/index.js
+++ b/app/assets/javascripts/browsered/web-payments/index.js
@@ -6,7 +6,7 @@ const makeApplePayRequest = require('./apple-pay')
 const { googlePayNow } = require('./google-pay')
 
 // Browser elements
-const paymentMethodForm = document.getElementById('web-payments-container')
+const paymentMethodForms = Array.prototype.slice.call(document.getElementsByClassName('web-payments-container'))
 const standardMethodForm = document.getElementById('card-details')
 
 const initApplePayIfAvailable = () => {
@@ -23,20 +23,22 @@ const initGooglePayIfAvailable = () => {
 
 const setupEventListener = () => {
   if (window.PaymentRequest || window.ApplePaySession) {
-    paymentMethodForm.addEventListener('submit', function (e) {
-      e.preventDefault()
-      clearErrorSummary()
-      const webPaymentMethod = e.target[0].value
+    paymentMethodForms.forEach(form => {
+      form.addEventListener('submit', function (e) {
+        e.preventDefault()
+        clearErrorSummary()
+        const webPaymentMethod = e.target[0].value
 
-      ga('send', 'event', webPaymentMethod, 'Selection', `User chose ${webPaymentMethod} method`)
+        ga('send', 'event', webPaymentMethod, 'Selection', `User chose ${webPaymentMethod} method`)
 
-      switch (webPaymentMethod) {
-        case 'Apple Pay':
-          return makeApplePayRequest()
-        case 'Google Pay':
-          return googlePayNow()
-      }
-    }, false)
+        switch (webPaymentMethod) {
+          case 'Apple Pay':
+            return makeApplePayRequest()
+          case 'Google Pay':
+            return googlePayNow()
+        }
+      }, false)
+    })
 
     standardMethodForm.addEventListener('submit', function (e) {
       ga('send', 'event', 'Standard', 'Selection', `User chose Standard method`)

--- a/app/assets/sass/modules/_web-payments.scss
+++ b/app/assets/sass/modules/_web-payments.scss
@@ -1,17 +1,18 @@
-#web-payments-container {
+#apple-pay-container,
+#google-pay-container {
   display: none;
 }
 
 // Toggle Apple Pay
 .apple-pay-available {
-  #web-payments-container {
+  #apple-pay-container {
     display: block;
   }
 }
 
 // Toggle Google Pay
 .google-pay-available {
-  #web-payments-container {
+  #google-pay-container {
     display: block;
   }
 }

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -56,32 +56,39 @@
         </ul>
       </div>
     </div>
-    {% if allowApplePay or allowGooglePay %}
-      {% if allowApplePay %}
-        {% set buttonHTML %}
-            {{ __p("cardDetails.webPayments.payWith") }}
-            <span class="govuk-visually-hidden">Apple Pay</span>
-            <img role="presentation" class="web-payments-logo" src="/images/apple-pay-logo.svg"/>
-        {% endset %}
-        {% set webPaymentValue = 'Apple Pay'%}
-        {% set webPaymentClass = 'apple-pay'%}
-      {% endif %}
-      {% if allowGooglePay %}
-        {% set buttonHTML %}
-            {{ __p("cardDetails.webPayments.payWith") }}
-            <span class="govuk-visually-hidden">Google Pay</span>
-            <img role="presentation" class="web-payments-logo" src="/images/google-pay-logo.svg"/>
-        {% endset %}
-        {% set webPaymentValue = 'Google Pay'%}
-        {% set webPaymentClass = 'google-pay'%}
-      {% endif %}
-
-      <form id="web-payments-container" class="govuk-!-width-three-quarters">
-          <input type="hidden" name="payment-method" value="{{webPaymentValue}}"/>
+    {% if allowApplePay %}
+      {% set ApplePayButtonHTML %}
+          {{ __p("cardDetails.webPayments.payWith") }}
+          <span class="govuk-visually-hidden">Apple Pay</span>
+          <img role="presentation" class="web-payments-logo" src="/images/apple-pay-logo.svg"/>
+      {% endset %}
+      <form id="apple-pay-container" class="govuk-!-width-three-quarters web-payments-container">
+        <input type="hidden" name="payment-method" value="Apple Pay"/>
           {{
             govukButton({
-              html: buttonHTML,
-              classes: "web-payments-button " + webPaymentClass,
+              html: ApplePayButtonHTML,
+              classes: "web-payments-button apple-pay",
+              attributes: {
+                id: "payment-method-submit"
+              }
+            })
+          }}
+        <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
+        <span class="pay-divider"><span class="pay-divider--word">or</span></span>
+      </form>
+    {% endif %}
+    {% if allowGooglePay %}
+      {% set GooglePayButtonHTML %}
+          {{ __p("cardDetails.webPayments.payWith") }}
+          <span class="govuk-visually-hidden">Google Pay</span>
+          <img role="presentation" class="web-payments-logo" src="/images/google-pay-logo.svg"/>
+      {% endset %}
+      <form id="google-pay-container" class="govuk-!-width-three-quarters web-payments-container">
+          <input type="hidden" name="payment-method" value="Google Pay"/>
+          {{
+            govukButton({
+              html: GooglePayButtonHTML,
+              classes: "web-payments-button google-pay",
               attributes: {
                 id: "payment-method-submit"
               }


### PR DESCRIPTION
If both are available we had overrode the Apple Button with a Google one.

Now we make a separate form for each and use Javascript/CSS to determine which one to present to user.

Had to also rejig the JS to understand there are two forms on the page and it needs to set event listeners on both
