### PR TITLE
PP-5366 - Suppress native browser validation

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -101,7 +101,7 @@
 
     <h1 class="govuk-heading-l">{{ __p("cardDetails.title") }}</h1>
 
-    <form id="card-details" name="cardDetails" method="POST" action="{{ post_card_action }}">
+    <form id="card-details" name="cardDetails" method="POST" action="{{ post_card_action }}" novalidate>
       <input id="charge-id" name="chargeId" type="hidden" value="{{ id }}"/>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       {% if (originalEmail) %}
@@ -125,6 +125,7 @@
         <input id="card-no"
                 type="text"
                 inputmode="numeric"
+                pattern="[0-9]*"
                 name="cardNo"
                 maxlength="26"
                 class="govuk-input govuk-!-width-three-quarters"


### PR DESCRIPTION
In some modern browsers when a pattern attribute is added a native
browser message pops up and blocks form submission. They’re not helpful
and just suppress our more helpful error messages.

Thanks @nickcolley for the tip https://github.com/alphagov/govuk-design-system/issues/941#issuecomment-506286337
