### PR TITLE
PP-5406 - revert confirmation page design changes

### DIFF
--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -12,114 +12,6 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-9">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">{{ __p("confirmDetails.title") }}</h1>
-    <form id="confirmation" method="POST" action="{{ confirmPath }}" class="form">
-      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
-      <input id="chargeId" name="chargeId" type="hidden" value="{{ charge.id }}"/>
-      {% set confirmButtonHTML %}
-        {{ __p("confirmDetails.pay") }}
-        <span class="govuk-!-font-weight-bold">£{{ charge.totalAmount if charge.totalAmount else charge.amount }}</span>
-        {{ __p("confirmDetails.now") }}
-      {% endset %}
-      {{
-        govukButton({
-          html: confirmButtonHTML,
-          classes: "govuk-!-font-size-24 pay-button--custom",
-          attributes: {
-            id: 'confirm',
-            'data-module': 'stop-double-submit'
-          }
-        })
-      }}
-    </form>
-
-    {% if charge.corporateCardSurcharge %}
-      {% set chargeDetailsArray = [
-        [
-          {
-            text: __p('confirmDetails.description')
-          },
-          {
-            text: charge.description,
-            classes: 'govuk-!-width-two-thirds',
-            attributes: {
-              id: 'payment-description'
-            }
-          }
-        ],
-        [
-          {
-            text: __p('paymentSummary.amount')
-          },
-          {
-            text: '£' + charge.amount,
-            classes: 'govuk-!-width-two-thirds',
-            attributes: {
-              id: 'payment-summary-breakdown-amount'
-            }
-          }
-        ],
-        [
-          {
-            text: __p('paymentSummary.corporateCardFee')
-          },
-          {
-            text: '£' + charge.corporateCardSurcharge,
-            classes: 'govuk-!-width-two-thirds',
-            attributes: {
-              id: 'payment-summary-corporate-card-fee'
-            }
-          }
-        ],
-        [
-          {
-            text: __p('paymentSummary.totalAmount')
-          },
-          {
-            text: '£' + charge.totalAmount,
-            classes: 'govuk-!-width-two-thirds',
-            attributes: {
-              id: 'amount'
-            }
-          }
-        ]
-      ] %}
-    {% else %}
-      {% set chargeDetailsArray = [
-        [
-          {
-            text: __p('confirmDetails.description')
-          },
-          {
-            text: charge.description,
-            classes: 'govuk-!-width-two-thirds',
-            attributes: {
-              id: 'payment-description'
-            }
-          }
-        ],
-        [
-          {
-            text: __p('paymentSummary.amount')
-          },
-          {
-            text: '£' + charge.amount,
-            classes: 'govuk-!-width-two-thirds',
-            attributes: {
-              id: 'amount'
-            }
-          }
-        ]
-      ] %}
-    {% endif %}
-
-    {{
-      govukTable({
-        caption: __p('paymentSummary.title'),
-        captionClasses: 'govuk-!-font-size-24 govuk-!-margin-top-3 govuk-!-margin-bottom-3',
-        firstCellIsHeader: true,
-        rows: chargeDetailsArray
-      })
-    }}
 
     {% set cardDetailsArray = [
       [
@@ -198,12 +90,27 @@
 
     {{
       govukTable({
-        caption: __p('confirmDetails.cardDetails'),
-        captionClasses: 'govuk-!-font-size-24 govuk-!-margin-top-3 govuk-!-margin-bottom-3',
         firstCellIsHeader: true,
         rows: cardDetailsArray.concat(billingAddressArray).concat(emailArray)
       })
     }}
+
+    <form id="confirmation" method="POST" action="{{ confirmPath }}" class="form">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+      <input id="chargeId" name="chargeId" type="hidden" value="{{ charge.id }}"/>
+      {% set confirmButtonHTML %}
+        {{ __p("commonButtons.confirmButton") }}
+      {% endset %}
+      {{
+        govukButton({
+          html: confirmButtonHTML,
+          attributes: {
+            id: 'confirm',
+            'data-module': 'stop-double-submit'
+          }
+        })
+      }}
+    </form>
 
     <form id="cancel" name="cancel" method="POST" action="{{ post_cancel_action }}" class="form">
       <div>
@@ -211,6 +118,24 @@
         <input id="csrf2" name="csrfToken" type="hidden" value="{{ csrf }}"/>
       </div>
     </form>
+  </div>
+  <div class="govuk-grid-column-one-third payment-summary-wrap">
+    <aside class="payment-summary">
+      <h2 class="govuk-heading-m">{{ __p("paymentSummary.title") }}</h2>
+      <p id="payment-description" class="govuk-body">
+        {{ charge.description }}
+      </p>
+      {% if charge.corporateCardSurcharge %}
+      <p class="govuk-body" id="payment-summary-breakdown">
+        {{ __p("paymentSummary.amount") }} <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount">£{{ charge.amount }}</span><br/>
+        {{ __p("paymentSummary.corporateCardFee") }} <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee">£{{ charge.corporateCardSurcharge }}</span>
+      </p>
+      {% endif %}
+      <p class="govuk-body govuk-!-margin-bottom-0">
+        {{ __p("paymentSummary.totalAmount") }}
+        <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold">£{{ charge.totalAmount if charge.totalAmount else charge.amount }}</span>
+      </p>
+    </aside>
   </div>
 </div>
 {% endblock %}

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -36,6 +36,7 @@
 		"corporateDebitCardSurchargeMessage": "Mae ffi o £%s am ddefnyddio cerdyn ddebyd corfforaethol"
 	},
 	"commonButtons": {
+		"confirmButton": "Cadarnhau’r taliad",
 		"continueButton": "Parhau",
 		"cancelButton": "Canslo’r taliad",
 		"goBackToService": "Mynd yn ôl i’r gwasanaeth"

--- a/locales/en.json
+++ b/locales/en.json
@@ -33,6 +33,7 @@
 		"corporateDebitCardSurchargeMessage": "There is a fee of £%s for using a corporate debit card"
 	},
 	"commonButtons": {
+		"confirmButton": "Confirm payment",
 		"continueButton": "Continue",
 		"cancelButton": "Cancel payment",
 		"goBackToService": "Go back to the service"

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -206,7 +206,7 @@ describe('The confirm view', function () {
         action: '/card_details/123/confirm',
         method: 'POST'
       })
-    $('#confirm').text().replace(/\s+/g, ' ').trim().should.contain('Pay £50 now')
+    $('#confirm').text().replace(/\s+/g, ' ').trim().should.contain('Confirm payment')
     body.should.containInputField('chargeId', 'hidden').withAttribute('value', '1234')
   })
 


### PR DESCRIPTION
- Moved button back to bottom and changed it back to just say 'Confirm
payment'
- Added the summary panel on the right
- Removed the table that replaced the summary panel

## BEFORE

![Screenshot_2019-07-04 Confirm your payment(1)](https://user-images.githubusercontent.com/440503/60679350-35134000-9e7f-11e9-83cd-70910ce73f16.png)

## AFTER

![Screenshot_2019-07-04 Confirm your payment(2)](https://user-images.githubusercontent.com/440503/60679354-3a708a80-9e7f-11e9-9806-8d51cf3867de.png)



