### PR TITLE
PP-5873 turn CSP on with report only option

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -7,9 +7,45 @@ const environment = process.env.ENVIRONMENT
 
 const sentryCspReportUri = `${cspReportUri}&sentry_environment=${environment}`
 
+// Worldpay 3ds flex iframe
+const frameSource = ["'self'", 'https://secure-test.worldpay.com/']
+
+// Google analytics
+const imgSource = ["'self'", 'https://www.google-analytics.com/', 'http://www.google-analytics.com/']
+
+// Google analytics
+const scriptSource = ["'self'", 'https://www.google-analytics.com/', 'http://www.google-analytics.com/',
+  "'unsafe-inline'"]
+const styleSource = ["'self'"]
+
+// Google analytics, Apple pay, Google pay uses standard Payment Request API so requires no exceptions
+const connectSource = ["'self'", 'https://www.google-analytics.com/', 'http://www.google-analytics.com/',
+  'https://apple-pay-gateway.apple.com/', 'https://apple-pay-gateway-nc-pod1.apple.com/',
+  'https://apple-pay-gateway-nc-pod2.apple.com/', 'https://apple-pay-gateway-nc-pod3.apple.com/',
+  'https://apple-pay-gateway-nc-pod4.apple.com/', 'https://apple-pay-gateway-nc-pod5.apple.com/',
+  'https://apple-pay-gateway-pr-pod1.apple.com/', 'https://apple-pay-gateway-pr-pod2.apple.com/',
+  'https://apple-pay-gateway-pr-pod3.apple.com/', 'https://apple-pay-gateway-pr-pod4.apple.com/',
+  'https://apple-pay-gateway-pr-pod5.apple.com/', 'https://apple-pay-gateway-nc-pod1-dr.apple.com/',
+  'https://apple-pay-gateway-nc-pod2-dr.apple.com/', 'https://apple-pay-gateway-nc-pod3-dr.apple.com/',
+  'https://apple-pay-gateway-nc-pod4-dr.apple.com/', 'https://apple-pay-gateway-nc-pod5-dr.apple.com/',
+  'https://apple-pay-gateway-pr-pod1-dr.apple.com/', 'https://apple-pay-gateway-pr-pod2-dr.apple.com/',
+  'https://apple-pay-gateway-pr-pod3-dr.apple.com/', 'https://apple-pay-gateway-pr-pod4-dr.apple.com/',
+  'https://apple-pay-gateway-pr-pod5-dr.apple.com/',
+  'https://cn-applepay-gateway-sh-pod1.apple.com/', 'https://cn-applepay-gateway-sh-pod1-dr.apple.com/',
+  'https://cn-applepay-gateway-sh-pod2.apple.com/', 'https://cn-applepay-gateway-sh-pod2-dr.apple.com/',
+  'https://cn-applepay-gateway-sh-pod3.apple.com/', 'https://cn-applepay-gateway-sh-pod3-dr.apple.com/',
+  'https://cn-applepay-gateway-tj-pod1.apple.com/', 'https://cn-applepay-gateway-tj-pod1-dr.apple.com/',
+  'https://cn-applepay-gateway-tj-pod2.apple.com/', 'https://cn-applepay-gateway-tj-pod2-dr.apple.com/',
+  'https://cn-applepay-gateway-tj-pod3.apple.com/', 'https://cn-applepay-gateway-tj-pod3-dr.apple.com/']
+
 const csp = helmet.contentSecurityPolicy({
   directives: {
-    reportUri: sentryCspReportUri
+    reportUri: sentryCspReportUri,
+    frameSrc: frameSource,
+    imgSrc: imgSource,
+    styleSrc: styleSource,
+    scriptSrc: scriptSource,
+    connectSrc: connectSource
   },
   reportOnly: !enforceCsp
 })


### PR DESCRIPTION
## WHAT
- Turn CSP protection on with report only option
- add required exceptions
- 'unsafe-inline' from scriptSrc shall be removed once [PP-5872](https://payments-platform.atlassian.net/browse/PP-5872) completed

with @sfount


