### PR TITLE
PP-5545: Pact test for authorising card

### DIFF
--- a/test/cypress/plugins/stubs.js
+++ b/test/cypress/plugins/stubs.js
@@ -99,7 +99,7 @@ module.exports = {
 
   connectorPostValidChargeCardDetailsAuthorisation: (opts = {}) => {
     const path = `/v1/frontend/charges/${opts.chargeid}/cards`
-    const body = paymentFixtures.validChargeCardDetailsAuthorised()
+    const body = paymentFixtures.validChargeCardDetailsAuthorised().getPlain()
 
     return simpleStubBuilder('POST', 200, path, body)
   },

--- a/test/fixtures/payment_fixtures.js
+++ b/test/fixtures/payment_fixtures.js
@@ -249,7 +249,47 @@ const fixtures = {
   },
 
   validChargeDetails: (opts = {}) => buildChargeDetails(opts),
-  validChargeCardDetailsAuthorised: () => ({ 'status': 'AUTHORISATION SUCCESS' }),
+
+  validChargeCardDetailsAuthorised: () => {
+    const data = { 'status': 'AUTHORISATION SUCCESS' }
+    return {
+      getPactified: () => {
+        return pactBase.pactify(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
+  },
+
+  validAuthorisationRequest: () => {
+    const data = {
+      'card_number': '371449635398431',
+      'cvc': '1234',
+      'expiry_date': '11/99',
+      'card_brand': 'american-express',
+      'cardholder_name': 'Scrooge McDuck',
+      'accept_header': 'text/html',
+      'user_agent_header': 'Mozilla/5.0',
+      'prepaid': 'NOT_PREPAID',
+      'worldpay_3ds_flex_ddc_result': '96c3fcf6-d90a-467e-a224-107f70052528',
+      'address': {
+        'line1': 'The Money Pool',
+        'city': 'London',
+        'postcode': 'DO11 4RS',
+        'country': 'GB'
+      }
+    }
+    return {
+      getPactified: () => {
+        return pactBase.pactify(data)
+      },
+      getPlain: () => {
+        return data
+      }
+    }
+  },
+
   validChargeDetailsWithPrefilledCardHolderDetails: (opts = {}) => buildChargeDetailsWithPrefilledCardHolderDeatils(opts),
 
   validCardDetails: () => {

--- a/test/unit/clients/connector_client_charge_tests.js
+++ b/test/unit/clients/connector_client_charge_tests.js
@@ -12,6 +12,7 @@ const { PactInteractionBuilder } = require('../../fixtures/pact_interaction_buil
 
 const TEST_CHARGE_ID = 'testChargeId'
 const GET_CHARGE_URL = `/v1/frontend/charges/${TEST_CHARGE_ID}`
+const AUTHORISE_CHARGE_URL = `/v1/frontend/charges/${TEST_CHARGE_ID}/cards`
 
 const PORT = Math.floor(Math.random() * 48127) + 1024
 const BASE_URL = `http://localhost:${PORT}`
@@ -30,30 +31,55 @@ describe('connector client - charge tests', function () {
   before(() => provider.setup())
   after(() => provider.finalize())
 
+  describe('making auth request', function () {
+    const authRequest = fixtures.validAuthorisationRequest()
+    
+    before(() => {
+      const response = fixtures.validChargeCardDetailsAuthorised()
+      const builder = new PactInteractionBuilder(AUTHORISE_CHARGE_URL)
+        .withRequestBody(authRequest.getPactified())
+        .withMethod('POST')
+        .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+        .withUponReceiving('an authorisation request')
+        .withResponseBody(response.getPactified())
+        .withStatusCode(200)
+        .build()
+      return provider.addInteraction(builder)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should return authorisation success', async function () {
+      const res = await connectorClient({ baseUrl: BASE_URL }).chargeAuth({
+        chargeId: TEST_CHARGE_ID,
+        payload: authRequest.getPlain()
+      })
+      expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+    })
+  })
+
   describe('find charge', function () {
-    describe('find charge success', function () {
-      before(() => {
-        const response = fixtures.validChargeDetails({
-          chargeId: TEST_CHARGE_ID,
-          cardTypes: [{ brand: 'visa' }]
-        })
-
-        const builder = new PactInteractionBuilder(GET_CHARGE_URL)
-          .withMethod('GET')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid get charge request')
-          .withResponseBody(response.getPactified())
-          .withStatusCode(200)
-          .build()
-        return provider.addInteraction(builder)
+    before(() => {
+      const response = fixtures.validChargeDetails({
+        chargeId: TEST_CHARGE_ID,
+        cardTypes: [{ brand: 'visa' }]
       })
 
-      afterEach(() => provider.verify())
+      const builder = new PactInteractionBuilder(GET_CHARGE_URL)
+        .withMethod('GET')
+        .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+        .withUponReceiving('a valid get charge request')
+        .withResponseBody(response.getPactified())
+        .withStatusCode(200)
+        .build()
+      return provider.addInteraction(builder)
+    })
 
-      it('should return charge', async function () {
-        const res = await connectorClient({ baseUrl: BASE_URL }).findCharge({ chargeId: TEST_CHARGE_ID })
-        expect(res.body.charge_id).to.be.equal(TEST_CHARGE_ID)
-      })
+    afterEach(() => provider.verify())
+
+    it('should return charge', async function () {
+      const res = await connectorClient({ baseUrl: BASE_URL }).findCharge({ chargeId: TEST_CHARGE_ID })
+      expect(res.body.charge_id).to.be.equal(TEST_CHARGE_ID)
     })
   })
 })


### PR DESCRIPTION
This test is really to ensure `worldpay_3ds_flex_ddc_result` is a valid
property in the auth request to connector.

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


