### PR TITLE
PP-5754 Add Sentry

### DIFF
--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -1,6 +1,7 @@
 const { createLogger, format, transports } = require('winston')
 const { json, splat, prettyPrint } = format
 const { govUkPayLoggingFormat } = require('@govuk-pay/pay-js-commons').logging
+const { addSentryToErrorLevel } = require('./sentry.js')
 
 const logger = createLogger({
   format: format.combine(
@@ -15,5 +16,6 @@ const logger = createLogger({
 })
 
 module.exports = (loggerName) => {
-  return logger.child({ logger_name: loggerName })
+  const childLogger = logger.child({ logger_name: loggerName })
+  return addSentryToErrorLevel(childLogger)
 }

--- a/app/utils/sentry.js
+++ b/app/utils/sentry.js
@@ -1,0 +1,32 @@
+const Sentry = require('@sentry/node')
+
+function initialiseSentry () {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.ENVIRONMENT,
+    beforeSend (event) {
+      if (event.request) {
+        delete event.request // This can include sensitive data such as card numbers
+      }
+      return event
+    }
+  })
+  return Sentry
+}
+
+const addSentryToErrorLevel = (originalLogger) => {
+  const sentryLogger = Object.create(originalLogger)
+  sentryLogger.error = msg => {
+    try {
+      Sentry.captureException(new Error(msg))
+    } finally {
+      originalLogger.error(msg)
+    }
+  }
+  return sentryLogger
+}
+
+module.exports = {
+  initialiseSentry,
+  addSentryToErrorLevel
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1300,6 +1300,104 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sentry/core": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.7.1.tgz",
+      "integrity": "sha512-AOn3k3uVWh2VyajcHbV9Ta4ieDIeLckfo7UMLM+CTk2kt7C89SayDGayJMSsIrsZlL4qxBoLB9QY4W2FgAGJrg==",
+      "requires": {
+        "@sentry/hub": "5.7.1",
+        "@sentry/minimal": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.7.1.tgz",
+      "integrity": "sha512-evGh323WR073WSBCg/RkhlUmCQyzU0xzBzCZPscvcoy5hd4SsLE6t9Zin+WACHB9JFsRQIDwNDn+D+pj3yKsig==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.7.1.tgz",
+      "integrity": "sha512-nS/Dg+jWAZtcxQW8wKbkkw4dYvF6uyY/vDiz/jFCaux0LX0uhgXAC9gMOJmgJ/tYBLJ64l0ca5LzpZa7BMJQ0g==",
+      "requires": {
+        "@sentry/hub": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.7.1.tgz",
+      "integrity": "sha512-hVM10asFStrOhYZzMqFM7V1lrHkr1ydc2n/SFG0ZmIQxfTjCVElyXV/BJASIdqadM1fFIvvtD/EfgkTcZmub1g==",
+      "requires": {
+        "@sentry/core": "5.7.1",
+        "@sentry/hub": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "cookie": "^0.3.1",
+        "https-proxy-agent": "^3.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+          "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.7.1.tgz",
+      "integrity": "sha512-tbUnTYlSliXvnou5D4C8Zr+7/wJrHLbpYX1YkLXuIJRU0NSi81bHMroAuHWILcQKWhVjaV/HZzr7Y/hhWtbXVQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.7.1.tgz",
+      "integrity": "sha512-nhirUKj/qFLsR1i9kJ5BRvNyzdx/E2vorIsukuDrbo8e3iZ11JMgCOVrmC8Eq9YkHBqgwX4UnrPumjFyvGMZ2Q==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -1891,7 +1989,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
@@ -3215,7 +3313,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -5155,7 +5253,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -5782,7 +5880,7 @@
     },
     "dotenv": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
       "dev": true
     },
@@ -6286,7 +6384,7 @@
         },
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
         },
@@ -8638,7 +8736,7 @@
     },
     "get-stream": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
       "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
       "dev": true,
       "requires": {
@@ -8912,7 +9010,7 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -12286,6 +12384,11 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "macos-release": {
       "version": "2.3.0",
@@ -18156,7 +18259,7 @@
       "dependencies": {
         "bl": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
           "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
           "dev": true,
           "requires": {
@@ -18180,7 +18283,7 @@
         },
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
@@ -18883,7 +18986,7 @@
         },
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
           "dev": true
         },
@@ -20243,8 +20346,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tsscmp": {
       "version": "1.0.6",
@@ -21104,7 +21206,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "dependencies": {
     "@govuk-pay/pay-js-commons": "2.16.0",
+    "@sentry/node": "5.7.1",
     "appmetrics": "4.0.x",
     "appmetrics-statsd": "3.0.x",
     "aws-xray-sdk": "^2.4.0",

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const noCache = require('./app/utils/no_cache')
 const session = require('./app/utils/session')
 const i18nConfig = require('./config/i18n')
 const i18nPayTranslation = require('./config/pay-translation')
+const Sentry = require('./app/utils/sentry.js').initialiseSentry()
 
 // Global constants
 const { NODE_ENV, PORT, ANALYTICS_TRACKING_ID, GOOGLE_PAY_MERCHANT_ID, APPLE_PAY_MERCHANT_ID_CERTIFICATE } = process.env
@@ -156,6 +157,7 @@ function logApplePayCertificateTimeToExpiry () {
  */
 function initialise () {
   const app = unconfiguredApp
+  app.use(Sentry.Handlers.requestHandler())
   initialiseProxy(app)
 
   initialiseGlobalMiddleware(app)
@@ -165,6 +167,7 @@ function initialise () {
   initialisePublic(app)
   initialiseRoutes(app) // This contains the 404 override and so should be last
   logApplePayCertificateTimeToExpiry()
+  app.use(Sentry.Handlers.errorHandler())
 
   return app
 }


### PR DESCRIPTION
Send error level log messages to Sentry. Using the log level to
control when messages are sent to Sentry seems intuitive and since we now
require a common logger throughout the application it offers a
convenient point to add Sentry.

Unhandled exceptions will be caught by the Sentry error middleware added
within `server.js` as per the guidlines when using Sentry with Express.

When initialising Sentry a `beforeSend` filter is added to remove the
`request` element from the event if it exists. The `request` element contains the
data from a failed request and this can include sensitive information such
as card numbers. We may want to introduce more refined filtering to allow
non-sensitive information from a failed request to go to Sentry at a
later date.

`app/utils/sentry.js` and more elements of `app/utils/logger.js` can
probably move to `pay-js-commons` once we're happy with the implementation.


## HOW
I have been testing locally and you can see some of the notifications for environment `Dan_testing_frontend` at:
https://pay-sentry.cloudapps.digital/sentry/frontend/
