### PR TITLE
PP-5546 Add client method to get JWT from connector

### DIFF
--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -19,6 +19,7 @@ const CARD_CANCEL_PATH = '/v1/frontend/charges/{chargeId}/cancel'
 const CARD_FIND_BY_TOKEN_PATH = '/v1/frontend/tokens/{chargeTokenId}/charge'
 const CARD_DELETE_CHARGE_TOKEN_PATH = '/v1/frontend/tokens/{chargeTokenId}'
 const CARD_CHARGE_PATH = '/v1/frontend/charges/{chargeId}'
+const WORLDPAY_3DS_FLEX_JWT_PATH = '/v1/frontend/charges/{chargeId}/worldpay/3ds-flex/ddc'
 
 let baseUrl
 let correlationId
@@ -52,6 +53,9 @@ const _getDeleteTokenUrlFor = tokenId => baseUrl + CARD_DELETE_CHARGE_TOKEN_PATH
 
 /** @private */
 const _getPatchUrlFor = chargeId => baseUrl + CARD_CHARGE_PATH.replace('{chargeId}', chargeId)
+
+/** @private */
+const _getWorldpay3dsFlexUrlFor = chargeId => baseUrl + WORLDPAY_3DS_FLEX_JWT_PATH.replace('{chargeId}', chargeId)
 
 /** @private */
 const _putConnector = (url, payload, description, subSegment) => {
@@ -276,6 +280,11 @@ const findByToken = chargeOptions => {
   return _getConnector(findByTokenUrl, 'find by token')
 }
 
+const getWorldpay3dsFlexJwt = chargeOptions => {
+  const getWorldpay3dsFlexJwtUrl = _getWorldpay3dsFlexUrlFor(chargeOptions.chargeId)
+  return _getConnector(getWorldpay3dsFlexJwtUrl, 'get Worldpay 3DS Flex DDC JWT')
+}
+
 // DELETE functions
 const deleteToken = chargeOptions => {
   const deleteTokenUrl = _getDeleteTokenUrlFor(chargeOptions.tokenId)
@@ -295,6 +304,7 @@ module.exports = function (clientOptions = {}) {
     cancel,
     findByToken,
     patch,
-    deleteToken
+    deleteToken,
+    getWorldpay3dsFlexJwt
   }
 }

--- a/test/fixtures/worldpay_3ds_flex_fixtures.js
+++ b/test/fixtures/worldpay_3ds_flex_fixtures.js
@@ -1,0 +1,20 @@
+const pactBase = require('./pact_base')()
+
+const validDdcJwt = function validDdcJwt () {
+  const data = {
+    'jwt': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+  }
+
+  return {
+    getPactified: () => {
+      return pactBase.pactify(data)
+    },
+    getPlain: () => {
+      return data
+    }
+  }
+}
+
+module.exports = {
+  validDdcJwt
+}

--- a/test/unit/clients/connector_client_worldpay_3ds_flex_tests.js
+++ b/test/unit/clients/connector_client_worldpay_3ds_flex_tests.js
@@ -1,0 +1,56 @@
+'use strict'
+
+// NPM dependencies
+const path = require('path')
+const Pact = require('pact')
+const { expect } = require('chai')
+
+// Local dependencies
+const connectorClient = require('../../../app/services/clients/connector_client')
+const { PactInteractionBuilder } = require('../../fixtures/pact_interaction_builder')
+const fixtures = require('../../fixtures/worldpay_3ds_flex_fixtures')
+
+const TEST_CHARGE_ID = 'testChargeId'
+const GET_JWT_URL = `/v1/frontend/charges/${TEST_CHARGE_ID}/worldpay/3ds-flex/ddc`
+
+const PORT = Math.floor(Math.random() * 48127) + 1024
+const BASE_URL = `http://localhost:${PORT}`
+
+describe('connector client - Worldpay 3DS flex tests', function () {
+  const provider = Pact({
+    consumer: 'frontend',
+    provider: 'connector',
+    port: PORT,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(() => provider.finalize())
+
+  describe('get Worldpay 3DS flex JWT', function () {
+    describe('success', function () {
+      const response = fixtures.validDdcJwt()
+
+      before(() => {
+        const builder = new PactInteractionBuilder(GET_JWT_URL)
+          .withMethod('GET')
+          .withState('a Worldpay account exists with 3DS flex credentials and a charge with id testChargeId')
+          .withUponReceiving('a valid get Worldpay 3DS flex DDC JWT request')
+          .withResponseBody(response.getPactified())
+          .withStatusCode(200)
+          .build()
+        return provider.addInteraction(builder)
+      })
+
+      afterEach(() => provider.verify())
+
+      it('should return jwt', async function () {
+        const res = await connectorClient({ baseUrl: BASE_URL }).getWorldpay3dsFlexJwt({ chargeId: TEST_CHARGE_ID })
+        expect(res.body.jwt).to.be.equal(response.getPlain().jwt)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add a method to connector client to call the connector endpoint to get a Worldpay 3DS Flex DDC JWT.

Add a pact test for this interaction.