### PR TITLE
PP-5366 - pattern is problematic

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -125,7 +125,6 @@
         <input id="card-no"
                 type="text"
                 inputmode="numeric"
-                pattern="[0-9]*"
                 name="cardNo"
                 maxlength="26"
                 class="govuk-input govuk-!-width-three-quarters"


### PR DESCRIPTION
Whilst it makes the number pad show on older iOS devices also then show
native error pop ups if the users uses non whitelisted characters we
want to allow people to enter their card number with or without spaces.

Editing the regex to allow spaces stops it from showing the number pad
so it’s redundant to include it.