### PR TITLE
PP-5824 Remove inline styles from card payment page

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -473,7 +473,7 @@
     </div>
   </div>
   {% if worldpay3dsFlexDdcJwt %}
-    <iframe id="worldpay3dsFlexDdcIframe" src="/public/worldpay/worldpay-3ds-flex-ddc.html" style="display: none;"></iframe>
+    <iframe id="worldpay3dsFlexDdcIframe" src="/public/worldpay/worldpay-3ds-flex-ddc.html" class="govuk-!-display-none"></iframe>
   {% endif %}
   <div class="govuk-grid-column-one-third payment-summary-wrap">
     <aside class="payment-summary">


### PR DESCRIPTION
* in order to avoid 'unsafe-inline' for our style
content-security-policy we can't have inline styles in our markup
* trusted javascript can still manipulate inline styles
* favour class instead of inline style for display: none