### PR TITLE
REP: Only automatically update product-page

### DIFF
--- a/.github/workflows/product-page.yml
+++ b/.github/workflows/product-page.yml
@@ -24,7 +24,7 @@ jobs:
           mv tmp package.json
 
       - name: Update npm
-        run: npm install
+        run: npm install --save-dev pay-product-page
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v1.2.0


### PR DESCRIPTION
We don't want the GitHub action triggered by a product page release to
update every package, just pay-product-page