### PR TITLE
Bump pay-js-commons to 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "2.6.0",
+    "@govuk-pay/pay-js-commons": "2.7.0",
     "accessible-autocomplete": "^1.6.2",
     "appmetrics": "4.0.x",
     "appmetrics-statsd": "3.0.x",


### PR DESCRIPTION
- Bumps pay js commons to 2.7.0
