### PR TITLE
Update config.yml

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,6 +2,10 @@ version: 1
 
 update_configs:
   - package_manager: "javascript"
+    default_labels:
+      - "dependencies"
+      - "govuk-pay"
+      - "javascript"
     directory: "/"
     update_schedule: "weekly"
     allowed_updates:


### PR DESCRIPTION
Use default labels.
Adding `govuk-pay` label so we can build a dependabot dashboard to show outstanding PRs.

Current dashboard: https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+org%3Aalphagov+archived%3Afalse+label%3Adependencies+label%3Agovuk-pay