### PR TITLE
PP-5778 Temporarily log paRes post 3DS auth

### DIFF
--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -26,11 +26,12 @@ const redirect = res => {
   }
 }
 
-const build3dsPayload = req => {
+const build3dsPayload = (chargeId, req) => {
   let auth3dsPayload = {}
   const paRes = _.get(req, 'body.PaRes')
   if (!_.isUndefined(paRes)) {
     auth3dsPayload.pa_response = paRes
+    logger.info(`paRes received for charge [${chargeId}] 3DS authorisation [${paRes}]`)
   }
 
   const providerStatus = threeDsEPDQResults[_.get(req, 'body.providerStatus', '')]
@@ -70,7 +71,7 @@ module.exports = {
   auth3dsHandler (req, res) {
     const charge = normalise.charge(req.chargeData, req.chargeId)
     const correlationId = req.headers[CORRELATION_HEADER] || ''
-    const payload = build3dsPayload(req)
+    const payload = build3dsPayload(charge.id, req)
     connectorClient({ correlationId }).threeDs({ chargeId: charge.id, payload })
       .then(handleThreeDsResponse(req, res, charge))
       .catch((err) => {


### PR DESCRIPTION
## WHAT
- We have few 3DS payments (1-2 payments/day) failing with error response (`error code: 1, error: Internal error`) from Worldpay.
  Although the exact reason is not known, Worldpay has indicated we didn't send full paRes in payload for one of the payments.
  Log paRes to ruleout/to find if it is cause of failure.