### PR TITLE
[PP-5887] allow unsafe-eval scripts when configured

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -4,7 +4,7 @@ const sendCspHeader = process.env.CSP_SEND_HEADER === 'true'
 const enforceCsp = process.env.CSP_ENFORCE === 'true'
 const cspReportUri = process.env.CSP_REPORT_URI
 const environment = process.env.ENVIRONMENT
-const zapTestHash = process.env.CSP_ZAP_TEST_HASH
+const allowUnsafeEvalScripts = process.env.CSP_ALLOW_UNSAFE_EVAL_SCRIPTS === 'true'
 
 const sentryCspReportUri = `${cspReportUri}&sentry_environment=${environment}`
 
@@ -25,8 +25,8 @@ const scriptSource = ["'self'", 'https://www.google-analytics.com/',
   (req, res) => `'nonce-${res.locals && res.locals.nonce}'`, govUkFrontendLayoutJsEnabledScriptHash]
 
 // Sript that is being used during zap test: https://github.com/alphagov/pay-endtoend/blob/d685d5bc38d639e8adef629673e5577cb923408e/src/test/resources/uk/gov/pay/pen/tests/frontend.feature#L23
-if (zapTestHash) {
-  scriptSource.push(zapTestHash)
+if (allowUnsafeEvalScripts) {
+  scriptSource.push("'unsafe-eval'")
 }
 
 // Google analytics, Apple pay, Google pay uses standard Payment Request API so requires no exceptions

--- a/test/middleware/csp_test.js
+++ b/test/middleware/csp_test.js
@@ -51,15 +51,15 @@ describe('CSP middleware', () => {
     sinon.assert.calledWith(response.setHeader, 'Content-Security-Policy')
   })
 
-  it('should add zap hash to Content-Security-Policy header when included in configuration', () => {
+  it('should add `unsafe-eval` to Content-Security-Policy header when included in configuration', () => {
     process.env.CSP_SEND_HEADER = 'true'
-    process.env.CSP_ZAP_TEST_HASH = "'sha256-xUXfQvaQIcsBFXwODJDnPGU3R2JQw59eNsZ6XDIotxU='"
+    process.env.CSP_ALLOW_UNSAFE_EVAL_SCRIPTS = 'true'
     const csp = requireHelper('../../app/middleware/csp')
 
     const next = sinon.spy()
     const response = { setHeader: sinon.spy() }
     csp(mockRequest, response, next)
 
-    sinon.assert.calledWith(response.setHeader, 'Content-Security-Policy', sinon.match(/'sha256-xUXfQvaQIcsBFXwODJDnPGU3R2JQw59eNsZ6XDIotxU='/g))
+    sinon.assert.calledWith(response.setHeader, 'Content-Security-Policy', sinon.match(/'unsafe-eval'/g))
   })
 })


### PR DESCRIPTION
Why?
When enabling csp in enforce mode for end2end tests, the zap tests are failing
because they try to inject the script into the frontend page (which csp is preventing
from doing).
It seems we're not allowed to simply disable javascript while running selenium tests,
so in order to workaround the issue with injecting and evaluating the script we're going to allow it,
but only when specified in environment variable (it will be set only for end to end tests)

Changes:
* replace hash (which works only for inline scripts) with `unsafe-eval`
* update test