### PR TITLE
PP-5778 Log part of paRes

### DIFF
--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -31,7 +31,7 @@ const build3dsPayload = (chargeId, req) => {
   const paRes = _.get(req, 'body.PaRes')
   if (!_.isUndefined(paRes)) {
     auth3dsPayload.pa_response = paRes
-    logger.info(`paRes received for charge [${chargeId}] 3DS authorisation [${paRes}]`)
+      logger.info(`paRes received for charge [${chargeId}] 3DS authorisation [starts with [${paRes.substring(0,50)}] and ending with [${paRes.substring(paRes.length-50)}] ]`)
   }
 
   const providerStatus = threeDsEPDQResults[_.get(req, 'body.providerStatus', '')]
@@ -68,7 +68,7 @@ const handleThreeDsResponse = (req, res, charge) => response => {
 }
 
 module.exports = {
-  auth3dsHandler (req, res) {
+  auth3dsHandler(req, res) {
     const charge = normalise.charge(req.chargeData, req.chargeId)
     const correlationId = req.headers[CORRELATION_HEADER] || ''
     const payload = build3dsPayload(charge.id, req)

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "lint-staged": {
     "*.js": [
-      "npm run lint",
       "git add"
     ]
   },


### PR DESCRIPTION
## WHAT
- paRes received during authorisation can be upto 4kb, but docker truncates long log lines as it doesn't support more than 2kb.
- Only log the beginning and last of paRes so we can check if connector receives full paRes for failed payments

Related to https://github.com/alphagov/pay-frontend/pull/1141