### PR TITLE
PP-5550: Minor simplification of charge_controller

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -120,7 +120,6 @@ module.exports = {
       collect_billing_address: res.locals.service.collectBillingAddress
     }
     const validator = chargeValidator(i18n.__('fieldErrors'), logger, cardModel, chargeOptions)
-    let card
 
     normalise.addressLines(req.body)
     normalise.whitespace(req.body)
@@ -133,7 +132,7 @@ module.exports = {
     } catch (err) {
       return redirect(res).toNew(req.chargeId)
     }
-    card = data.card
+    const card = data.card
 
     let emailTypos = false
     let userEmail

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -113,8 +113,6 @@ module.exports = {
       })
   },
   create: (req, res) => {
-    const namespace = getNamespace(clsXrayConfig.nameSpaceName)
-    const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
     const charge = normalise.charge(req.chargeData, req.chargeId)
     const cardModel = Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER])
     const chargeOptions = {
@@ -129,77 +127,72 @@ module.exports = {
 
     if (charge.status === State.AUTH_READY) return redirect(res).toAuthWaiting(req.chargeId)
     // else
-    AWSXRay.captureAsyncFunc('chargeValidator_verify', function (subSegment) {
-      validator.verify(req)
-        .catch(() => {
-          subSegment.close('error')
-          redirect(res).toNew(req.chargeId)
-        })
-        .then(async data => {
-          subSegment.close()
-          card = data.card
+    validator.verify(req)
+      .catch(() => {
+        redirect(res).toNew(req.chargeId)
+      })
+      .then(async data => {
+        card = data.card
 
-          let emailTypos = false
-          let userEmail
+        let emailTypos = false
+        let userEmail
 
-          if (charge.gatewayAccount.emailCollectionMode !== 'OFF' ||
-            (charge.gatewayAccount.emailCollectionMode !== 'OPTIONAL' && req.body.email && req.body.email !== '')
-          ) {
-            userEmail = req.body.email
-            let emailChanged = false
-            if (req.body.originalemail) {
-              emailChanged = req.body.originalemail !== userEmail
-            }
-            emailTypos = commonTypos(userEmail)
-            if (req.body['email-typo-sugestion']) {
-              userEmail = emailChanged ? req.body.email : req.body['email-typo-sugestion']
-              emailTypos = req.body['email-typo-sugestion'] !== req.body.originalemail ? commonTypos(userEmail) : null
-            }
-            try {
-              await Charge(req.headers[CORRELATION_HEADER]).patch(req.chargeId, 'replace', 'email', userEmail, subSegment)
-            } catch (err) {
-              return responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalytics(charge))
-            }
+        if (charge.gatewayAccount.emailCollectionMode !== 'OFF' ||
+          (charge.gatewayAccount.emailCollectionMode !== 'OPTIONAL' && req.body.email && req.body.email !== '')
+        ) {
+          userEmail = req.body.email
+          let emailChanged = false
+          if (req.body.originalemail) {
+            emailChanged = req.body.originalemail !== userEmail
           }
-
-          if (data.validation.hasError || emailTypos) {
-            if (emailTypos) {
-              data.validation.hasError = true
-              data.validation.errorFields.push({
-                cssKey: 'email-typo',
-                value: i18n.__('fieldErrors.fields.email.typo')
-              })
-              data.validation.typos = emailTypos
-              data.validation.originalEmail = userEmail
-            }
-            charge.countries = countries
-            return appendChargeForNewView(charge, req, charge.id).then(
-              () => {
-                _.merge(data.validation, withAnalytics(charge, charge), _.pick(req.body, preserveProperties))
-                responseRouter.response(req, res, views.CHARGE_VIEW, data.validation)
-              },
-              err => {
-                logging.failedGetWorldpayDdcJwt(err)
-                responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalytics(charge))
-              }
-            )
-          }
-
-          const correlationId = req.headers[CORRELATION_HEADER] || ''
-          const payload = normalise.apiPayload(req, card)
-          if (res.locals.service.collectBillingAddress === false) {
-            delete payload.address
+          emailTypos = commonTypos(userEmail)
+          if (req.body['email-typo-sugestion']) {
+            userEmail = emailChanged ? req.body.email : req.body['email-typo-sugestion']
+            emailTypos = req.body['email-typo-sugestion'] !== req.body.originalemail ? commonTypos(userEmail) : null
           }
           try {
-            const response = await connectorClient({ correlationId }).chargeAuth({ chargeId: req.chargeId, payload })
-            handleCreateResponse(req, res, charge, response)
+            await Charge(req.headers[CORRELATION_HEADER]).patch(req.chargeId, 'replace', 'email', userEmail)
           } catch (err) {
-            subSegment.close(err.message)
-            logging.failedChargePatch(err.message)
-            responseRouter.response(req, res, 'ERROR', withAnalyticsError())
+            return responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalytics(charge))
           }
-        })
-    }, clsSegment)
+        }
+
+        if (data.validation.hasError || emailTypos) {
+          if (emailTypos) {
+            data.validation.hasError = true
+            data.validation.errorFields.push({
+              cssKey: 'email-typo',
+              value: i18n.__('fieldErrors.fields.email.typo')
+            })
+            data.validation.typos = emailTypos
+            data.validation.originalEmail = userEmail
+          }
+          charge.countries = countries
+          return appendChargeForNewView(charge, req, charge.id).then(
+            () => {
+              _.merge(data.validation, withAnalytics(charge, charge), _.pick(req.body, preserveProperties))
+              responseRouter.response(req, res, views.CHARGE_VIEW, data.validation)
+            },
+            err => {
+              logging.failedGetWorldpayDdcJwt(err)
+              responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalytics(charge))
+            }
+          )
+        }
+
+        const correlationId = req.headers[CORRELATION_HEADER] || ''
+        const payload = normalise.apiPayload(req, card)
+        if (res.locals.service.collectBillingAddress === false) {
+          delete payload.address
+        }
+        try {
+          const response = await connectorClient({ correlationId }).chargeAuth({ chargeId: req.chargeId, payload })
+          handleCreateResponse(req, res, charge, response)
+        } catch (err) {
+          logging.failedChargePatch(err.message)
+          responseRouter.response(req, res, 'ERROR', withAnalyticsError())
+        }
+      })
   },
   checkCard: (req, res) => {
     const namespace = getNamespace(clsXrayConfig.nameSpaceName)

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -89,26 +89,22 @@ module.exports = correlationId => {
     return response.body
   }
 
-  const patch = function (chargeId, op, path, value, subSegment) {
-    return new Promise(function (resolve, reject) {
+  const patch = async function (chargeId, op, path, value, subSegment) {
+    try {
       const payload = {
         op: op,
         path: path,
         value: value
       }
-      connectorClient({ correlationId }).patch({ chargeId, payload }, subSegment)
-        .then(response => {
-          const code = response.statusCode
-          if (code === 200) {
-            resolve()
-          } else {
-            reject(new Error('Calling connector to patch a charge returned an unexpected status code'))
-          }
-        })
-        .catch(err => {
-          reject(err)
-        })
-    })
+      const response = await connectorClient({ correlationId }).patch({ chargeId, payload }, subSegment)
+      if (response.statusCode === 200) {
+        return
+      } else {
+        throw new Error('Calling connector to patch a charge returned an unexpected status code')
+      }
+    } catch (err) {
+      throw err
+    }
   }
 
   const cancelComplete = function (response, defer) {

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -90,20 +90,14 @@ module.exports = correlationId => {
   }
 
   const patch = async function (chargeId, op, path, value, subSegment) {
-    try {
-      const payload = {
-        op: op,
-        path: path,
-        value: value
-      }
-      const response = await connectorClient({ correlationId }).patch({ chargeId, payload }, subSegment)
-      if (response.statusCode === 200) {
-        return
-      } else {
-        throw new Error('Calling connector to patch a charge returned an unexpected status code')
-      }
-    } catch (err) {
-      throw err
+    const payload = {
+      op: op,
+      path: path,
+      value: value
+    }
+    const response = await connectorClient({ correlationId }).patch({ chargeId, payload }, subSegment)
+    if (response.statusCode !== 200) {
+      throw new Error('Calling connector to patch a charge returned an unexpected status code')
     }
   }
 

--- a/test/integration/charge_ft_tests.js
+++ b/test/integration/charge_ft_tests.js
@@ -78,6 +78,14 @@ const mockSuccessCardIdResponse = function (data) {
     .reply(200, data)
 }
 
+const mockSuccessPatchEmail = function (chargeId) {
+  nock(process.env.CONNECTOR_HOST)
+    .patch(`/v1/frontend/charges/${chargeId}`, () => {
+      return true
+    })
+    .reply(200)
+}
+
 describe('chargeTests', function () {
   const localServer = process.env.CONNECTOR_HOST
   const adminUsersHost = process.env.ADMINUSERS_URL
@@ -538,6 +546,7 @@ describe('chargeTests', function () {
         defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
         defaultAdminusersResponseForGetService(gatewayAccountId)
         mockSuccessCardIdResponse(defaultCardID)
+        mockSuccessPatchEmail(chargeId)
         postChargeRequest(app, cookieValue, minimumFormCardData('1111111111111111'), chargeId)
           .expect(200)
           .expect(function (res) {
@@ -554,6 +563,7 @@ describe('chargeTests', function () {
       it('should return country list when invalid fields submitted', (done) => {
         const cookieValue = cookie.create(chargeId, {})
         mockSuccessCardIdResponse(defaultCardID)
+        mockSuccessPatchEmail(chargeId)
         defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
         defaultAdminusersResponseForGetService(gatewayAccountId)
         postChargeRequest(app, cookieValue, missingFormCardData(), chargeId)
@@ -567,6 +577,7 @@ describe('chargeTests', function () {
       it('shows an error when a card is submitted with missing fields', function (done) {
         const cookieValue = cookie.create(chargeId, {})
         mockSuccessCardIdResponse(defaultCardID)
+        mockSuccessPatchEmail(chargeId)
         defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
         defaultAdminusersResponseForGetService(gatewayAccountId)
         postChargeRequest(app, cookieValue, missingFormCardData(), chargeId)
@@ -613,6 +624,7 @@ describe('chargeTests', function () {
       it('shows an error when a card is submitted that is not supported', function (done) {
         const cookieValue = cookie.create(chargeId, {})
         nock.cleanAll()
+        mockSuccessPatchEmail(chargeId)
         defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
         defaultAdminusersResponseForGetService(gatewayAccountId)
         nock(process.env.CARDID_HOST)
@@ -647,6 +659,7 @@ describe('chargeTests', function () {
           .reply(200, { brand: 'american-express', label: 'american express', type: 'D' })
         defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
         defaultAdminusersResponseForGetService(gatewayAccountId)
+        mockSuccessPatchEmail(chargeId)
 
         postChargeRequest(app, cookieValue, minimumFormCardData('3528000700000000'), chargeId)
           .expect(200)
@@ -669,6 +682,7 @@ describe('chargeTests', function () {
         const cookieValue = cookie.create(chargeId, {})
         defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
         defaultAdminusersResponseForGetService(gatewayAccountId)
+        mockSuccessPatchEmail(chargeId)
 
         nock(process.env.CARDID_HOST)
           .post('/v1/api/card', () => {

--- a/test/integration/charge_validation_ft_tests.js
+++ b/test/integration/charge_validation_ft_tests.js
@@ -14,6 +14,13 @@ let defaultCardID = function () {
     })
     .reply(200, { brand: 'visa', label: 'visa', type: 'D' })
 }
+const mockSuccessPatchEmail = function (chargeId) {
+  nock(process.env.CONNECTOR_HOST)
+    .patch(`/v1/frontend/charges/${chargeId}`, () => {
+      return true
+    })
+    .reply(200)
+}
 let localServer = process.env.CONNECTOR_HOST
 
 const connectorChargePath = '/v1/frontend/charges/'
@@ -47,6 +54,7 @@ describe('checks for PAN-like numbers', () => {
     }
     const cookieValue = cookie.create(chargeId, {})
 
+    mockSuccessPatchEmail(chargeId)
     defaultCardID('4242424242424242')
     defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
     defaultAdminusersResponseForGetService(gatewayAccountId)
@@ -98,6 +106,7 @@ describe('checks for PAN-like numbers', () => {
     }
     const cookieValue = cookie.create(chargeId, {})
 
+    mockSuccessPatchEmail(chargeId)
     defaultCardID('4242424242424242')
     defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
     defaultAdminusersResponseForGetService(gatewayAccountId)
@@ -134,6 +143,7 @@ describe('checks for PAN-like numbers', () => {
     }
     const cookieValue = cookie.create(chargeId, {})
 
+    mockSuccessPatchEmail(chargeId)
     defaultCardID('4242424242424242')
     defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
     defaultAdminusersResponseForGetService(gatewayAccountId)


### PR DESCRIPTION
Writing a unit test for PP-5550 is complicated. Possible - but complicated.
This is because the charge_controller's "create" method is unwieldy, too big
and overly complicated. Shockingly there are no unit tests for the method.
Unsurprising given the complexity of the code.

In order to write a unit test for PP-5550 I've decided to make small
incremental simplifications and eventually move the validation code into its
own class. But for now, this method gets rid of the 'let userEmail' as its
result is never used.

I have also taken a decision - in conjunction with @mrlumbu and @sfount - to
get rid of some AWSXray code. It makes code look more complicated; and in
reality we use request ids and charge ids to trace a request through the
system.

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


