### PR TITLE
PP-5851 Log charge id missing from session at INFO level

### DIFF
--- a/app/services/charge_param_retriever.js
+++ b/app/services/charge_param_retriever.js
@@ -12,7 +12,7 @@ exports.retrieve = req => {
     })
     return false
   } else if (!cookie.getSessionCookieName() || !cookie.isSessionPresent(req)) {
-    logger.error('Session cookie is not present', {
+    logger.info('Session cookie is not present', {
       chargeId: chargeId,
       referrer: req.get('Referrer'),
       url: req.originalUrl,
@@ -20,7 +20,7 @@ exports.retrieve = req => {
     })
     return false
   } else if (!cookie.getSessionVariable(req, 'ch_' + chargeId)) {
-    logger.error('ChargeId was not found on the session', {
+    logger.info('ChargeId was not found on the session', {
       chargeId: chargeId,
       referrer: req.get('Referrer'),
       url: req.originalUrl,


### PR DESCRIPTION
It has been determined that in the vast majority of cases, this line is logged when the user has completed their payment and then attempted to go back to a payment page after we have removed the session variable from their cookie.

Therefore this is creating a lot of noise in Sentry when it is mainly business as usual.

We might want to investigate whether we should be immediately removing the cookie when we return the user to the return_url. If we didn't we would be able to show the user a more meaningful page, which might be desirable as the user clicking back occurs a lot.

