### PR TITLE
BAU PR-1014 add lint ignore

### DIFF
--- a/app/services/clients/base_client/base_client.js
+++ b/app/services/clients/base_client/base_client.js
@@ -2,7 +2,7 @@
 
 // NPM dependencies
 const http = require('http')
-const urlParse = require('url').parse
+const urlParse = require('url').parse // eslint-disable-line
 const _ = require('lodash')
 const request = require('requestretry')
 const { getNamespace } = require('continuation-local-storage')

--- a/app/utils/add_proxy.js
+++ b/app/utils/add_proxy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // NPM dependencies
-const urlParse = require('url').parse
+const urlParse = require('url').parse // eslint-disable-line
 const _ = require('lodash')
 
 // Constants

--- a/app/utils/flattened_paths.js
+++ b/app/utils/flattened_paths.js
@@ -5,11 +5,11 @@
 module.exports = paths => {
   const flattenedPaths = {}
   for (const controllerName in paths) {
-    if (paths.hasOwnProperty(controllerName)) {
+    if (paths.hasOwnProperty(controllerName)) { // eslint-disable-line
       const controller = paths[controllerName]
       if (typeof controller !== 'object') continue
       for (const actionName in controller) {
-        if (controller.hasOwnProperty(actionName)) {
+        if (controller.hasOwnProperty(actionName)) { // eslint-disable-line
           const action = controller[actionName]
           flattenedPaths[`${action.path}_${action.action}`] = `${controllerName}.${actionName}`
         }

--- a/test/test_helpers/html_assertions.js
+++ b/test/test_helpers/html_assertions.js
@@ -77,7 +77,7 @@ chai.use(function (_chai, utils) {
 
   chai.Assertion.addMethod('withAttributes', function (attributes) {
     for (const attr in attributes) {
-      if (attributes.hasOwnProperty(attr)) {
+      if (attributes.hasOwnProperty(attr)) { // eslint-disable-line
         this.withAttribute(attr, attributes[attr])
       }
     }

--- a/test/unit/clients/connector_client_charge_tests.js
+++ b/test/unit/clients/connector_client_charge_tests.js
@@ -33,7 +33,7 @@ describe('connector client - charge tests', function () {
 
   describe('making auth request', function () {
     const authRequest = fixtures.validAuthorisationRequest()
-    
+
     before(() => {
       const response = fixtures.validChargeCardDetailsAuthorised()
       const builder = new PactInteractionBuilder(AUTHORISE_CHARGE_URL)


### PR DESCRIPTION
## WHAT
- es-lint upgrade is stopping builds for a new rule that contrary to es-lint's setup is not being deprecated
