### PR TITLE
BAU - Remove trailing dashes in log lines

### DIFF
--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -27,11 +27,11 @@ const redirect = res => {
 }
 
 const build3dsPayload = (chargeId, req) => {
-  let auth3dsPayload = {}
+  const auth3dsPayload = {}
   const paRes = _.get(req, 'body.PaRes')
   if (!_.isUndefined(paRes)) {
     auth3dsPayload.pa_response = paRes
-      logger.info(`paRes received for charge [${chargeId}] 3DS authorisation [starts with [${paRes.substring(0,50)}] and ending with [${paRes.substring(paRes.length-50)}] ]`)
+    logger.info(`paRes received for charge [${chargeId}] 3DS authorisation [starts with [${paRes.substring(0, 50)}] and ending with [${paRes.substring(paRes.length - 50)}] ]`)
   }
 
   const providerStatus = threeDsEPDQResults[_.get(req, 'body.providerStatus', '')]
@@ -68,14 +68,14 @@ const handleThreeDsResponse = (req, res, charge) => response => {
 }
 
 module.exports = {
-  auth3dsHandler(req, res) {
+  auth3dsHandler (req, res) {
     const charge = normalise.charge(req.chargeData, req.chargeId)
     const correlationId = req.headers[CORRELATION_HEADER] || ''
     const payload = build3dsPayload(charge.id, req)
     connectorClient({ correlationId }).threeDs({ chargeId: charge.id, payload })
       .then(handleThreeDsResponse(req, res, charge))
       .catch((err) => {
-        logger.error('Exception in auth3dsHandler -', {
+        logger.error('Exception in auth3dsHandler', {
           chargeId: charge.id,
           chargeStatus: charge.status,
           error: err
@@ -96,7 +96,7 @@ module.exports = {
     const worldpayChallengeJwt = _.get(charge, 'auth3dsData.worldpayChallengeJwt')
 
     if (issuerUrl && paRequest) {
-      let data = {
+      const data = {
         postUrl: issuerUrl,
         paRequest: paRequest,
         threeDSReturnUrl: `${req.protocol}://${req.hostname}${paths.generateRoute('external.card.auth3dsRequiredIn', { chargeId: charge.id })}`
@@ -109,7 +109,7 @@ module.exports = {
       const challengeUrl = charge.gatewayAccount.type === 'live'
         ? process.env.WORLDPAY_3DS_FLEX_CHALLENGE_LIVE_URL
         : process.env.WORLDPAY_3DS_FLEX_CHALLENGE_TEST_URL
-      let data = {
+      const data = {
         postUrl: challengeUrl,
         worldpayChallengeJwt: worldpayChallengeJwt
       }

--- a/app/models/card.js
+++ b/app/models/card.js
@@ -60,7 +60,7 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
             prepaid: body.prepaid
           }
 
-          logger.debug(`[${correlationId}] Checking card brand - `, {
+          logger.debug(`[${correlationId}] Checking card brand`, {
             cardBrand: card.brand,
             cardType: card.type
           })

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -101,7 +101,7 @@ module.exports = correlationId => {
   const cancelComplete = function (response, defer) {
     const code = response.statusCode
     if (code === 204) return defer.resolve()
-    logger.error('[%s] Calling connector cancel a charge failed -', correlationId, {
+    logger.error('[%s] Calling connector cancel a charge failed', correlationId, {
       service: 'connector',
       method: 'POST',
       status: code
@@ -127,7 +127,7 @@ module.exports = correlationId => {
 
   const updateComplete = function (response, defer) {
     if (response.statusCode !== 204) {
-      logger.error('[%s] Calling connector to update charge status failed -', correlationId, {
+      logger.error('[%s] Calling connector to update charge status failed', correlationId, {
         chargeId: response.body,
         status: response.statusCode
       })

--- a/app/services/charge_param_retriever.js
+++ b/app/services/charge_param_retriever.js
@@ -7,12 +7,12 @@ exports.retrieve = req => {
   const chargeId = req.params.chargeId ? req.params.chargeId : req.body.chargeId
 
   if (!chargeId) {
-    logger.error('ChargeId was not found in request -', {
+    logger.error('ChargeId was not found in request', {
       chargeId: 'undefined'
     })
     return false
   } else if (!(cookie.getSessionCookieName() && cookie.getSessionVariable(req, 'ch_' + chargeId))) {
-    logger.error('ChargeId was not found on the session -', {
+    logger.error('ChargeId was not found on the session', {
       chargeId: chargeId
     })
     return false

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -75,7 +75,7 @@ const _putConnector = (url, payload, description, subSegment) => {
       resolve(response)
     }).catch(err => {
       logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PUT', url, new Date() - startTime)
-      logger.error('Calling connector threw exception -', {
+      logger.error('Calling connector threw exception', {
         service: 'connector',
         method: 'PUT',
         url: url,
@@ -107,7 +107,7 @@ const _postConnector = (url, payload, description) => {
       resolve(response)
     }).catch(err => {
       logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
-      logger.error('Calling connector threw exception -', {
+      logger.error('Calling connector threw exception', {
         service: 'connector',
         method: 'POST',
         url: url,
@@ -139,7 +139,7 @@ const _patchConnector = (url, payload, description) => {
       resolve(response)
     }).catch(err => {
       logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', url, new Date() - startTime)
-      logger.error('Calling connector threw exception -', {
+      logger.error('Calling connector threw exception', {
         service: 'connector',
         method: 'PATCH',
         url: url,
@@ -178,7 +178,7 @@ const _getConnector = (url, description) => {
       resolve(response)
     }).catch(err => {
       logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
-      logger.error('Calling connector threw exception -', {
+      logger.error('Calling connector threw exception', {
         service: 'connector',
         method: 'GET',
         url: url,

--- a/app/utils/charge_validation_backend.js
+++ b/app/utils/charge_validation_backend.js
@@ -14,7 +14,7 @@ module.exports = (translations, logger, cardModel, chargeOptions) => {
       const validation = validator.verify(req.body)
       cardModel.checkCard(normalise.creditCard(req.body.cardNo), req.chargeData.language)
         .then(card => {
-          logger.debug('Card supported - ', {
+          logger.debug('Card supported', {
             cardBrand: card.brand,
             cardType: card.type,
             cardCorporate: card.corporate,
@@ -23,7 +23,7 @@ module.exports = (translations, logger, cardModel, chargeOptions) => {
           resolve({ validation, card })
         })
         .catch(err => {
-          logger.debug('Card not supported - ', { err: err.message })
+          logger.debug('Card not supported', { err: err.message })
           // add card not supported error to validation
           validation.hasError = true
           _.remove(validation.errorFields, errorField => errorField.cssKey === 'card-no')

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -3,7 +3,7 @@
 const logger = require('./logger')(__filename)
 
 exports.authChargePost = url => {
-  logger.debug('Calling connector to authorize a charge (post card details) -', {
+  logger.debug('Calling connector to authorize a charge (post card details)', {
     service: 'connector',
     method: 'POST',
     url: url
@@ -11,7 +11,7 @@ exports.authChargePost = url => {
 }
 
 exports.failedChargePost = status => {
-  logger.warn('Calling connector to authorize a charge (post card details) failed -', {
+  logger.warn('Calling connector to authorize a charge (post card details) failed', {
     service: 'connector',
     method: 'POST',
     status: status
@@ -19,7 +19,7 @@ exports.failedChargePost = status => {
 }
 
 exports.failedChargePostException = err => {
-  logger.error('Calling connector to authorize a charge (post card details) threw exception -', {
+  logger.error('Calling connector to authorize a charge (post card details) threw exception', {
     service: 'connector',
     method: 'POST',
     error: err
@@ -27,7 +27,7 @@ exports.failedChargePostException = err => {
 }
 
 exports.failedChargePatch = err => {
-  logger.warn('Calling connector to patch a charge failed -', {
+  logger.warn('Calling connector to patch a charge failed', {
     service: 'connector',
     method: 'PATCH',
     err: err
@@ -35,7 +35,7 @@ exports.failedChargePatch = err => {
 }
 
 exports.failedGetWorldpayDdcJwt = err => {
-  logger.error('Calling connector to get a Worldpay 3DS Flex DDC JWT threw exception -', {
+  logger.error('Calling connector to get a Worldpay 3DS Flex DDC JWT threw exception', {
     service: 'connector',
     method: 'GET',
     error: err

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -3,7 +3,7 @@
 const logger = require('./logger')(__filename)
 
 exports.logRequestStart = context => {
-  logger.info(`Calling ${context.service}  ${context.description}-`, {
+  logger.info(`Calling ${context.service} ${context.description}`, {
     service: context.service,
     method: context.method,
     url: context.url
@@ -14,7 +14,7 @@ exports.logRequestEnd = context => {
   logger.info(`[${context.correlationId}] - ${context.method} to ${context.url} ended - elapsed time: ${duration} ms`)
 }
 exports.logRequestFailure = (context, response) => {
-  logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed -`, {
+  logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed`, {
     service: context.service,
     method: context.method,
     url: context.url,
@@ -22,7 +22,7 @@ exports.logRequestFailure = (context, response) => {
   })
 }
 exports.logRequestError = (context, error) => {
-  logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception -`, {
+  logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception`, {
     service: context.service,
     method: context.method,
     url: context.url,


### PR DESCRIPTION
These dashes were there previously because before we logged in JSON the
logger would concatenate the JSON object it was passed as a second
parameter into the line.

Now, however, the keys in this JSON object are merged into the top-level
JSON object for the logline, so there is a hanging dash on the end of
the message which makes it appear that the message is incomplete. Remove
these.