### PR TITLE
PP-5884 add csp restrictions to worldpay flex ddc initial iframe

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -17,20 +17,21 @@ const CSP_NONE = ["'none'"]
 const CSP_SELF = ["'self'"]
 
 // Worldpay 3ds flex iframe - frame and child must be kept in sync
-const frameAndChildSource = ["'self'", 'https://secure-test.worldpay.com/', 'https://centinelapi.cardinalcommerce.com/']
+const frameAndChildSourceCardDetails = ["'self'", 'https://secure-test.worldpay.com/', 'https://centinelapi.cardinalcommerce.com/']
 
-const imgSource = ["'self'", 'https://www.google-analytics.com/']
+const imgSourceCardDetails = ["'self'", 'https://www.google-analytics.com/']
 
-const scriptSource = ["'self'", 'https://www.google-analytics.com/',
+const scriptSourceCardDetails = ["'self'", 'https://www.google-analytics.com/',
   (req, res) => `'nonce-${res.locals && res.locals.nonce}'`, govUkFrontendLayoutJsEnabledScriptHash]
 
+const formActionWP3DS = ["'self'", 'https://centinelapi.cardinalcommerce.com/V1/Cruise/Collect', 'https://secure-test.worldpay.com/shopper/3ds']
 // Sript that is being used during zap test: https://github.com/alphagov/pay-endtoend/blob/d685d5bc38d639e8adef629673e5577cb923408e/src/test/resources/uk/gov/pay/pen/tests/frontend.feature#L23
 if (allowUnsafeEvalScripts) {
-  scriptSource.push("'unsafe-eval'")
+  scriptSourceCardDetails.push("'unsafe-eval'")
 }
 
 // Google analytics, Apple pay, Google pay uses standard Payment Request API so requires no exceptions
-const connectSource = ["'self'", 'https://www.google-analytics.com/',
+const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com/',
   'https://apple-pay-gateway.apple.com/', 'https://apple-pay-gateway-nc-pod1.apple.com/',
   'https://apple-pay-gateway-nc-pod2.apple.com/', 'https://apple-pay-gateway-nc-pod3.apple.com/',
   'https://apple-pay-gateway-nc-pod4.apple.com/', 'https://apple-pay-gateway-nc-pod5.apple.com/',
@@ -49,14 +50,16 @@ const connectSource = ["'self'", 'https://www.google-analytics.com/',
   'https://cn-applepay-gateway-tj-pod2.apple.com/', 'https://cn-applepay-gateway-tj-pod2-dr.apple.com/',
   'https://cn-applepay-gateway-tj-pod3.apple.com/', 'https://cn-applepay-gateway-tj-pod3-dr.apple.com/']
 
-const csp = helmet.contentSecurityPolicy({
+const skipSendingCspHeader = (req, res, next) => { next() }
+
+const cardDetailsCSP = helmet.contentSecurityPolicy({
   directives: {
     reportUri: sentryCspReportUri,
-    frameSrc: frameAndChildSource,
-    childSrc: frameAndChildSource,
-    imgSrc: imgSource,
-    scriptSrc: scriptSource,
-    connectSrc: connectSource,
+    frameSrc: frameAndChildSourceCardDetails,
+    childSrc: frameAndChildSourceCardDetails,
+    imgSrc: imgSourceCardDetails,
+    scriptSrc: scriptSourceCardDetails,
+    connectSrc: connectSourceCardDetails,
     styleSrc: CSP_SELF,
     formAction: CSP_SELF,
     fontSrc: CSP_SELF,
@@ -71,6 +74,29 @@ const csp = helmet.contentSecurityPolicy({
   reportOnly: !enforceCsp
 })
 
-const skipSendingCspHeader = (req, res, next) => { next() }
+const worldpayIframeCSP = helmet.contentSecurityPolicy({
+  directives: {
+    reportUri: sentryCspReportUri,
+    frameSrc: CSP_NONE,
+    childSrc: CSP_NONE,
+    imgSrc: CSP_SELF,
+    scriptSrc: CSP_SELF,
+    connectSrc: CSP_SELF,
+    styleSrc: CSP_SELF,
+    formAction: formActionWP3DS,
+    fontSrc: CSP_SELF,
+    frameAncestors: CSP_SELF,
+    manifestSrc: CSP_NONE,
+    mediaSrc: CSP_NONE,
+    objectSrc: CSP_NONE,
+    prefetchSrc: CSP_SELF,
+    baseUri: CSP_NONE,
+    blockAllMixedContent: true
+  },
+  reportOnly: !enforceCsp
+})
 
-module.exports = sendCspHeader ? csp : skipSendingCspHeader
+module.exports = {
+  cardDetails: sendCspHeader ? cardDetailsCSP : skipSendingCspHeader,
+  worldpayIframe: sendCspHeader ? worldpayIframeCSP : skipSendingCspHeader
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -70,7 +70,7 @@ exports.bind = function (app) {
     stateEnforcer
   ]
 
-  app.get(card.new.path, csp, middlewareStack, charge.new)
+  app.get(card.new.path, csp.cardDetails, middlewareStack, charge.new)
   app.get(card.authWaiting.path, middlewareStack, charge.authWaiting)
   app.get(card.captureWaiting.path, middlewareStack, charge.captureWaiting)
   app.post(card.create.path, middlewareStack, charge.create)

--- a/server.js
+++ b/server.js
@@ -27,6 +27,7 @@ const session = require('./app/utils/session')
 const i18nConfig = require('./config/i18n')
 const i18nPayTranslation = require('./config/pay-translation')
 const Sentry = require('./app/utils/sentry.js').initialiseSentry()
+const csp = require('./app/middleware/csp')
 
 // Global constants
 const { NODE_ENV, PORT, ANALYTICS_TRACKING_ID, GOOGLE_PAY_MERCHANT_ID, APPLE_PAY_MERCHANT_ID_CERTIFICATE } = process.env
@@ -125,6 +126,7 @@ function initialiseTemplateEngine (app) {
 }
 
 function initialisePublic (app) {
+  app.use('/public/worldpay', csp.worldpayIframe, express.static(path.join(__dirname, '/public/worldpay/'), publicCaching))
   app.use('/public', express.static(path.join(__dirname, '/public'), publicCaching))
   app.use('/public', express.static(path.join(__dirname, '/app/data'), publicCaching))
   app.use('/public', express.static(path.join(__dirname, '/govuk_modules/govuk-country-and-territory-autocomplete'), publicCaching))

--- a/test/middleware/csp_test.js
+++ b/test/middleware/csp_test.js
@@ -21,7 +21,7 @@ describe('CSP middleware', () => {
 
     const next = sinon.spy()
     const response = { setHeader: sinon.spy() }
-    csp(mockRequest, response, next)
+    csp.cardDetails(mockRequest, response, next)
 
     expect(next.called).to.be.true
     expect(response.setHeader.called).to.be.false
@@ -34,7 +34,7 @@ describe('CSP middleware', () => {
 
     const next = sinon.spy()
     const response = { setHeader: sinon.spy() }
-    csp(mockRequest, response, next)
+    csp.cardDetails(mockRequest, response, next)
 
     sinon.assert.calledWith(response.setHeader, 'Content-Security-Policy-Report-Only')
   })
@@ -46,7 +46,7 @@ describe('CSP middleware', () => {
 
     const next = sinon.spy()
     const response = { setHeader: sinon.spy() }
-    csp(mockRequest, response, next)
+    csp.cardDetails(mockRequest, response, next)
 
     sinon.assert.calledWith(response.setHeader, 'Content-Security-Policy')
   })
@@ -58,7 +58,7 @@ describe('CSP middleware', () => {
 
     const next = sinon.spy()
     const response = { setHeader: sinon.spy() }
-    csp(mockRequest, response, next)
+    csp.cardDetails(mockRequest, response, next)
 
     sinon.assert.calledWith(response.setHeader, 'Content-Security-Policy', sinon.match(/'unsafe-eval'/g))
   })


### PR DESCRIPTION
## WHAT
- add csp headers to worldpay 3ds flex ddc frame
- refactor csp.js to have separate methods for different csp settings


