### PR TITLE
PP-5883 Add nonces to non external scripts

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -15,7 +15,7 @@ const imgSource = ["'self'", 'https://www.google-analytics.com/', 'http://www.go
 
 // Google analytics
 const scriptSource = ["'self'", 'https://www.google-analytics.com/', 'http://www.google-analytics.com/',
-  (req, res) => `'nonce-${res.locals.nonce}'`]
+  (req, res) => `'nonce-${res.locals && res.locals.nonce}'`, "'unsafe-inline'"]
 const styleSource = ["'self'"]
 
 // Google analytics, Apple pay, Google pay uses standard Payment Request API so requires no exceptions

--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -15,7 +15,7 @@ const imgSource = ["'self'", 'https://www.google-analytics.com/', 'http://www.go
 
 // Google analytics
 const scriptSource = ["'self'", 'https://www.google-analytics.com/', 'http://www.google-analytics.com/',
-  "'unsafe-inline'"]
+  (req, res) => `'nonce-${res.locals.nonce}'`]
 const styleSource = ["'self'"]
 
 // Google analytics, Apple pay, Google pay uses standard Payment Request API so requires no exceptions

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -10,7 +10,7 @@
 
   {% block bodyStart %}
     {% if allowApplePay or allowGooglePay %}
-      <script>
+      <script nonce="{{ nonce }}">
       {% if allowApplePay %}
           if (window.ApplePaySession && window.ApplePaySession.canMakePayments() && window.ApplePaySession.supportsVersion(4)) {
             document.body.classList.add('apple-pay-available')

--- a/app/views/includes/analytics.njk
+++ b/app/views/includes/analytics.njk
@@ -1,4 +1,4 @@
-<script>
+<script nonce="{{ nonce }}">
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function()
             { (i[r].q=i[r].q||[]).push(arguments)}
             ,i[r].l=1*new Date();a=s.createElement(o),

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -1,4 +1,4 @@
-<script id="govuk-script-analytics" type="text/javascript">
+<script id="govuk-script-analytics" nonce="{{ nonce }}" type="text/javascript">
   {% if translationStrings %}
   var i18n = {{ translationStrings | safe }}
   {% endif %}

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ if (process.env.DISABLE_APPMETRICS !== 'true') {
 
 // Node.js core dependencies
 const path = require('path')
+const crypto = require('crypto')
 
 // NPM dependencies
 const express = require('express')
@@ -66,6 +67,7 @@ function initialiseGlobalMiddleware (app) {
     res.locals.session = function () {
       return session.retrieve(req, req.chargeId)
     }
+    res.locals.nonce = crypto.randomBytes(16).toString('hex')
     next()
   })
 


### PR DESCRIPTION
A number of the inline scripts on the card payment page are dynamically
templated in based on various params that can change per journey. This
makes them complex to safely hash.

Use a `nonce` generated per request to remove the need for `unsafe-inline`.

Older browsers can't gaurantee consistent behaviour with the nonce CSP
rule (introduced in CSP 2). Adding 'unsafe-inline' will be rejected by
browsers that support `nonce` and executed by older browsers that do
not.

---

Completes the `nonce` implementation from https://github.com/alphagov/pay-frontend/pull/1199

