### PR TITLE
PP-5546 Add pact test for find charge

### DIFF
--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -53,7 +53,7 @@ module.exports = {
 
   connectorGetChargeDetails: (opts = {}) => {
     const path = `/v1/frontend/charges/${opts.chargeId}`
-    const body = paymentFixtures.validChargeDetails(opts)
+    const body = paymentFixtures.validChargeDetails(opts).getPlain()
 
     return simpleStubBuilder('GET', 200, path, body)
   },
@@ -92,7 +92,7 @@ module.exports = {
       chargeId: opts.chargeId,
       status: 'ENTERING CARD DETAILS',
       state: { finished: false, status: 'started' }
-    })
+    }).getPlain()
 
     return simpleStubBuilder('PATCH', 200, path, body)
   },
@@ -105,8 +105,8 @@ module.exports = {
   },
 
   connectorMultipleSubsequentChargeDetails: ([ firstChargeOpts, secondChargeOpts ]) => {
-    const firstChargeBody = paymentFixtures.validChargeDetails(firstChargeOpts)
-    const secondChargeBody = paymentFixtures.validChargeDetails(secondChargeOpts)
+    const firstChargeBody = paymentFixtures.validChargeDetails(firstChargeOpts).getPlain()
+    const secondChargeBody = paymentFixtures.validChargeDetails(secondChargeOpts).getPlain()
 
     const stub = {
       predicates: [{

--- a/test/fixtures/pact_base.js
+++ b/test/fixtures/pact_base.js
@@ -3,12 +3,11 @@ let Pact = require('pact')
 let matchers = Pact.Matchers
 
 module.exports = function (options = {}) {
-  let pactifySimpleArray = (arr) => {
-    let pactified = []
-    arr.forEach((val) => {
-      pactified.push(matchers.somethingLike(val))
-    })
-    return pactified
+  let pactifyArray = (arr) => {
+    if (arr.length && arr[0].constructor === Object) {
+      return pactifyNestedArray(arr)
+    }
+    return arr.map(matchers.somethingLike)
   }
 
   let pactifyNestedArray = (arr) => {
@@ -18,10 +17,12 @@ module.exports = function (options = {}) {
   let pactify = (object) => {
     let pactified = {}
     _.forIn(object, (value, key) => {
-      if (options.array && options.array.indexOf(key) !== -1) {
+      if (value === null) {
+        pactified[key] = null
+      } else if (options.array && options.array.indexOf(key) !== -1) {
         pactified[key] = matchers.eachLike(matchers.somethingLike(value[0]), { min: value.length })
       } else if (value.constructor === Array) {
-        pactified[key] = pactifySimpleArray(value)
+        pactified[key] = pactifyArray(value)
       } else if (value.constructor === Object) {
         pactified[key] = pactify(value)
       } else {

--- a/test/fixtures/payment_fixtures.js
+++ b/test/fixtures/payment_fixtures.js
@@ -1,106 +1,109 @@
+const lodash = require('lodash')
+const pactBase = require('./pact_base')()
+
 // helper methods for building entities common to many different types of requests
 const buildGatewayAccount = function buildGatewayAccount (opts = {}) {
+  const cardTypes = opts.cardTypes
+    ? lodash.flatMap(opts.cardTypes, buildCardType)
+    : buildStandardSupportedCardTypes()
   const structure = {
     'gateway_account_id': opts.gatewayAccountId || 6,
-    'allowApplePay': opts.allowApplePay || false,
-    'allowGooglePay': opts.allowGooglePay || false,
-    'gatewayMerchantId': opts.gatewayMerchantId || '',
-    'analytics_id': null,
-    card_types: buildStandardSupportedCardTypes(),
-    'corporate_credit_card_surcharge_amount': 0, // are these needed?
+    'allow_apple_pay': opts.allowApplePay || false,
+    'allow_google_pay': opts.allowGooglePay || false,
+    'gateway_merchant_id': opts.gatewayMerchantId || null,
+    'analytics_id': opts.analyticsId || 'an-analytics-id',
+    'corporate_credit_card_surcharge_amount': 0,
     'corporate_debit_card_surcharge_amount': 0,
     'corporate_prepaid_credit_card_surcharge_amount': 0,
     'corporate_prepaid_debit_card_surcharge_amount': 0,
     'email_collection_mode': 'MANDATORY',
-    'email_notifications': {
-      'PAYMENT_CONFIRMED': {
-        'enabled': true,
-        'template_body': null,
-        'version': 1
-      },
-      'REFUND_ISSUED': {
-        'enabled': true,
-        'template_body': null,
-        'version': 1
-      }
-    },
-    'gateway_merchant_id': null,
     'live': false,
-    'notifySettings': null,
     'payment_provider': 'sandbox',
     'requires3ds': false,
     'service_name': 'My service',
     'type': 'test',
-    'version': 1
+    'version': 1,
+    'integration_version_3ds': opts.integrationVersion3ds || 1,
+    card_types: cardTypes
   }
   return structure
 }
 
+const buildCardType = function buildCardType (opts) {
+  return {
+    'brand': opts.brand || 'visa',
+    'id': opts.id || 'an-id',
+    'label': opts.label || 'Visa',
+    'requires3ds': opts.requires3ds || false,
+    'type': opts.type || 'DEBIT'
+  }
+}
+
 const buildStandardSupportedCardTypes = function buildStandardSupportedCardTypes () {
   const structure = [
-    {
-      'brand': 'visa',
-      'id': 'b9dae820-0d11-4280-b8bb-6a3a320b7e7a',
-      'label': 'Visa',
-      'requires3ds': false,
-      'type': 'DEBIT'
-    },
-    {
-      'brand': 'visa',
-      'id': 'b2c53a34-8566-4050-963f-7f20b43f3650',
-      'label': 'Visa',
-      'requires3ds': false,
-      'type': 'CREDIT'
-    },
-    {
-      'brand': 'master-card',
-      'id': 'e33c7b30-f2f5-4d9d-ac00-a61d598d353e',
-      'label': 'Mastercard',
-      'requires3ds': false,
-      'type': 'DEBIT'
-    },
-    {
-      'brand': 'master-card',
-      'id': 'f9adcba5-3c8e-4bbb-bb29-3d8f1cf152fc',
-      'label': 'Mastercard',
-      'requires3ds': false,
-      'type': 'CREDIT'
-    },
-    {
-      'brand': 'american-express',
-      'id': '9cb3f107-391b-4ca9-a42e-27e8a0b277a2',
-      'label': 'American Express',
-      'requires3ds': false,
-      'type': 'CREDIT'
-    },
-    {
-      'brand': 'diners-club',
-      'id': 'c36f5a66-ce27-462f-a971-76783eed40e7',
-      'label': 'Diners Club',
-      'requires3ds': false,
-      'type': 'CREDIT'
-    },
-    {
-      'brand': 'discover',
-      'id': 'e0f2590d-219f-4627-b693-43fa8bb41583',
-      'label': 'Discover',
-      'requires3ds': false,
-      'type': 'CREDIT'
-    },
-    {
-      'brand': 'jcb',
-      'id': '45714fbd-ca7b-4900-9777-084fe5b223be',
-      'label': 'Jcb',
-      'requires3ds': false,
-      'type': 'CREDIT'
-    },
-    {
-      'brand': 'unionpay',
-      'id': 'acd5ca07-d27d-43b6-9e2a-bb42699dc644',
-      'label': 'Union Pay',
-      'requires3ds': false,
-      'type': 'CREDIT'
-    }
+    buildCardType({
+      brand: 'visa',
+      id: 'b9dae820-0d11-4280-b8bb-6a3a320b7e7a',
+      label: 'Visa',
+      requires3ds: false,
+      type: 'DEBIT'
+    }),
+    buildCardType({
+      brand: 'visa',
+      id: 'b2c53a34-8566-4050-963f-7f20b43f3650',
+      label: 'Visa',
+      requires3ds: false,
+      type: 'CREDIT'
+    }),
+    buildCardType({
+      brand: 'master-card',
+      id: 'e33c7b30-f2f5-4d9d-ac00-a61d598d353e',
+      label: 'Mastercard',
+      requires3ds: false,
+      type: 'DEBIT'
+    }),
+    buildCardType({
+      brand: 'master-card',
+      id: 'f9adcba5-3c8e-4bbb-bb29-3d8f1cf152fc',
+      label: 'Mastercard',
+      requires3ds: false,
+      type: 'CREDIT'
+    }),
+    buildCardType({
+      brand: 'american-express',
+      id: '9cb3f107-391b-4ca9-a42e-27e8a0b277a2',
+      label: 'American Express',
+      requires3ds: false,
+      type: 'CREDIT'
+    }),
+    buildCardType({
+      brand: 'diners-club',
+      id: 'c36f5a66-ce27-462f-a971-76783eed40e7',
+      label: 'Diners Club',
+      requires3ds: false,
+      type: 'CREDIT'
+    }),
+    buildCardType({
+      brand: 'discover',
+      id: 'e0f2590d-219f-4627-b693-43fa8bb41583',
+      label: 'Discover',
+      requires3ds: false,
+      type: 'CREDIT'
+    }),
+    buildCardType({
+      brand: 'jcb',
+      id: '45714fbd-ca7b-4900-9777-084fe5b223be',
+      label: 'Jcb',
+      requires3ds: false,
+      type: 'CREDIT'
+    }),
+    buildCardType({
+      brand: 'unionpay',
+      id: 'acd5ca07-d27d-43b6-9e2a-bb42699dc644',
+      label: 'Union Pay',
+      requires3ds: false,
+      type: 'CREDIT'
+    })
   ]
   return structure
 }
@@ -144,39 +147,37 @@ const utilFormatPrefilledCardHolderDetails = (details) => {
 
 const buildChargeDetails = function buildChargeDetails (opts) {
   const chargeId = opts.chargeId || 'ub8de8r5mh4pb49rgm1ismaqfv'
-  const structure = {
+  const data = {
     'amount': opts.amount || 1000,
-    'state': opts.state,
+    'state': opts.state || {
+      'status': 'created',
+      'finished': false
+    },
     'description': opts.description || 'Example fixture payment',
     'language': opts.language || 'en',
-    'status': opts.status,
-    'links': [{
-      'rel': 'self',
-      'method': 'GET',
-      'href': `https://connector:9300/v1/frontend/charges/${chargeId}`
-    }, {
-      'rel': 'cardAuth',
-      'method': 'POST',
-      'href': `https://connector:9300/v1/frontend/charges/${chargeId}/cards`
-    }, {
-      'rel': 'cardCapture',
-      'method': 'POST',
-      'href': `https://connector:9300/v1/frontend/charges/${chargeId}/capture`
-    }],
+    'status': opts.status || 'CREATED',
     charge_id: chargeId,
     'return_url': opts.returnUrl || '/?confirm',
-    // 'created_date': '2019-02-12T17:53:31.307Z',
+    'created_date': '2019-02-12T17:53:31.307Z',
     'delayed_capture': false,
     'gateway_account': buildGatewayAccount(opts)
   }
 
-  if (opts.state) { structure.state = opts.state }
+  if (opts.state) { data.state = opts.state }
 
   if (opts.paymentDetails) {
-    structure.email = opts.paymentDetails.email
-    structure.card_details = utilFormatPaymentDetails(opts.paymentDetails)
+    data.email = opts.paymentDetails.email
+    data.card_details = utilFormatPaymentDetails(opts.paymentDetails)
   }
-  return structure
+
+  return {
+    getPactified: () => {
+      return pactBase.pactify(data)
+    },
+    getPlain: () => {
+      return data
+    }
+  }
 }
 
 const buildChargeDetailsWithPrefilledCardHolderDeatils = (opts) => {

--- a/test/unit/clients/connector_client_charge_tests.js
+++ b/test/unit/clients/connector_client_charge_tests.js
@@ -1,0 +1,59 @@
+'use strict'
+
+// NPM dependencies
+const path = require('path')
+const Pact = require('pact')
+const { expect } = require('chai')
+
+// Local dependencies
+const connectorClient = require('../../../app/services/clients/connector_client')
+const fixtures = require('../../fixtures/payment_fixtures')
+const { PactInteractionBuilder } = require('../../fixtures/pact_interaction_builder')
+
+const TEST_CHARGE_ID = 'testChargeId'
+const GET_CHARGE_URL = `/v1/frontend/charges/${TEST_CHARGE_ID}`
+
+const PORT = Math.floor(Math.random() * 48127) + 1024
+const BASE_URL = `http://localhost:${PORT}`
+
+describe('connector client - charge tests', function () {
+  const provider = Pact({
+    consumer: 'frontend',
+    provider: 'connector',
+    port: PORT,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(() => provider.finalize())
+
+  describe('find charge', function () {
+    describe('find charge success', function () {
+      before(() => {
+        const response = fixtures.validChargeDetails({
+          chargeId: TEST_CHARGE_ID,
+          cardTypes: [{ brand: 'visa' }]
+        })
+
+        const builder = new PactInteractionBuilder(GET_CHARGE_URL)
+          .withMethod('GET')
+          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withUponReceiving('a valid get charge request')
+          .withResponseBody(response.getPactified())
+          .withStatusCode(200)
+          .build()
+        return provider.addInteraction(builder)
+      })
+
+      afterEach(() => provider.verify())
+
+      it('should return charge', async function () {
+        const res = await connectorClient({ baseUrl: BASE_URL }).findCharge({ chargeId: TEST_CHARGE_ID })
+        expect(res.body.charge_id).to.be.equal(TEST_CHARGE_ID)
+      })
+    })
+  })
+})

--- a/test/unit/clients/connector_client_google_authentication_tests.js
+++ b/test/unit/clients/connector_client_google_authentication_tests.js
@@ -16,7 +16,7 @@ const BASEURL = `http://localhost:${PORT}`
 
 // Custom dependencies
 const connectorClient = require('../../../app/services/clients/connector_client')
-const fixtures = require('../../fixtures/wallet_payment_fixtures.js')
+const fixtures = require('../../fixtures/wallet_payment_fixtures')
 const { PactInteractionBuilder } = require('../../fixtures/pact_interaction_builder')
 
 // Global setup


### PR DESCRIPTION
Add pact test for GET charge connector endpoint. Include the new 'integration_version_3ds' property of the gateway account.

Modify pact_base so that it will add matchers for objects in nested arrays so that we can assert on the structure of 'card_types' entries.

Remove fields from charges fixture which are not used in frontend.

