### PR TITLE
PP-5548 move form validation to browserify

### DIFF
--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -146,9 +146,11 @@ var init = function () {
   }
 
   var checkValidation = function (input) {
-    var formGroup = getFormGroup(input),
-      validationName = getFormGroupValidation(formGroup),
-      validation = validationFor(validationName)
+    var formGroup = getFormGroup(input)
+
+    var validationName = getFormGroupValidation(formGroup)
+
+    var validation = validationFor(validationName)
 
     if (validation) {
       input.classList.add('govuk-input--error')
@@ -195,8 +197,8 @@ var init = function () {
     var corporateCardSurchargeAmountNumber = corporateCardSurchargeAmount / 100
 
     // card message
-    var corporateCardSurchargeMessage = cardType === 'CREDIT' ?
-      i18n.cardDetails.corporateCreditCardSurchargeMessage : i18n.cardDetails.corporateDebitCardSurchargeMessage
+    var corporateCardSurchargeMessage = cardType === 'CREDIT'
+      ? i18n.cardDetails.corporateCreditCardSurchargeMessage : i18n.cardDetails.corporateDebitCardSurchargeMessage
     corporateCardMessageElement.textContent = corporateCardSurchargeMessage.replace('%s', corporateCardSurchargeAmountNumber.toFixed(2))
     corporateCardMessageElement.classList.remove('hidden')
     // payment summary
@@ -206,7 +208,7 @@ var init = function () {
     paymentSummaryBreakdownElement.classList.remove('hidden')
   }
 
-  var clearCorporateCardSurchargeInformation = function() {
+  var clearCorporateCardSurchargeInformation = function () {
     // card message
     corporateCardMessageElement.classList.add('hidden')
     corporateCardMessageElement.textContent = ''
@@ -242,7 +244,7 @@ var init = function () {
   }
 
   var validationFor = function (name) {
-    var validation = allValidations().errorFields.filter(function(validation) {
+    var validation = allValidations().errorFields.filter(function (validation) {
       return validation.key === name
     })
     if (!validation[0]) return
@@ -252,10 +254,10 @@ var init = function () {
   var allFields = function () {
     var fields = {}
     required.forEach(function (requiredField) {
-        var getField = findInputByKey(requiredField)
-        if (getField) {
-            fields[requiredField] = getField
-        }
+      var getField = findInputByKey(requiredField)
+      if (getField) {
+        fields[requiredField] = getField
+      }
     })
     return fields
   }
@@ -264,9 +266,9 @@ var init = function () {
     var values = {}
     required.forEach(function (requiredField) {
       var getField = findInputByKey(requiredField)
-        if (getField) {
-            values[requiredField] = getField.value.trim()
-        }
+      if (getField) {
+        values[requiredField] = getField.value.trim()
+      }
     })
     return values
   }
@@ -284,8 +286,8 @@ var init = function () {
   }
 
   var findInputByKey = function (key) {
-      var foundInput = document.querySelectorAll('input[name=' + key + '], select[name=' + key + ']')
-      // Only return inputs that exist on the form
+    var foundInput = document.querySelectorAll('input[name=' + key + '], select[name=' + key + ']')
+    // Only return inputs that exist on the form
     return foundInput ? foundInput[0] : null
   }
 
@@ -299,19 +301,20 @@ var init = function () {
         Element.prototype.oMatchesSelector ||
         Element.prototype.webkitMatchesSelector ||
         function (s) {
-          var matches = (this.document || this.ownerDocument).querySelectorAll(s),
-            i = matches.length;
+          var matches = (this.document || this.ownerDocument).querySelectorAll(s)
+
+          var i = matches.length
           while (--i >= 0 && matches.item(i) !== this) { }
-          return i > -1;
-        };
+          return i > -1
+        }
     }
 
     // Get the closest matching element
     for (; elem && elem !== document; elem = elem.parentNode) {
-      if (elem.matches(selector)) return elem;
+      if (elem.matches(selector)) return elem
     }
-    return null;
-  };
+    return null
+  }
 }
 
 module.exports = {

--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -1,6 +1,8 @@
 'use strict'
 
-var formValidation = function () {
+const chargeValidation = require('../../../utils/charge_validation')
+
+var init = function () {
   var form = document.getElementById('card-details')
   var formInputs = Array.prototype.slice.call(form.querySelectorAll('input'))
   var countryAutocomplete = document.getElementsByClassName('autocomplete__input')[0]
@@ -16,7 +18,8 @@ var formValidation = function () {
   var errorSummary = document.getElementsByClassName('govuk-error-summary')[0]
   var logger = { info: function () { } }// replace with console to see output
   // window.card comes from the view
-  var chargeValidations = module.chargeValidation(
+
+  const chargeValidations = chargeValidation(
     i18n.fieldErrors,
     logger,
     window.Card,
@@ -24,22 +27,20 @@ var formValidation = function () {
   )
   var required = chargeValidations.required
 
-  var init = function () {
-    form.addEventListener('submit', function (e) {
-      checkFormSubmission(e)
-    }, false)
-    if (formInputs) {
-      formInputs.forEach(function (input) {
-        input.addEventListener('blur', function (e) {
-          checkPreviousFocused(input)
-        }, false)
-      })
-    }
-    if (window.Charge.collect_billing_address === true) {
-      countrySelect.addEventListener('change', function () {
-        checkValidation(postcodeInput)
+  form.addEventListener('submit', function (e) {
+    checkFormSubmission(e)
+  }, false)
+  if (formInputs) {
+    formInputs.forEach(function (input) {
+      input.addEventListener('blur', function (e) {
+        checkPreviousFocused(input)
       }, false)
-    }
+    })
+  }
+  if (window.Charge.collect_billing_address === true) {
+    countrySelect.addEventListener('change', function () {
+      checkValidation(postcodeInput)
+    }, false)
   }
 
   var checkFormSubmission = function (e) {
@@ -311,6 +312,8 @@ var formValidation = function () {
     }
     return null;
   };
+}
 
-  init()
+module.exports = {
+  init
 }

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -1,6 +1,7 @@
 const inputConfirm = require('./assets/javascripts/browsered/form-input-confirm')
 const webPayments = require('./assets/javascripts/browsered/web-payments')
 const analytics = require('gaap-analytics')
+const formValidation = require('./assets/javascripts/browsered/form-validation')
 
 exports.chargeValidation = require('./utils/charge_validation')
 analytics.eventTracking.init()
@@ -8,7 +9,8 @@ analytics.eventTracking.init()
 // Place functions into scope so can trigger in scripts.njk
 window.payScripts = { // eslint-disable-line no-unused-vars
   inputConfirm,
-  webPayments
+  webPayments,
+  formValidation
 }
 
 // GA tracking if an email typo is spotted

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -491,7 +491,6 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  {% include "includes/scripts.njk" %}
   {% if service.collectBillingAddress %}
   <script type="text/javascript" src="/public/location-autocomplete.min.js"></script>
   <script type="text/javascript">
@@ -503,4 +502,5 @@
     })
   </script>
   {% endif %}
+  {% include "includes/scripts.njk" %}
 {% endblock %}

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -38,9 +38,9 @@
   document.addEventListener('DOMContentLoaded', function() {
     GOVUK.stopDoubleSubmit.init();
     if (mainWrap.classList.contains('charge-new')) {
-      formValidation();
       showCardType().init();
       window.payScripts.inputConfirm.init();
+      window.payScripts.formValidation.init();
     } else if (mainWrap.classList.contains('confirm-page')) {
       analyticsTrackConfirmClick().init('{{analytics.analyticsId}}', '{{analytics.type}}', '{{analytics.paymentProvider}}', '{{analytics.amount}}', '{{hitPage}}');
     }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,12 @@
       "ApplePaySession",
       "ApplePayError",
       "ga",
-      "fetch"
+      "fetch",
+      "Element",
+      "location",
+      "Charge",
+      "parent",
+      "showCardType"
     ],
     "ignore": [
       "app/assets/javascripts/modules/*.js"


### PR DESCRIPTION
For this story we need to augment form validation with a worldpay lookup.

We want to do this in a separate JS file/function but to do this we need to move form-validation.js so that we can require other JS files.

The PR does that. Once it’s moved our linting rules apply, so we did that too.