### PR TITLE
PP-5546 Get Worldpay 3DS Flex JWT on card details page

### DIFF
--- a/app/services/worldpay_3ds_flex_service.js
+++ b/app/services/worldpay_3ds_flex_service.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const connectorClient = require('./clients/connector_client')
+
+const getDdcJwt = async function getDdcJwt (charge, correlationId) {
+  if (charge.gatewayAccount.paymentProvider === 'worldpay' &&
+    charge.gatewayAccount.requires3ds &&
+    charge.gatewayAccount.integrationVersion3ds === 2) {
+    const data = await connectorClient({ correlationId }).getWorldpay3dsFlexJwt({ chargeId: charge.id })
+    return data.body.jwt
+  }
+  return null
+}
+
+module.exports = {
+  getDdcJwt
+}

--- a/app/services/worldpay_3ds_flex_service.js
+++ b/app/services/worldpay_3ds_flex_service.js
@@ -6,8 +6,11 @@ const getDdcJwt = async function getDdcJwt (charge, correlationId) {
   if (charge.gatewayAccount.paymentProvider === 'worldpay' &&
     charge.gatewayAccount.requires3ds &&
     charge.gatewayAccount.integrationVersion3ds === 2) {
-    const data = await connectorClient({ correlationId }).getWorldpay3dsFlexJwt({ chargeId: charge.id })
-    return data.body.jwt
+    const response = await connectorClient({ correlationId }).getWorldpay3dsFlexJwt({ chargeId: charge.id })
+    if (response.statusCode !== 200) {
+      throw new Error('Failed to get DDC JWT from connector')
+    }
+    return response.body.jwt
   }
   return null
 }

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -35,6 +35,14 @@ exports.failedChargePatch = err => {
   })
 }
 
+exports.failedGetWorldpayDdcJwt = err => {
+  logger.error('Calling connector to get a Worldpay 3DS Flex DDC JWT threw exception -', {
+    service: 'connector',
+    method: 'GET',
+    error: err
+  })
+}
+
 exports.systemError = function logSystemError (message, correlationId, chargeId) {
   const correlationID = correlationId || 'no-correlation-id'
   const chargeID = chargeId || 'no-charge-id'

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -30,7 +30,8 @@
   };
   window.Charge = {
     email_collection_mode: '{{ gatewayAccount.emailCollectionMode | safe }}',
-    collect_billing_address: {{ "true" if service.collectBillingAddress else "false" }}
+    collect_billing_address: {{ "true" if service.collectBillingAddress else "false" }},
+    worldpay_3ds_flex_ddc_jwt: '{{ worldpay3dsFlexDdcJwt | safe }}'
   }
 
   var mainWrap = document.getElementsByTagName('main')[0]

--- a/test/fixtures/worldpay_3ds_flex_fixtures.js
+++ b/test/fixtures/worldpay_3ds_flex_fixtures.js
@@ -1,8 +1,8 @@
 const pactBase = require('./pact_base')()
 
-const validDdcJwt = function validDdcJwt () {
+const validDdcJwt = function validDdcJwt (jwt) {
   const data = {
-    'jwt': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+    'jwt': jwt || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
   }
 
   return {

--- a/test/services/worldpay_3ds_flex_service_test.js
+++ b/test/services/worldpay_3ds_flex_service_test.js
@@ -1,0 +1,104 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const { expect } = require('chai')
+
+const { validDdcJwt } = require('../fixtures/worldpay_3ds_flex_fixtures')
+
+const TEST_JWT = 'a-jwt-returned-from-connector'
+
+const requireService = function (mockedConnectorClient) {
+  return proxyquire('../../app/services/worldpay_3ds_flex_service', {
+    './clients/connector_client': mockedConnectorClient
+  })
+}
+
+describe('Worldpay 3DS Flex service', () => {
+  let service
+  let connectorClientStub
+  let getWorldpay3dsFlexJwtStub
+
+  beforeEach(() => {
+    const jwtResponse = validDdcJwt(TEST_JWT).getPlain()
+    getWorldpay3dsFlexJwtStub = sinon.stub().resolves({ body: jwtResponse })
+    connectorClientStub = sinon.stub().callsFake(() => {
+      return {
+        getWorldpay3dsFlexJwt: getWorldpay3dsFlexJwtStub
+      }
+    })
+    service = requireService(connectorClientStub)
+  })
+
+  describe('get DDC JWT', () => {
+    describe('payment provider is Worldpay, 3DS is enabled and integration version is 2', () => {
+      it('should call connector to get a JWT', async () => {
+        const charge = {
+          id: 'a-charge-id',
+          gatewayAccount: {
+            paymentProvider: 'worldpay',
+            requires3ds: true,
+            integrationVersion3ds: 2
+          }
+        }
+        const correlationId = 'a-correlation-id'
+        const jwt = await service.getDdcJwt(charge, correlationId)
+
+        expect(jwt).to.equal(TEST_JWT)
+        expect(connectorClientStub.calledWith({ correlationId })).to.be.true // eslint-disable-line
+        expect(getWorldpay3dsFlexJwtStub.calledWith({ chargeId: charge.id })).to.be.true // eslint-disable-line
+      })
+    })
+
+    describe('payment provider is Worldpay, 3DS is enabled and integration version is 1', () => {
+      it('should not call connector to get a JWT', async () => {
+        const charge = {
+          id: 'a-charge-id',
+          gatewayAccount: {
+            paymentProvider: 'worldpay',
+            requires3ds: true,
+            integrationVersion3ds: 1
+          }
+        }
+        const jwt = await service.getDdcJwt(charge, 'a-correlation-id')
+
+        expect(jwt).to.equal(null)
+        expect(connectorClientStub.notCalled).to.be.true // eslint-disable-line
+      })
+    })
+
+    describe('payment provider is Worldpay, 3DS is disabled', () => {
+      it('should not call connector to get a JWT', async () => {
+        const charge = {
+          id: 'a-charge-id',
+          gatewayAccount: {
+            paymentProvider: 'worldpay',
+            requires3ds: false,
+            integrationVersion3ds: 2
+          }
+        }
+        const jwt = await service.getDdcJwt(charge, 'a-correlation-id')
+
+        expect(jwt).to.equal(null)
+        expect(connectorClientStub.notCalled).to.be.true // eslint-disable-line
+      })
+    })
+
+    describe('payment provider is not Worldpay', () => {
+      it('should not call connector to get a JWT', async () => {
+        const charge = {
+          id: 'a-charge-id',
+          gatewayAccount: {
+            paymentProvider: 'epdq',
+            requires3ds: true,
+            integrationVersion3ds: 2
+          }
+        }
+        const jwt = await service.getDdcJwt(charge, 'a-correlation-id')
+
+        expect(jwt).to.equal(null)
+        expect(connectorClientStub.notCalled).to.be.true // eslint-disable-line
+      })
+    })
+  })
+})


### PR DESCRIPTION
If a gateway account has payment provider "worldpay" and 3DS integration version of 2, call connector to get the JWT for DDC and store it on the window.Charge object.

Have added unit tests for worldpay_3ds_flex_service.js, but not integration tests as appropriate integration tests should be added when the device data collection is implemented.