### PR TITLE
PP-5851 Add additional logging when session cookie not present

### DIFF
--- a/app/services/charge_param_retriever.js
+++ b/app/services/charge_param_retriever.js
@@ -11,9 +11,21 @@ exports.retrieve = req => {
       chargeId: 'undefined'
     })
     return false
-  } else if (!(cookie.getSessionCookieName() && cookie.getSessionVariable(req, 'ch_' + chargeId))) {
+  } else if (!cookie.getSessionCookieName() || !cookie.isSessionPresent(req)) {
+    logger.error('Session cookie is not present', {
+      chargeId: chargeId,
+      referrer: req.get('Referrer'),
+      url: req.originalUrl,
+      method: req.method
+    })
+    return false
+  } else if (!cookie.getSessionVariable(req, 'ch_' + chargeId)) {
     logger.error('ChargeId was not found on the session', {
-      chargeId: chargeId
+      chargeId: chargeId,
+      referrer: req.get('Referrer'),
+      url: req.originalUrl,
+      method: req.method,
+      session_keys: cookie.getSessionVariableNames(req)
     })
     return false
   }

--- a/app/utils/cookies.js
+++ b/app/utils/cookies.js
@@ -15,7 +15,9 @@ module.exports = {
   setSessionVariable,
   getSessionVariable,
   namedCookie,
-  deleteSessionVariable
+  deleteSessionVariable,
+  isSessionPresent,
+  getSessionVariableNames
 }
 
 /**
@@ -156,4 +158,14 @@ function setSessionVariable (req, key, value) {
 function getSessionVariable (req, key) {
   const session = req[getSessionCookieName()]
   return session && session[key]
+}
+
+function isSessionPresent (req) {
+  const session = req[getSessionCookieName()]
+  return session && Object.getOwnPropertyNames(session).length > 0
+}
+
+function getSessionVariableNames (req) {
+  const session = req[getSessionCookieName()]
+  return Object.keys(session)
 }

--- a/test/middleware/csrf_test.js
+++ b/test/middleware/csrf_test.js
@@ -26,7 +26,8 @@ describe('retrieve param test', function () {
       ch_foo: {
         csrfSecret: process.env.CSRF_USER_SECRET
       }
-    }
+    },
+    get: () => null
   }
 
   var noSession = _.cloneDeep(validGetRequest)

--- a/test/services/charge_param_retriever_test.js
+++ b/test/services/charge_param_retriever_test.js
@@ -4,32 +4,36 @@ var assert = require('assert')
 var chargeParam = require(path.join(__dirname, '/../../app/services/charge_param_retriever.js'))
 
 describe('charge param retreiver', function () {
-  var EMPTY_RESPONSE = { params: {}, body: {} }
+  var EMPTY_RESPONSE = { params: {}, body: {}, get: () => null }
 
   var NO_SESSION_GET_RESPONSE = {
     params: { chargeId: 'foo' },
     body: {},
-    method: 'GET'
+    method: 'GET',
+    get: () => null
   }
 
   var NO_SESSION_POST_RESPONSE = {
     params: {},
     body: { chargeId: 'foo' },
-    method: 'POST'
+    method: 'POST',
+    get: () => null
   }
 
   var VALID_GET_RESPONSE = {
     params: { chargeId: 'foo' },
     body: {},
     method: 'GET',
-    frontend_state: { ch_foo: true }
+    frontend_state: { ch_foo: true },
+    get: () => null
   }
 
   var VALID_POST_RESPONSE = {
     params: {},
     body: { chargeId: 'foo' },
     method: 'POST',
-    frontend_state: { ch_foo: true }
+    frontend_state: { ch_foo: true },
+    get: () => null
   }
 
   it('should return false if the charge param is not present in params or body', function () {


### PR DESCRIPTION
- Log a different line if the session cookie is entirely missing as opposed to present, but the charge id is missing.
- Log the URL and the method for the request
- Log the referrer. Note, however, it seems that if the user clicks back in their browser, this will probably be the referrer for the initial request rather than the page they were on when they clicked back.
- If the cookie is present but the charge is not on it, log the other charge variables that are present on the cookie.