### PR TITLE
BAU - bump to latest version of product page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15708,8 +15708,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/2.1.81/pay-product-page-2.1.81.tgz",
-      "integrity": "sha512-p1j+Lt+o6gBZ+RMrwFisjiMCRm4StGzJFE6fj7GF10Huw/TLbVmAYj+ghem/NOuT94wB1104QGd+8LPctlay3A==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/2.1.82/pay-product-page-2.1.82.tgz",
+      "integrity": "sha512-NmGh5RVwVP5jZscSd7qlKFE8hFhS5fUs+IF/BrEVDlvYfVZQ0lMgKWDgya4cm/O3oDwEgk+kA06CO5Dm4inF+A==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "nodemon": "^1.19.1",
     "nyc": "14.1.x",
     "pact": "4.3.2",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.81/pay-product-page-2.1.81.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/2.1.82/pay-product-page-2.1.82.tgz",
     "proxyquire": "~2.1.0",
     "sass-lint": "^1.13.1",
     "sinon": "7.3.x",


### PR DESCRIPTION
Which includes this fix https://github.com/alphagov/pay-product-page/pull/149