### PR TITLE
PP-5554 Include JWT in 3ds_required_out form

### DIFF
--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -92,6 +92,7 @@ module.exports = {
     const paRequest = _.get(charge, 'auth3dsData.paRequest')
     const md = _.get(charge, 'auth3dsData.md')
     const htmlOut = _.get(charge, 'auth3dsData.htmlOut')
+    const worldpayChallengeJwt = _.get(charge, 'auth3dsData.worldpayChallengeJwt')
 
     if (issuerUrl && paRequest) {
       let data = {
@@ -101,6 +102,15 @@ module.exports = {
       }
       if (md) {
         data.md = md
+      }
+      responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_OUT_VIEW, data)
+    } else if (worldpayChallengeJwt) {
+      const challengeUrl = charge.gatewayAccount.type === 'live'
+        ? process.env.WORLDPAY_3DS_FLEX_CHALLENGE_LIVE_URL
+        : process.env.WORLDPAY_3DS_FLEX_CHALLENGE_TEST_URL
+      let data = {
+        issuerUrl: challengeUrl,
+        worldpayChallengeJwt: worldpayChallengeJwt
       }
       responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_OUT_VIEW, data)
     } else if (htmlOut) {

--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -96,7 +96,7 @@ module.exports = {
 
     if (issuerUrl && paRequest) {
       let data = {
-        issuerUrl: issuerUrl,
+        postUrl: issuerUrl,
         paRequest: paRequest,
         threeDSReturnUrl: `${req.protocol}://${req.hostname}${paths.generateRoute('external.card.auth3dsRequiredIn', { chargeId: charge.id })}`
       }
@@ -109,7 +109,7 @@ module.exports = {
         ? process.env.WORLDPAY_3DS_FLEX_CHALLENGE_LIVE_URL
         : process.env.WORLDPAY_3DS_FLEX_CHALLENGE_TEST_URL
       let data = {
-        issuerUrl: challengeUrl,
+        postUrl: challengeUrl,
         worldpayChallengeJwt: worldpayChallengeJwt
       }
       responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_OUT_VIEW, data)

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -117,7 +117,8 @@ module.exports = (function () {
       paRequest: auth3dsData.paRequest,
       issuerUrl: auth3dsData.issuerUrl,
       htmlOut: auth3dsData.htmlOut,
-      md: auth3dsData.md
+      md: auth3dsData.md,
+      worldpayChallengeJwt: auth3dsData.worldpayChallengeJwt
     }
   }
 

--- a/app/views/auth_3ds_required_out.njk
+++ b/app/views/auth_3ds_required_out.njk
@@ -8,9 +8,18 @@
   <p class="govuk-body-l lede">{{ __p("authorisation.approvalNeeded") }}</p>
 </noscript>
 <form name="three_ds_required" method="post" action="{{ issuerUrl }}">
+  {% if paRequest %}
   <input type="hidden" name="PaReq" value="{{ paRequest }}"/>
+  {% endif %}
+  {% if md %}
   <input type="hidden" name="MD" value="{{ md }}"/>
+  {% endif %}
+  {% if threeDSReturnUrl %}
   <input type="hidden" name="TermUrl" value="{{ threeDSReturnUrl }}"/>
+  {% endif %}
+  {% if worldpayChallengeJwt %}
+  <input type="hidden" name="JWT" value="{{ worldpayChallengeJwt }}"/>
+  {% endif %}
   <noscript>
     <button id="confirm" class="govuk-button">{{ __p("commonButtons.continueButton") }}</button>
   </noscript>

--- a/app/views/auth_3ds_required_out.njk
+++ b/app/views/auth_3ds_required_out.njk
@@ -7,7 +7,7 @@
 <noscript>
   <p class="govuk-body-l lede">{{ __p("authorisation.approvalNeeded") }}</p>
 </noscript>
-<form name="three_ds_required" method="post" action="{{ issuerUrl }}">
+<form name="three_ds_required" method="post" action="{{ postUrl }}">
   {% if paRequest %}
   <input type="hidden" name="PaReq" value="{{ paRequest }}"/>
   {% endif %}

--- a/test/fixtures/payment_fixtures.js
+++ b/test/fixtures/payment_fixtures.js
@@ -21,7 +21,7 @@ const buildGatewayAccount = function buildGatewayAccount (opts = {}) {
     'payment_provider': 'sandbox',
     'requires3ds': false,
     'service_name': 'My service',
-    'type': 'test',
+    'type': opts.gatewayAccountType || 'test',
     'version': 1,
     'integration_version_3ds': opts.integrationVersion3ds || 1,
     card_types: cardTypes
@@ -145,6 +145,27 @@ const utilFormatPrefilledCardHolderDetails = (details) => {
   return structure
 }
 
+const buildAuth3dsDetails = function buildAuth3dsDetails (opts) {
+  const data = {}
+  if (opts.worldpayChallengeJwt) {
+    data.worldpayChallengeJwt = opts.worldpayChallengeJwt
+  }
+  if (opts.paRequest) {
+    data.paRequest = opts.paRequest
+  }
+  if (opts.issuerUrl) {
+    data.issuerUrl = opts.issuerUrl
+  }
+  if (opts.htmlOut) {
+    data.htmlOut = opts.htmlOut
+  }
+  if (opts.md) {
+    data.md = opts.md
+  }
+
+  return data
+}
+
 const buildChargeDetails = function buildChargeDetails (opts) {
   const chargeId = opts.chargeId || 'ub8de8r5mh4pb49rgm1ismaqfv'
   const data = {
@@ -170,10 +191,8 @@ const buildChargeDetails = function buildChargeDetails (opts) {
     data.card_details = utilFormatPaymentDetails(opts.paymentDetails)
   }
 
-  if (opts.auth3dsData && opts.auth3dsData.worldpayChallengeJwt) {
-    data.auth_3ds_data = {
-      worldpayChallengeJwt: opts.auth3dsData.worldpayChallengeJwt
-    }
+  if (opts.auth3dsData) {
+    data.auth_3ds_data = buildAuth3dsDetails(opts.auth3dsData)
   }
 
   return {

--- a/test/integration/three_d_secure_ft_tests.js
+++ b/test/integration/three_d_secure_ft_tests.js
@@ -1,7 +1,6 @@
 'use strict'
 
 // NPM dependencies
-const _ = require('lodash')
 const nock = require('nock')
 const chai = require('chai')
 const cheerio = require('cheerio')
@@ -11,14 +10,16 @@ const proxyquire = require('proxyquire')
 const AWSXRay = require('aws-xray-sdk')
 
 // Local dependencies
+const paymentFixtures = require('../fixtures/payment_fixtures')
+
 const app = proxyquire('../../server.js', {
   'aws-xray-sdk': {
-    enableManualMode: () => {},
-    setLogger: () => {},
+    enableManualMode: () => { },
+    setLogger: () => { },
     middleware: {
-      setSamplingRules: () => {}
+      setSamplingRules: () => { }
     },
-    config: () => {},
+    config: () => { },
     express: {
       openSegment: () => (req, res, next) => next(),
       closeSegment: () => (req, rest, next) => next()
@@ -30,34 +31,32 @@ const app = proxyquire('../../server.js', {
     getNamespace: function () {
       return {
         get: () => new AWSXRay.Segment('stub-segment'),
-        bindEmitter: () => {},
+        bindEmitter: () => { },
         run: callback => callback(),
-        set: () => {}
+        set: () => { }
       }
     },
     '@global': true
   }
 }).getApp()
 const cookie = require('../test_helpers/session.js')
-const helper = require('../test_helpers/test_helpers.js')
 const { getChargeRequest, postChargeRequest } = require('../test_helpers/test_helpers.js')
 const { defaultAdminusersResponseForGetService } = require('../test_helpers/test_helpers.js')
 const State = require('../../config/state.js')
 
 // Constants
-const gatewayAccount = {
-  gatewayAccountId: '12345',
-  paymentProvider: 'sandbox',
-  analyticsId: 'test-1234',
-  type: 'test'
+const connectorChargePath = '/v1/frontend/charges/'
+const chargeId = '23144323'
+const frontendCardDetailsPath = '/card_details'
+const gatewayAccountId = '12345'
+
+const chargeOptionsWith3dsRequired = {
+  status: State.AUTH_3DS_REQUIRED,
+  chargeId,
+  gatewayAccountId
 }
 
 describe('chargeTests', function () {
-  const connectorChargePath = '/v1/frontend/charges/'
-  const chargeId = '23144323'
-  const frontendCardDetailsPath = '/card_details'
-  const gatewayAccountId = gatewayAccount.gatewayAccountId
-
   beforeEach(function () {
     nock.cleanAll()
   })
@@ -68,16 +67,18 @@ describe('chargeTests', function () {
   })
 
   describe('The /card_details/charge_id/3ds_required', function () {
-    beforeEach(function () {
-      nock.cleanAll()
-    })
     describe('When invoked on a worldpay gateway account', function () {
       it('should return the data needed for the iframe UI', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', chargeId, gatewayAccountId,
-          {
-            'paRequest': 'aPaRequest',
-            'issuerUrl': 'http://issuerUrl.com'
-          })
+        const paRequest = 'aPaRequest'
+        const issuerUrl = 'http://issuerUrl.com'
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          auth3dsData: {
+            paRequest,
+            issuerUrl
+          }
+        }).getPlain()
+
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -88,20 +89,77 @@ describe('chargeTests', function () {
           .expect(200)
           .expect(function (res) {
             const $ = cheerio.load(res.text)
-            expect($('form[name=\'three_ds_required\'] > input[name=\'PaReq\']').attr('value')).to.eql('aPaRequest')
-            expect($('form[name=\'three_ds_required\']').attr('action')).to.eql('http://issuerUrl.com')
+            expect($('form[name=\'three_ds_required\'] > input[name=\'PaReq\']').attr('value')).to.eql(paRequest)
+            expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(issuerUrl)
+          })
+          .end(done)
+      })
+    })
+    describe('When invoked on a worldpay gateway account using 3DS Flex', function () {
+      it('should return the data needed for the iframe UI for a test gateway account', function (done) {
+        const worldpayChallengeJwt = 'aChallengeJwt'
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          auth3dsData: {
+            worldpayChallengeJwt
+          },
+          gatewayAccountType: 'test'
+        }).getPlain()
+
+        defaultAdminusersResponseForGetService(gatewayAccountId)
+
+        nock(process.env.CONNECTOR_HOST)
+          .get('/v1/frontend/charges/' + chargeId).reply(200, chargeResponse)
+        const cookieValue = cookie.create(chargeId)
+
+        getChargeRequest(app, cookieValue, chargeId, '/3ds_required_out')
+          .expect(200)
+          .expect(function (res) {
+            const $ = cheerio.load(res.text)
+            expect($('form[name=\'three_ds_required\'] > input[name=\'JWT\']').attr('value')).to.eql(worldpayChallengeJwt)
+            expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(process.env.WORLDPAY_3DS_FLEX_CHALLENGE_TEST_URL)
+          })
+          .end(done)
+      })
+      it('should return the data needed for the iframe UI for a live gateway account', function (done) {
+        const worldpayChallengeJwt = 'aChallengeJwt'
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          auth3dsData: {
+            worldpayChallengeJwt
+          },
+          gatewayAccountType: 'live'
+        }).getPlain()
+        defaultAdminusersResponseForGetService(gatewayAccountId)
+
+        nock(process.env.CONNECTOR_HOST)
+          .get('/v1/frontend/charges/' + chargeId).reply(200, chargeResponse)
+        const cookieValue = cookie.create(chargeId)
+
+        getChargeRequest(app, cookieValue, chargeId, '/3ds_required_out')
+          .expect(200)
+          .expect(function (res) {
+            const $ = cheerio.load(res.text)
+            expect($('form[name=\'three_ds_required\'] > input[name=\'JWT\']').attr('value')).to.eql(worldpayChallengeJwt)
+            expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(process.env.WORLDPAY_3DS_FLEX_CHALLENGE_LIVE_URL)
           })
           .end(done)
       })
     })
     describe('When invoked on a smartpay gateway account', function () {
       it('should return the data needed for the iframe UI', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', chargeId, gatewayAccountId,
-          {
-            'paRequest': 'aPaRequest',
-            'md': 'mdValue',
-            'issuerUrl': 'http://issuerUrl.com'
-          })
+        const paRequest = 'aPaRequest'
+        const md = 'mdValue'
+        const issuerUrl = 'http://issuerUrl.com'
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          auth3dsData: {
+            paRequest,
+            md,
+            issuerUrl
+          }
+        }).getPlain()
+
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -122,14 +180,12 @@ describe('chargeTests', function () {
     describe('When invoked on a stripe gateway account', function () {
       it('should redirect to the issuer URL', function (done) {
         const issuerUrl = 'http://issuerUrl.com'
-        const chargeResponse = helper.rawSuccessfulGetChargeWithPaymentProvider(
-          State.AUTH_3DS_REQUIRED,
-          'http://www.example.com/service',
-          chargeId,
-          gatewayAccountId,
-          { issuerUrl },
-          'stripe'
-        )
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          auth3dsData: {
+            issuerUrl
+          }
+        }).getPlain()
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -147,10 +203,13 @@ describe('chargeTests', function () {
 
     describe('When invoked on an epdq gateway account', function () {
       it('should return the data needed for the iframe UI', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', chargeId, gatewayAccountId,
-          {
-            'htmlOut': Buffer.from('<form> epdq data </form>').toString('base64')
-          })
+        const htmlOut = Buffer.from('<form> epdq data </form>').toString('base64')
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          auth3dsData: {
+            htmlOut
+          }
+        }).getPlain()
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -169,7 +228,7 @@ describe('chargeTests', function () {
 
     describe('When required information not found for auth 3ds out view', function () {
       it('should display error in iframe UI', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', chargeId, gatewayAccountId, {})
+        const chargeResponse = paymentFixtures.validChargeDetails(chargeOptionsWith3dsRequired).getPlain()
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -188,13 +247,9 @@ describe('chargeTests', function () {
   })
 
   describe('The /card_details/charge_id/3ds_required_in', function () {
-    beforeEach(function () {
-      nock.cleanAll()
-    })
-
     describe('for worldpay payment provider', function () {
       it('should return the data needed for the UI', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', gatewayAccountId)
+        const chargeResponse = paymentFixtures.validChargeDetails(chargeOptionsWith3dsRequired).getPlain()
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -216,7 +271,7 @@ describe('chargeTests', function () {
       })
 
       it('should not return UI elements for which there is no data', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', gatewayAccountId)
+        const chargeResponse = paymentFixtures.validChargeDetails(chargeOptionsWith3dsRequired).getPlain()
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -237,8 +292,10 @@ describe('chargeTests', function () {
 
     describe('for epdq payment provider', function () {
       it('should return the data needed for the UI when POST', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', gatewayAccountId)
-        chargeResponse.gateway_account.payment_provider = 'epdq'
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          paymentProvider: 'epdq'
+        }).getPlain()
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -256,8 +313,10 @@ describe('chargeTests', function () {
       })
 
       it('should return the data needed for the UI when GET', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', gatewayAccountId)
-        chargeResponse.gateway_account.payment_provider = 'epdq'
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          paymentProvider: 'epdq'
+        }).getPlain()
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -274,8 +333,10 @@ describe('chargeTests', function () {
       })
 
       it('should return error when POST', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', gatewayAccountId)
-        chargeResponse.gateway_account.payment_provider = 'epdq'
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          paymentProvider: 'epdq'
+        }).getPlain()
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -295,7 +356,7 @@ describe('chargeTests', function () {
 
     describe('for smartpay payment provider', function () {
       it('should return the data needed for the UI when GET', function (done) {
-        const chargeResponse = helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', gatewayAccountId)
+        const chargeResponse = paymentFixtures.validChargeDetails(chargeOptionsWith3dsRequired).getPlain()
         defaultAdminusersResponseForGetService(gatewayAccountId)
 
         nock(process.env.CONNECTOR_HOST)
@@ -319,11 +380,7 @@ describe('chargeTests', function () {
   })
 
   describe('The /card_details/charge_id/3ds_handler', function () {
-    beforeEach(function () {
-      nock.cleanAll()
-    })
-    const chargeResponse = _.extend(
-      helper.rawSuccessfulGetCharge(State.AUTH_3DS_REQUIRED, 'http://www.example.com/service', gatewayAccountId))
+    const chargeResponse = paymentFixtures.validChargeDetails(chargeOptionsWith3dsRequired).getPlain()
 
     it('should send 3ds data to connector and redirect to confirm', function (done) {
       const cookieValue = cookie.create(chargeId)
@@ -366,9 +423,11 @@ describe('chargeTests', function () {
 
     it('should redirect to auth_waiting if connector returns a 409 for Stripe when status AUTHORISATION 3DS READY', function (done) {
       const cookieValue = cookie.create(chargeId)
-      const stripeChargeResponse = helper.rawSuccessfulGetChargeWithPaymentProvider(
-        State.AUTH_3DS_READY, 'http://www.example.com/service', chargeId, gatewayAccountId, {}, 'stripe'
-      )
+      const stripeChargeResponse = paymentFixtures.validChargeDetails(
+        {
+          ...chargeOptionsWith3dsRequired,
+          paymentProvider: 'stripe'
+        }).getPlain()
       nock(process.env.CONNECTOR_HOST)
         .get(`/v1/frontend/charges/${chargeId}`).reply(200, stripeChargeResponse)
         .post(`${connectorChargePath}${chargeId}/3ds`, {}).reply(409)

--- a/test/integration/three_d_secure_ft_tests.js
+++ b/test/integration/three_d_secure_ft_tests.js
@@ -70,7 +70,7 @@ describe('chargeTests', function () {
     describe('When invoked on a worldpay gateway account', function () {
       it('should return the data needed for the iframe UI', function (done) {
         const paRequest = 'aPaRequest'
-        const issuerUrl = 'http://issuerUrl.com'
+        const issuerUrl = 'http://issuerUrl.test'
         const chargeResponse = paymentFixtures.validChargeDetails({
           ...chargeOptionsWith3dsRequired,
           auth3dsData: {
@@ -150,7 +150,7 @@ describe('chargeTests', function () {
       it('should return the data needed for the iframe UI', function (done) {
         const paRequest = 'aPaRequest'
         const md = 'mdValue'
-        const issuerUrl = 'http://issuerUrl.com'
+        const issuerUrl = 'http://issuerUrl.test'
         const chargeResponse = paymentFixtures.validChargeDetails({
           ...chargeOptionsWith3dsRequired,
           auth3dsData: {
@@ -172,14 +172,14 @@ describe('chargeTests', function () {
             const $ = cheerio.load(res.text)
             expect($('form[name=\'three_ds_required\'] > input[name=\'PaReq\']').attr('value')).to.eql('aPaRequest')
             expect($('form[name=\'three_ds_required\'] > input[name=\'MD\']').attr('value')).to.eql('mdValue')
-            expect($('form[name=\'three_ds_required\']').attr('action')).to.eql('http://issuerUrl.com')
+            expect($('form[name=\'three_ds_required\']').attr('action')).to.eql('http://issuerUrl.test')
           })
           .end(done)
       })
     })
     describe('When invoked on a stripe gateway account', function () {
       it('should redirect to the issuer URL', function (done) {
-        const issuerUrl = 'http://issuerUrl.com'
+        const issuerUrl = 'http://issuerUrl.test'
         const chargeResponse = paymentFixtures.validChargeDetails({
           ...chargeOptionsWith3dsRequired,
           auth3dsData: {

--- a/test/test.env
+++ b/test/test.env
@@ -9,3 +9,5 @@ APPLE_PAY_MERCHANT_ID=merchant.uk.gov.service.payments.test
 APPLE_PAY_MERCHANT_DOMAIN=www.pymnt.uk
 GOOGLE_PAY_GATEWAY_MERCHANT_ID=exampleGatewayMerchantId
 GOOGLE_PAY_MERCHANT_ID=01234567890123456789
+WORLDPAY_3DS_FLEX_CHALLENGE_TEST_URL=http://test-worldpay-challenge.pymnt.localdomain
+WORLDPAY_3DS_FLEX_CHALLENGE_LIVE_URL=http://live-worldpay-challenge.pymnt.localdomain

--- a/test/utils/normalise_test.js
+++ b/test/utils/normalise_test.js
@@ -17,7 +17,8 @@ var unNormalisedCharge = {
     paRequest: 'paRequest',
     issuerUrl: 'issuerUrl',
     htmlOut: 'html',
-    md: 'md'
+    md: 'md',
+    worldpayChallengeJwt: 'worldpayChallengeJwt'
   },
   gateway_account: {
     analytics_id: 'bla-1234',
@@ -47,7 +48,8 @@ var normalisedCharge = {
     paRequest: 'paRequest',
     issuerUrl: 'issuerUrl',
     htmlOut: 'html',
-    md: 'md'
+    md: 'md',
+    worldpayChallengeJwt: 'worldpayChallengeJwt'
   },
   gatewayAccount: {
     analyticsId: 'bla-1234',


### PR DESCRIPTION
Include a hidden field in the 3ds_required_out form for the Worldpay
challenge JWT if it is present, and post to the Worldpay challenge URL,
which differs depending on whether gateway account is a live or test
account.

In three_d_secure_ft_tests, add new test cases for 3DS flex and use the
payment fixtures rather than test_helper to construct the mocked
connector get charge response.

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


