### PR TITLE
RED-116: Use tini in docker to run node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/
 
 RUN ["apk", "--no-cache", "upgrade"]
 
-RUN ["apk", "add", "--no-cache", "nodejs", "npm"]
+RUN ["apk", "add", "--no-cache", "nodejs", "npm", "tini"]
 
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json
@@ -22,4 +22,6 @@ ADD . /app
 ENV LD_LIBRARY_PATH /app/node_modules/appmetrics
 RUN ["ln", "-s", "/tmp/node_modules", "/app/node_modules"]
 
-CMD npm start
+ENTRYPOINT ["tini", "--"]
+
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# alpine:3.8
 FROM alpine@sha256:ea47a59a33f41270c02c8c7764e581787cf5b734ab10d27e876e62369a864459
 
 ### Needed to run appmetrics and pact-mock-service


### PR DESCRIPTION
By having bash as PID 1, we have a problem. Signals sent to the container (e.g.
SIGTERM to shut it down) will not reach npm - bash will not pass them on. This
means that shutting the container down is done uncleanly. Once the SIGTERM is
ignored, the container orchestrator will then send a SIGKILL and forcibly exit
the process.

We could make npm PID 1 instead but this creates further problems - If npm
creates any child processes and those processes (or any of their children) die,
npm will be the parent of them and will not know to waitpid() on them, so they
will remain zombies forever.

tini solves these problems - it will correctly reparent orphaned child
processes and pass signals through to npm.
