### PR TITLE
PP-5554 Add pact test for challenge JWT

### DIFF
--- a/test/fixtures/payment_fixtures.js
+++ b/test/fixtures/payment_fixtures.js
@@ -170,6 +170,12 @@ const buildChargeDetails = function buildChargeDetails (opts) {
     data.card_details = utilFormatPaymentDetails(opts.paymentDetails)
   }
 
+  if (opts.auth3dsData && opts.auth3dsData.worldpayChallengeJwt) {
+    data.auth_3ds_data = {
+      worldpayChallengeJwt: opts.auth3dsData.worldpayChallengeJwt
+    }
+  }
+
   return {
     getPactified: () => {
       return pactBase.pactify(data)

--- a/test/unit/clients/connector_client_worldpay_3ds_flex_tests.js
+++ b/test/unit/clients/connector_client_worldpay_3ds_flex_tests.js
@@ -8,10 +8,12 @@ const { expect } = require('chai')
 // Local dependencies
 const connectorClient = require('../../../app/services/clients/connector_client')
 const { PactInteractionBuilder } = require('../../fixtures/pact_interaction_builder')
-const fixtures = require('../../fixtures/worldpay_3ds_flex_fixtures')
+const worlpay3dsFlexFixtures = require('../../fixtures/worldpay_3ds_flex_fixtures')
+const paymentFixtures = require('../../fixtures/payment_fixtures')
 
 const TEST_CHARGE_ID = 'testChargeId'
 const GET_JWT_URL = `/v1/frontend/charges/${TEST_CHARGE_ID}/worldpay/3ds-flex/ddc`
+const GET_CHARGE_URL = `/v1/frontend/charges/${TEST_CHARGE_ID}`
 
 const PORT = Math.floor(Math.random() * 48127) + 1024
 const BASE_URL = `http://localhost:${PORT}`
@@ -32,7 +34,7 @@ describe('connector client - Worldpay 3DS flex tests', function () {
 
   describe('get Worldpay 3DS flex JWT', function () {
     describe('success', function () {
-      const response = fixtures.validDdcJwt()
+      const response = worlpay3dsFlexFixtures.validDdcJwt()
 
       before(() => {
         const builder = new PactInteractionBuilder(GET_JWT_URL)
@@ -51,6 +53,34 @@ describe('connector client - Worldpay 3DS flex tests', function () {
         const res = await connectorClient({ baseUrl: BASE_URL }).getWorldpay3dsFlexJwt({ chargeId: TEST_CHARGE_ID })
         expect(res.body.jwt).to.be.equal(response.getPlain().jwt)
       })
+    })
+  })
+
+  describe('get charge in 3DS required has a 3DS flex challenge JWT', function () {
+    before(() => {
+      const response = paymentFixtures.validChargeDetails({
+        chargeId: TEST_CHARGE_ID,
+        cardTypes: [{ brand: 'visa' }],
+        auth3dsData: {
+          worldpayChallengeJwt: 'a-jwt'
+        }
+      })
+
+      const builder = new PactInteractionBuilder(GET_CHARGE_URL)
+        .withMethod('GET')
+        .withState('a Worldpay account exists with 3DS flex credentials and a charge with id testChargeId that is in state AUTHORISATION_3DS_REQUIRED')
+        .withUponReceiving('a valid get charge request')
+        .withResponseBody(response.getPactified())
+        .withStatusCode(200)
+        .build()
+      return provider.addInteraction(builder)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should return charge with worldpayChallengeJwt', async function () {
+      const res = await connectorClient({ baseUrl: BASE_URL }).findCharge({ chargeId: TEST_CHARGE_ID })
+      expect(res.body.charge_id).to.be.equal(TEST_CHARGE_ID)
     })
   })
 })


### PR DESCRIPTION
Add pact test to assert that the response to a call to /v1/frontend/charges/{CHARGE_ID} for a Worldpay payment with status AUTHORISATION 3DS REQUIRED and 3DS flex challenge details saved contains a worldpayChallengeJwt property.