### PR TITLE
PP-5560 - govuk-frontend 3.0 upgrade

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend/all";
+@import "govuk-frontend/govuk/all";
 
 @import "modules/3ds";
 @import "modules/accepted-cards";

--- a/app/assets/sass/modules/_button-reset.scss
+++ b/app/assets/sass/modules/_button-reset.scss
@@ -15,6 +15,20 @@
   &:hover {
     color: $govuk-link-hover-colour;
   }
+
+  &:focus {
+    @include govuk-not-ie8 {
+      outline: $govuk-focus-width solid transparent;
+      outline-offset: 0;
+    }
+    color: $govuk-text-colour;
+    background-color: $govuk-focus-colour;
+    box-shadow: -5px -1px 0 1px $govuk-focus-colour,
+                5px -1px 0 1px $govuk-focus-colour,
+                -3px 1px 0 3px $govuk-text-colour,
+                3px 1px 0 3px $govuk-text-colour;
+    text-decoration: none;
+  }
 }
 
 .pay-button--custom {

--- a/app/assets/sass/modules/_button-reset.scss
+++ b/app/assets/sass/modules/_button-reset.scss
@@ -17,17 +17,7 @@
   }
 
   &:focus {
-    @include govuk-not-ie8 {
-      outline: $govuk-focus-width solid transparent;
-      outline-offset: 0;
-    }
-    color: $govuk-text-colour;
-    background-color: $govuk-focus-colour;
-    box-shadow: -5px -1px 0 1px $govuk-focus-colour,
-                5px -1px 0 1px $govuk-focus-colour,
-                -3px 1px 0 3px $govuk-text-colour,
-                3px 1px 0 3px $govuk-text-colour;
-    text-decoration: none;
+    @include govuk-focused-text;
   }
 }
 

--- a/app/assets/sass/modules/_summary-panel.scss
+++ b/app/assets/sass/modules/_summary-panel.scss
@@ -2,7 +2,7 @@
   margin-top: govuk-spacing(6);
   border-top: 2px solid $govuk-brand-colour;
   padding: govuk-spacing(3);
-  background-color: govuk-colour('grey-4');
+  background-color: govuk-colour('light-grey');
 
   @include govuk-media-query($from: tablet) {
     margin-top: 0;

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
-{% from "components/radios/macro.njk" import govukRadios %}
-{% from "components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block pageTitle %}
   {{ __p("cardDetails.title") }}

--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
-{% from "components/button/macro.njk" import govukButton %}
-{% from "components/table/macro.njk" import govukTable %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% block pageTitle %}
   {{ __p("confirmDetails.title") }}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
 {% set htmlLang = language %}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9180,9 +9180,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-2.13.0.tgz",
-      "integrity": "sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.0.0.tgz",
+      "integrity": "sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A=="
     },
     "graceful-fs": {
       "version": "4.1.11",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "csrf": "3.1.x",
     "express": "4.17.x",
     "gaap-analytics": "^3.0.0",
-    "govuk-frontend": "^2.13.0",
+    "govuk-frontend": "^3.0.0",
     "humps": "^2.0.1",
     "i18n": "0.8.x",
     "lodash": "4.17.x",

--- a/server.js
+++ b/server.js
@@ -50,7 +50,7 @@ function initialiseGlobalMiddleware (app) {
   app.set('settings', { getVersionedPath: staticify.getVersionedPath })
   app.use(/\/((?!images|public|stylesheets|javascripts).)*/, loggingMiddleware(
     ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" - total time :response-time ms'))
-  app.use(favicon(path.join(__dirname, '/node_modules/govuk-frontend/assets/images', 'favicon.ico')))
+  app.use(favicon(path.join(__dirname, '/node_modules/govuk-frontend/govuk/assets/images', 'favicon.ico')))
   app.use(staticify.middleware)
 
   app.use(function (req, res, next) {
@@ -128,7 +128,7 @@ function initialisePublic (app) {
   app.use('/javascripts', express.static(path.join(__dirname, '/public/assets/javascripts'), publicCaching))
   app.use('/images', express.static(path.join(__dirname, '/public/images'), publicCaching))
   app.use('/stylesheets', express.static(path.join(__dirname, '/public/assets/stylesheets'), publicCaching))
-  app.use('/', express.static(path.join(__dirname, '/node_modules/govuk-frontend/')))
+  app.use('/', express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/')))
   app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-pay/pay-js-commons/')))
 }
 


### PR DESCRIPTION
Updated all templates to meet breaking changes as part of 3.0.0 release which are all detailed here — https://github.com/alphagov/govuk-frontend/releases/tag/v3.0.0

This 3.0 release includes numerous accessibility updates but most visually prominent is the all new colour scheme - https://designnotes.blog.gov.uk/2019/07/29/weve-made-the-gov-uk-design-system-more-accessible/