### PR TITLE
PP-5573 accessibility fixes for autocomplete

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,4 +1,5 @@
 @import "govuk-frontend/govuk/all";
+@import "govuk-country-and-territory-autocomplete/location-autocomplete";
 
 @import "modules/3ds";
 @import "modules/accepted-cards";
@@ -13,5 +14,3 @@
 @import "modules/text-align";
 @import "modules/borders";
 @import "modules/divider";
-
-@import "govuk-country-and-territory-autocomplete/location-autocomplete";

--- a/app/assets/sass/modules/_accessible-autocomplete.scss
+++ b/app/assets/sass/modules/_accessible-autocomplete.scss
@@ -5,4 +5,22 @@
 
 .autocomplete__input {
   @extend .govuk-\!-width-three-quarters;
+  border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+
+  &--focused {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    // Ensure outline appears outside of the element
+    outline-offset: 0;
+    // Double the border by adding its width again. Use `box-shadow` for this // instead of changing `border-width` - this is for consistency with
+    // components such as textarea where we avoid changing `border-width` as
+    // it will change the element size. Also, `outline` cannot be utilised
+    // here as it is already used for the yellow focus state.
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+
+    @include govuk-if-ie8 {
+      // IE8 doesn't support `box-shadow` so double the border with
+      // `border-width`.
+      border-width: $govuk-border-width-form-element * 2;
+    }
+  }
 }

--- a/app/assets/sass/modules/_accessible-autocomplete.scss
+++ b/app/assets/sass/modules/_accessible-autocomplete.scss
@@ -26,5 +26,10 @@
 }
 
 .autocomplete__hint {
+  width: 75%;
   @include govuk-font($size: 19);
+}
+
+.autocomplete__menu {
+  width: calc(75% - 4px);
 }

--- a/app/assets/sass/modules/_accessible-autocomplete.scss
+++ b/app/assets/sass/modules/_accessible-autocomplete.scss
@@ -24,3 +24,7 @@
     }
   }
 }
+
+.autocomplete__hint {
+  @include govuk-font($size: 19);
+}


### PR DESCRIPTION
The accessible autocomplete has yet to be moved to the design system as such some thing looks a little bit funky this fixes those things.

# Before

![Screen Shot 2019-09-05 at 11 57 00](https://user-images.githubusercontent.com/440503/64336233-62da4980-cfd4-11e9-8f83-8b18b7f4864b.png)

# After

![Screen Shot 2019-09-05 at 11 56 45](https://user-images.githubusercontent.com/440503/64336242-67066700-cfd4-11e9-9d8d-31a78813b9ef.png)
