### PR TITLE
BAU - Do not need to include accessible-autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   },
   "dependencies": {
     "@govuk-pay/pay-js-commons": "^2.13.1",
-    "accessible-autocomplete": "^1.6.2",
     "appmetrics": "4.0.x",
     "appmetrics-statsd": "3.0.x",
     "aws-xray-sdk": "^2.3.6",


### PR DESCRIPTION
We use `govuk-country-and-territory-autocomplete` which includes the
accessible-autocomplete as a dependency so we dont need to explicitly
call it ourselves
