### PR TITLE
PP-5872 Browserify Card details page inline scripts

### DIFF
--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -6,7 +6,6 @@ const { submitWithWorldpay3dsFlexDdcResult } = require('./worldpay-3ds-flex-ddc'
 var init = function () {
   var form = document.getElementById('card-details')
   var formInputs = Array.prototype.slice.call(form.querySelectorAll('input'))
-  var countryAutocomplete = document.getElementsByClassName('autocomplete__input')[0]
   var countrySelect = document.getElementById('address-country')
   var postcodeInput = document.getElementById('address-postcode')
   var cardInput = document.getElementById('card-no')
@@ -52,6 +51,10 @@ var init = function () {
     }
     e.preventDefault()
     var validations = allValidations()
+
+    // can't get the element in init() as the object wouldn't have been initalised by helpers.js -> initialiseAddressCountryAutocomplete
+    var countryAutocomplete = document.getElementsByClassName('autocomplete__input')[0]
+
     if ((window.Charge.collect_billing_address === true) && (countryAutocomplete.value === '')) {
       countryAutocomplete.value = document.getElementById('address-country-select').value
     }

--- a/app/assets/javascripts/browsered/helpers.js
+++ b/app/assets/javascripts/browsered/helpers.js
@@ -1,0 +1,26 @@
+const setGlobalChargeId = () => {
+  const chargeId = document.getElementById('charge-id').value
+  window.chargeId = chargeId
+}
+
+const initialiseAddressCountryAutocomplete = () => {
+  var autocompleteScript = document.createElement('script')
+
+  autocompleteScript.onload = function () {
+    openregisterLocationPicker({
+      selectElement: document.getElementById('address-country'),
+      url: '/public/countries-autocomplete-graph.json',
+      autoselect: true,
+      displayMenu: 'overlay'
+    })
+  }
+
+  autocompleteScript.setAttribute('type', 'text/javascript')
+  autocompleteScript.setAttribute('src', '/public/location-autocomplete.min.js')
+  document.getElementsByTagName('head')[0].appendChild(autocompleteScript)
+}
+
+module.exports = {
+  setGlobalChargeId,
+  initialiseAddressCountryAutocomplete
+}

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -2,12 +2,14 @@ const inputConfirm = require('./assets/javascripts/browsered/form-input-confirm'
 const webPayments = require('./assets/javascripts/browsered/web-payments')
 const analytics = require('gaap-analytics')
 const formValidation = require('./assets/javascripts/browsered/form-validation')
+const helpers = require('./assets/javascripts/browsered/helpers')
 
 exports.chargeValidation = require('./utils/charge_validation')
 analytics.eventTracking.init()
 
 // Place functions into scope so can trigger in scripts.njk
 window.payScripts = { // eslint-disable-line no-unused-vars
+  helpers,
   inputConfirm,
   webPayments,
   formValidation

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -492,22 +492,9 @@
     </aside>
   </div>
 </div>
-  <script id="govuk-script-charge">
-    window.chargeId = "{{ id }}"
-  </script>
+
 {% endblock %}
 
 {% block bodyEnd %}
-  {% if service.collectBillingAddress %}
-  <script type="text/javascript" src="/public/location-autocomplete.min.js"></script>
-  <script type="text/javascript">
-    openregisterLocationPicker({
-      selectElement: document.getElementById('address-country'),
-      url: '/public/countries-autocomplete-graph.json',
-      autoselect: true,
-      displayMenu: 'overlay'
-    })
-  </script>
-  {% endif %}
   {% include "includes/scripts.njk" %}
 {% endblock %}

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -39,7 +39,11 @@
   document.addEventListener('DOMContentLoaded', function() {
     window.GOVUKFrontend.initAll();
     if (mainWrap.classList.contains('charge-new')) {
+      window.payScripts.helpers.setGlobalChargeId();
       showCardType().init();
+      {% if service.collectBillingAddress %}
+        window.payScripts.helpers.initialiseAddressCountryAutocomplete();
+      {% endif %}
       window.payScripts.inputConfirm.init();
       window.payScripts.formValidation.init();
     } else if (mainWrap.classList.contains('confirm-page')) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "location",
       "Charge",
       "parent",
-      "showCardType"
+      "showCardType",
+      "openregisterLocationPicker"
     ],
     "ignore": [
       "app/assets/javascripts/modules/*.js"

--- a/test/cypress/integration/card/payment.spec.js
+++ b/test/cypress/integration/card/payment.spec.js
@@ -44,7 +44,8 @@ describe('Standard card payment flow', () => {
   const createPaymentChargeStubsWelsh = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'cy')
 
   const checkCardDetailsStubs = [
-    { name: 'connectorGetChargeDetails',
+    {
+      name: 'connectorGetChargeDetails',
       opts: {
         chargeId,
         status: 'ENTERING CARD DETAILS',
@@ -58,7 +59,8 @@ describe('Standard card payment flow', () => {
   // i.e - charge after or before authorisation when clicking confirm should bring up confirmation page or 'your payment is in progress' page respectively
   const confirmPaymentDetailsStubs = [
     { name: 'adminUsersGetService', opts: {} },
-    { name: 'connectorMultipleSubsequentChargeDetails',
+    {
+      name: 'connectorMultipleSubsequentChargeDetails',
       opts: [{
         chargeId,
         status: 'ENTERING CARD DETAILS',
@@ -75,7 +77,8 @@ describe('Standard card payment flow', () => {
   ]
 
   const submitPaymentCaptureStubs = [
-    { name: 'connectorMultipleSubsequentChargeDetails',
+    {
+      name: 'connectorMultipleSubsequentChargeDetails',
       opts: [{
         chargeId,
         paymentDetails: validPayment,
@@ -108,8 +111,9 @@ describe('Standard card payment flow', () => {
       // 3. Charge will be fetched (GET)
       // 4. Service related to charge will be fetched (GET)
       // 5. Charge status will be updated (PUT)
-      // 6. Client will be redirected to /card_details/:chargeId (304)
+      // 6. Client will be redirected to /card_details/:chargeId (304) and global variable `chargeId` should be set
       cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      cy.window().its('chargeId').should('eq', `${chargeId}`)
     })
 
     it('Should enter and validate a correct card', () => {
@@ -169,8 +173,8 @@ describe('Standard card payment flow', () => {
       // 14. Get charge status before continuing - should be the same as authorised success (GET)
       // 15. Post to connector capture route (POST)
       // 16. Get charge status following post - should show capture success (GET)
-      cy.location('pathname').should('eq', `/`)
-      cy.location('search').should('eq', `?confirm`)
+      cy.location('pathname').should('eq', '/')
+      cy.location('search').should('eq', '?confirm')
     })
   })
 

--- a/test/integration/charge_billing_address_ft_tests.js
+++ b/test/integration/charge_billing_address_ft_tests.js
@@ -121,19 +121,19 @@ describe('chargeTests - billing address', function () {
 
   function minimumFormCardData (cardNumber) {
     return {
-      'returnUrl': RETURN_URL,
-      'cardUrl': connectorAuthUrl,
-      'chargeId': chargeId,
-      'cardNo': cardNumber,
-      'cvc': '234',
-      'expiryMonth': '11',
-      'expiryYear': '99',
-      'cardholderName': 'Jimi Hendrix',
-      'addressLine1': '32 Whip Ma Whop Ma Avenue',
-      'addressPostcode': 'Y1 1YN',
-      'addressCity': 'Willy wonka',
-      'email': 'willy@wonka.com',
-      'addressCountry': 'GB'
+      returnUrl: RETURN_URL,
+      cardUrl: connectorAuthUrl,
+      chargeId: chargeId,
+      cardNo: cardNumber,
+      cvc: '234',
+      expiryMonth: '11',
+      expiryYear: '99',
+      cardholderName: 'Jimi Hendrix',
+      addressLine1: '32 Whip Ma Whop Ma Avenue',
+      addressPostcode: 'Y1 1YN',
+      addressCity: 'Willy wonka',
+      email: 'willy@wonka.com',
+      addressCountry: 'GB'
     }
   }
 
@@ -183,7 +183,6 @@ describe('chargeTests - billing address', function () {
         .expect(200)
         .expect(function (res) {
           const $ = cheerio.load(res.text)
-          expect($('#govuk-script-charge')[0].children[0].data).to.contains(chargeId)
           expect($('#card-details #csrf').attr('value')).to.not.be.empty // eslint-disable-line
           expect($('.payment-summary #amount').text()).to.eql('£23.45')
           expect($('.payment-summary #payment-description').text()).to.contain('Payment Description')

--- a/test/integration/charge_ft_tests.js
+++ b/test/integration/charge_ft_tests.js
@@ -230,7 +230,6 @@ describe('chargeTests', function () {
             const $ = cheerio.load(res.text)
             expect($('#card-details #csrf').attr('value')).to.not.be.empty // eslint-disable-line
             expect($('#amount').text()).to.eql('£23.45')
-            expect($('#govuk-script-charge')[0].children[0].data).to.contains(chargeId)
             expect($('#payment-description').text()).to.contain('Payment Description')
             expect($('#govuk-script-analytics')[0].children[0].data).to.contains(`init('${gatewayAccount.analyticsId}', '${gatewayAccount.type}', '${gatewayAccount.paymentProvider}', '23.45', '')`)
             expect($('#card-details').attr('action')).to.eql(frontendCardDetailsPostPath)
@@ -552,7 +551,6 @@ describe('chargeTests', function () {
           .expect(200)
           .expect(function (res) {
             const $ = cheerio.load(res.text)
-            expect($('#govuk-script-charge')[0].children[0].data).to.contains(chargeId)
             expect($('#card-details').attr('action')).to.eql(frontendCardDetailsPostPath)
             expect($('#amount').text()).to.eql('£23.45')
             expect($('#card-no-error').text()).to.contains('Enter a valid card number')
@@ -585,7 +583,6 @@ describe('chargeTests', function () {
           .expect(200)
           .expect(function (res) {
             const $ = cheerio.load(res.text)
-            expect($('#govuk-script-charge')[0].children[0].data).to.contains(chargeId)
             expect($('#payment-description').text()).to.contain('Payment Description')
             expect($('#card-details').attr('action')).to.eql(frontendCardDetailsPostPath)
             expect($('#amount').text()).to.eql('£23.45')
@@ -637,7 +634,6 @@ describe('chargeTests', function () {
           .expect(200)
           .expect(function (res) {
             const $ = cheerio.load(res.text)
-            expect($('#govuk-script-charge')[0].children[0].data).to.contains(chargeId)
             expect($('#payment-description').text()).to.contain('Payment Description')
             expect($('#card-details').attr('action')).to.eql(frontendCardDetailsPostPath)
             expect($('#amount').text()).to.eql('£23.45')
@@ -666,7 +662,6 @@ describe('chargeTests', function () {
           .expect(200)
           .expect(function (res) {
             const $ = cheerio.load(res.text)
-            expect($('#govuk-script-charge')[0].children[0].data).to.contains(chargeId)
             expect($('#payment-description').text()).to.contain('Payment Description')
             expect($('#card-details').attr('action')).to.eql(frontendCardDetailsPostPath)
             expect($('#amount').text()).to.eql('£23.45')
@@ -798,7 +793,6 @@ describe('chargeTests', function () {
         .expect(200)
         .expect(function (res) {
           const $ = cheerio.load(res.text)
-          expect($('#govuk-script-charge')[0].children[0].data).to.contains(chargeId)
           expect($('#card-details #csrf').attr('value')).to.not.be.empty // eslint-disable-line
           expect($('#amount').text()).to.eql('£23.45')
           expect($('#payment-description').text()).to.contain('Payment Description')


### PR DESCRIPTION
## WHAT
- Externalise `address country` autocomplete & setting global charge ID scripts to helper.js, so we don't need to allow unsafe-line scripts as part of CSP
- Add exception for `openregisterLocationPicker` as linter complains it as 'not defined'. `openregisterLocationPicker` is defined in a script (`location-autocomplete.min.js`)  loaded separately

There is no visible impact (when running locally) on performance due to externalisation of these scripts

**Before the change**
<img width="464" alt="Before - desktop" src="https://user-images.githubusercontent.com/40598480/69622859-abd0f580-1039-11ea-8391-13df3904200b.png">

**and After the change**
<img width="447" alt="After - desktop" src="https://user-images.githubusercontent.com/40598480/69622872-b4293080-1039-11ea-98af-1292fea223ad.png">

