### PR TITLE
PP-5822 Remove CSRF from 3ds iframe routes

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -81,11 +81,11 @@ exports.bind = function (app) {
 
   app.get(card.auth3dsRequired.path, middlewareStack, threeDS.auth3dsRequired)
   app.get(card.auth3dsRequiredOut.path, middlewareStack, threeDS.auth3dsRequiredOut)
-  app.post(card.auth3dsRequiredInEpdq.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredInEpdq)
-  app.get(card.auth3dsRequiredInEpdq.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredInEpdq)
-  app.post(card.auth3dsRequiredIn.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredIn)
-  app.get(card.auth3dsRequiredIn.path, [xraySegmentCls, csrfTokenGeneration, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredIn)
-  app.post(card.auth3dsHandler.path, middlewareStack, threeDS.auth3dsHandler)
+  app.post(card.auth3dsRequiredInEpdq.path, [xraySegmentCls, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredInEpdq)
+  app.get(card.auth3dsRequiredInEpdq.path, [xraySegmentCls, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredInEpdq)
+  app.post(card.auth3dsRequiredIn.path, [xraySegmentCls, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredIn)
+  app.get(card.auth3dsRequiredIn.path, [xraySegmentCls, retrieveCharge, resolveLanguage], threeDS.auth3dsRequiredIn)
+  app.post(card.auth3dsHandler.path, [xraySegmentCls, actionName, retrieveCharge, resolveLanguage, resolveService, stateEnforcer], threeDS.auth3dsHandler)
 
   // Apple Pay endpoints
   app.post(paths.applePay.session.path, applePayMerchantValidation)

--- a/app/views/auth_3ds_required_in.njk
+++ b/app/views/auth_3ds_required_in.njk
@@ -8,7 +8,6 @@
     <p class="govuk-body-l lede">{{ __p("authorisation.approved") }}</p>
 </noscript>
 <form name="three_ds_required" method="post" action="{{ threeDsHandlerUrl }}" target="_top">
-    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
     {% if paResponse %}
         <input type="hidden" name="PaRes" value="{{ paResponse }}"/>
     {% endif %}


### PR DESCRIPTION
* we cannot guarantee the behaviour for cookies being set on our 3ds
pages
* this seems to negatively impact payment journeys and doesn't defend
against a particular risk surface