### PR TITLE
PP-5758 Handle 422 responses from card id

### DIFF
--- a/app/models/card.js
+++ b/app/models/card.js
@@ -20,7 +20,7 @@ i18n.configure(i18nConfig)
 const checkCard = function (cardNo, allowed, language, correlationId, subSegment) {
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
-    const data = { 'cardNumber': parseInt(cardNo) }
+    const data = { cardNumber: parseInt(cardNo) }
 
     i18n.setLocale(language || 'en')
 
@@ -43,6 +43,9 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
           if (response.statusCode === 404) {
             return reject(new Error('Your card is not supported'))
           }
+          if (response.statusCode === 422) {
+            return reject(new Error(i18n.__('fieldErrors.fields.cardNo.message')))
+          }
           // if the server is down, or returns non 500, just continue
           if (response.statusCode !== 200) {
             return resolve()
@@ -58,8 +61,8 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
           }
 
           logger.debug(`[${correlationId}] Checking card brand - `, {
-            'cardBrand': card.brand,
-            'cardType': card.type
+            cardBrand: card.brand,
+            cardType: card.type
           })
 
           if (_.filter(allowed, { brand: card.brand }).length === 0) {


### PR DESCRIPTION
Card id responds with a 422 if frontend sends it an empty card number or a card number of the wrong length. Currently, this response is swallowed and nothing is displayed to the user. There is an issue with how we do this, as an unhandled error is thrown but this commit doesn't seek to resolve this.

This commit treats a 422 response as a validation error and displays an appropriate message to the user.
