### PR TITLE
BAU Include parent layout start block in payment page

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -9,6 +9,8 @@
 {% set mainClasses = "charge-new" %}
 
   {% block bodyStart %}
+    {{ super() }}
+
     {% if allowApplePay or allowGooglePay %}
       <script>
       {% if allowApplePay %}


### PR DESCRIPTION
Cookie banner currently isn't shown on the card payment page. 
* include parent layout block to show this

We should verify that the cookie banner should be shown on payment pages, however this brings it in line with all of the other payment journey (3ds, confirmation, etc.)