### PR TITLE
PP-5758 Change state enforcer log line to log at INFO level

### DIFF
--- a/app/middleware/state_enforcer.js
+++ b/app/middleware/state_enforcer.js
@@ -12,7 +12,7 @@ const paths = require('../paths')
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 
 module.exports = (req, res, next) => {
-  let correctStates = stateService.resolveStates(req.actionName)
+  const correctStates = stateService.resolveStates(req.actionName)
   const currentState = req.chargeData.status
 
   const paymentProvider = req.chargeData.gateway_account.payment_provider
@@ -20,7 +20,7 @@ module.exports = (req, res, next) => {
     correctStates.push(State.AUTH_3DS_READY)
   }
   if (!correctStates.includes(currentState)) {
-    logger.error(`State enforcer status doesn't match: current charge state from \
+    logger.info(`State enforcer status doesn't match: current charge state from \
     connector [${currentState}], expected [${correctStates}] for charge [${req.chargeId}] \
     with payment provider [${paymentProvider}]`)
     const stateName = currentState.toUpperCase().replace(/\s/g, '_')
@@ -39,10 +39,10 @@ function getGoogleAnalytics (req) {
   if (gatewayAccount) {
     return {
       // The state enforcer will append the correct analytics page to the base charge path
-      'path': paths.generateRoute(`card.new`, { chargeId: req.chargeId }),
-      'analyticsId': gatewayAccount.analytics_id,
-      'type': gatewayAccount.type,
-      'paymentProvider': gatewayAccount.payment_provider
+      path: paths.generateRoute('card.new', { chargeId: req.chargeId }),
+      analyticsId: gatewayAccount.analytics_id,
+      type: gatewayAccount.type,
+      paymentProvider: gatewayAccount.payment_provider
     }
   }
   return withAnalyticsError().analytics


### PR DESCRIPTION
We log when the state enforcer decides that the charge is not in the correct state to access a route, and as a result render an appropriate page. This is business as usual, and part of the design of connector, so we shouldn't log this at ERROR level, instead log at INFO level.

Co-authored-by: Dan Worth <dan.worth@digital.cabinet-office.gov.uk>