### PR TITLE
PP-5885 CSP exceptions for non-external scripts

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -7,6 +7,10 @@ const environment = process.env.ENVIRONMENT
 
 const sentryCspReportUri = `${cspReportUri}&sentry_environment=${environment}`
 
+// Script responsible for setting 'js-enabled' class, extends GOV.UK frontend `layout` which we have no control over
+// and never changes
+const govUkFrontendLayoutJsEnabledScriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
+
 // Worldpay 3ds flex iframe
 const frameSource = ["'self'", 'https://secure-test.worldpay.com/']
 
@@ -15,7 +19,7 @@ const imgSource = ["'self'", 'https://www.google-analytics.com/', 'http://www.go
 
 // Google analytics
 const scriptSource = ["'self'", 'https://www.google-analytics.com/', 'http://www.google-analytics.com/',
-  (req, res) => `'nonce-${res.locals && res.locals.nonce}'`, "'unsafe-inline'"]
+  (req, res) => `'nonce-${res.locals && res.locals.nonce}'`, govUkFrontendLayoutJsEnabledScriptHash]
 const styleSource = ["'self'"]
 
 // Google analytics, Apple pay, Google pay uses standard Payment Request API so requires no exceptions


### PR DESCRIPTION
A number of the inline scripts on the card payment page are dynamically
templated in based on various params that can change per journey. This
makes them complex to safely hash.

Use a `nonce` generated per request to initially allow rejected
`unsafe-inline` policy.

---

As we extend the base design system `layout` template we inherit a
script to set a 'js-enabled' class on themain page.

We don't have control to add a nonce here and the script never changes
so allow this particular hash.