### PR TITLE
BAU - snyk has a dependency that needs git installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/
 
 RUN ["apk", "--no-cache", "upgrade"]
 
-RUN ["apk", "add", "--no-cache", "nodejs", "npm", "tini"]
+RUN ["apk", "add", "--no-cache", "nodejs", "npm", "tini", "git"]
 
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json


### PR DESCRIPTION
Snyk has a dependency that needs git and so the container needs git
available to it