### PR TITLE
Revert "BAU - snyk has a dependency that needs git installed"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/
 
 RUN ["apk", "--no-cache", "upgrade"]
 
-RUN ["apk", "add", "--no-cache", "nodejs", "npm", "tini", "git"]
+RUN ["apk", "add", "--no-cache", "nodejs", "npm", "tini"]
 
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json


### PR DESCRIPTION
This reverts commit 057694d8c3908efbb6420dff2085616146c4ce9c.

I think this was a red herring for some reason when changing
package.json something changed that borked NPM and made it try and
install a package with git. I think this isnt normal. So we dont need
git in the container.