### PR TITLE
PP-5762 Add common keys to logs

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -31,7 +31,7 @@ const supportedNetworksFormattedByProvider = require('../assets/javascripts/brow
 const worlpay3dsFlexService = require('../services/worldpay_3ds_flex_service')
 
 // Constants
-const clsXrayConfig = require('../../config/xray-cls')
+const { NAMESPACE_NAME, XRAY_SEGMENT_KEY_NAME } = require('../../config/cls')
 const { views, preserveProperties } = require('../../config/charge_controller')
 const { CORRELATION_HEADER } = require('../../config/correlation_header')
 const { createChargeIdSessionKey } = require('../utils/session')
@@ -198,8 +198,8 @@ module.exports = {
     }
   },
   checkCard: (req, res) => {
-    const namespace = getNamespace(clsXrayConfig.nameSpaceName)
-    const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
+    const namespace = getNamespace(NAMESPACE_NAME)
+    const clsSegment = namespace.get(XRAY_SEGMENT_KEY_NAME)
     AWSXRay.captureAsyncFunc('Card_checkCard', function (subSegment) {
       Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER])
         .checkCard(normalise.creditCard(req.body.cardNo), req.chargeData.language, subSegment)
@@ -215,7 +215,7 @@ module.exports = {
           },
           error => {
             subSegment.close(error.message)
-            return res.json({ 'accepted': false, message: error.message })
+            return res.json({ accepted: false, message: error.message })
           }
         )
     }, clsSegment)

--- a/app/controllers/web-payments/payment-auth-request-controller.js
+++ b/app/controllers/web-payments/payment-auth-request-controller.js
@@ -9,16 +9,14 @@ const normaliseApplePayPayload = require('./apple-pay/normalise-apple-pay-payloa
 const normaliseGooglePayPayload = require('./google-pay/normalise-google-pay-payload')
 const { CORRELATION_HEADER } = require('../../../config/correlation_header')
 const { setSessionVariable } = require('../../utils/cookies')
-
-// constants
-const clsXrayConfig = require('../../../config/xray-cls')
+const { NAMESPACE_NAME, XRAY_SEGMENT_KEY_NAME } = require('../../../config/cls')
 
 module.exports = (req, res) => {
   const { chargeId, params, body } = req
   const { provider } = params
   const payload = provider === 'apple' ? normaliseApplePayPayload(body) : normaliseGooglePayPayload(body)
-  const namespace = getNamespace(clsXrayConfig.nameSpaceName)
-  const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
+  const namespace = getNamespace(NAMESPACE_NAME)
+  const clsSegment = namespace.get(XRAY_SEGMENT_KEY_NAME)
   return AWSXRay.captureAsyncFunc('Auth_charge_wallet', subsegment => {
     return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet({ chargeId, provider, payload })
       .then(data => {

--- a/app/middleware/cls.js
+++ b/app/middleware/cls.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { createNamespace, getNamespace } = require('continuation-local-storage')
+const { NAMESPACE_NAME } = require('../../config/cls')
+createNamespace(NAMESPACE_NAME)
+
+module.exports = (req, res, next) => {
+  const namespace = getNamespace(NAMESPACE_NAME)
+  namespace.bindEmitter(req)
+  namespace.bindEmitter(res)
+  namespace.run(() => {
+    next()
+  })
+}

--- a/app/middleware/correlation_header.js
+++ b/app/middleware/correlation_header.js
@@ -1,0 +1,11 @@
+'use strict'
+const { getNamespace } = require('continuation-local-storage')
+const { CORRELATION_ID } = require('@govuk-pay/pay-js-commons').logging.keys
+const { CORRELATION_HEADER } = require('../../config/correlation_header')
+const { NAMESPACE_NAME } = require('../../config/cls')
+
+module.exports = (req, res, next) => {
+  req.correlationId = req.headers[CORRELATION_HEADER] || ''
+  getNamespace(NAMESPACE_NAME).set(CORRELATION_ID, req.correlationId)
+  next()
+}

--- a/app/middleware/retrieve_charge.js
+++ b/app/middleware/retrieve_charge.js
@@ -3,6 +3,7 @@
 // NPM dependencies
 const AWSXRay = require('aws-xray-sdk')
 const { getNamespace } = require('continuation-local-storage')
+const { PAYMENT_EXTERNAL_ID } = require('@govuk-pay/pay-js-commons').logging.keys
 
 // Local dependencies
 const logging = require('../utils/logging')
@@ -11,14 +12,14 @@ const Charge = require('../models/charge')
 const chargeParam = require('../services/charge_param_retriever')
 const { CORRELATION_HEADER } = require('../../config/correlation_header')
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
-
-// Constants
-const clsXrayConfig = require('../../config/xray-cls')
+const { NAMESPACE_NAME, XRAY_SEGMENT_KEY_NAME } = require('../../config/cls')
 
 module.exports = (req, res, next) => {
   const chargeId = chargeParam.retrieve(req)
-  const namespace = getNamespace(clsXrayConfig.nameSpaceName)
-  const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
+  const namespace = getNamespace(NAMESPACE_NAME)
+  namespace.set(PAYMENT_EXTERNAL_ID, chargeId)
+
+  const clsSegment = namespace.get(XRAY_SEGMENT_KEY_NAME)
   if (!chargeId) {
     responseRouter.response(req, res, 'UNAUTHORISED', withAnalyticsError())
   } else {

--- a/app/middleware/x_ray.js
+++ b/app/middleware/x_ray.js
@@ -4,10 +4,10 @@
 const { getNamespace } = require('continuation-local-storage')
 
 // Local dependencies
-const clsXrayConfig = require('../../config/xray-cls')
+const { NAMESPACE_NAME, XRAY_SEGMENT_KEY_NAME } = require('../../config/cls')
 
 module.exports = (req, res, next) => {
-  const namespace = getNamespace(clsXrayConfig.nameSpaceName)
-  namespace.set(clsXrayConfig.segmentKeyName, req.segment)
+  const namespace = getNamespace(NAMESPACE_NAME)
+  namespace.set(XRAY_SEGMENT_KEY_NAME, req.segment)
   next()
 }

--- a/app/models/card.js
+++ b/app/models/card.js
@@ -10,9 +10,7 @@ const i18n = require('i18n')
 // Local dependencies
 const logger = require('../utils/logger')(__filename)
 const cardIdClient = require('../services/clients/cardid_client')
-
-// Constants
-const clsXrayConfig = require('../../config/xray-cls')
+const { NAMESPACE_NAME, XRAY_SEGMENT_KEY_NAME } = require('../../config/cls')
 const i18nConfig = require('../../config/i18n')
 
 i18n.configure(i18nConfig)
@@ -26,8 +24,8 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
 
     // Use a subSegment if passed, otherwise get our main segment
     if (!subSegment) {
-      const namespace = getNamespace(clsXrayConfig.nameSpaceName)
-      subSegment = namespace.get(clsXrayConfig.segmentKeyName)
+      const namespace = getNamespace(NAMESPACE_NAME)
+      subSegment = namespace.get(XRAY_SEGMENT_KEY_NAME)
     }
 
     AWSXRay.captureAsyncFunc('cardIdClient_post', function (postSubsegment) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,7 +2,6 @@
 
 // NPM dependencies
 const AWSXRay = require('aws-xray-sdk')
-const { getNamespace, createNamespace } = require('continuation-local-storage')
 
 // Local dependencies
 const logger = require('./utils/logger')(__filename)
@@ -27,9 +26,6 @@ const resolveService = require('./middleware/resolve_service.js')
 const resolveLanguage = require('./middleware/resolve_language.js')
 const xraySegmentCls = require('./middleware/x_ray')
 
-// Constants
-const clsXrayConfig = require('../config/xray-cls')
-
 // Import AB test when we need to use it
 // const abTest = require('./utils/ab_test.js')
 // const AB_TEST_THRESHOLD = process.env.AB_TEST_THRESHOLD
@@ -42,17 +38,6 @@ exports.bind = function (app) {
   AWSXRay.middleware.setSamplingRules('aws-xray.rules')
   AWSXRay.config([AWSXRay.plugins.ECSPlugin])
   app.use(AWSXRay.express.openSegment('pay_frontend'))
-
-  createNamespace(clsXrayConfig.nameSpaceName)
-
-  app.use((req, res, next) => {
-    const namespace = getNamespace(clsXrayConfig.nameSpaceName)
-    namespace.bindEmitter(req)
-    namespace.bindEmitter(res)
-    namespace.run(() => {
-      next()
-    })
-  })
 
   app.get('/healthcheck', healthcheck)
 

--- a/app/services/clients/base_client/base_client.js
+++ b/app/services/clients/base_client/base_client.js
@@ -11,6 +11,7 @@ const AWSXRay = require('aws-xray-sdk')
 // Local dependencies
 const CORRELATION_HEADER_NAME = require('../../../../config/correlation_header').CORRELATION_HEADER
 const { addProxy } = require('../../../utils/add_proxy')
+const { NAMESPACE_NAME, XRAY_SEGMENT_KEY_NAME } = require('../../../../config/cls')
 
 const agentOptions = {
   keepAlive: true,
@@ -18,7 +19,6 @@ const agentOptions = {
 }
 
 // Constants
-const clsXrayConfig = require('../../../../config/xray-cls')
 const RETRIABLE_ERRORS = ['ECONNRESET']
 
 function retryOnEconnreset (err) {
@@ -37,12 +37,12 @@ const client = request
   })
 
 const getHeaders = function getHeaders (args, segmentData, url) {
-  let headers = {}
+  const headers = {}
   headers['Content-Type'] = 'application/json'
   headers[CORRELATION_HEADER_NAME] = args.correlationId || ''
   if (url) {
     const port = (urlParse(url).port) ? ':' + urlParse(url).port : ''
-    headers['host'] = urlParse(url).hostname + port
+    headers.host = urlParse(url).hostname + port
   }
 
   if (segmentData.clsSegment) {
@@ -71,8 +71,8 @@ const getHeaders = function getHeaders (args, segmentData, url) {
  * @private
  */
 const _request = function request (methodName, url, args, callback, subSegment) {
-  const namespace = getNamespace(clsXrayConfig.nameSpaceName)
-  const clsSegment = namespace ? namespace.get(clsXrayConfig.segmentKeyName) : null
+  const namespace = getNamespace(NAMESPACE_NAME)
+  const clsSegment = namespace ? namespace.get(XRAY_SEGMENT_KEY_NAME) : null
 
   const proxiedUrl = addProxy(url)
   const optionalPort = proxiedUrl.port ? ':' + proxiedUrl.port : ''

--- a/app/utils/logger.js
+++ b/app/utils/logger.js
@@ -2,12 +2,28 @@ const { createLogger, format, transports } = require('winston')
 const { json, splat, prettyPrint } = format
 const { govUkPayLoggingFormat } = require('@govuk-pay/pay-js-commons').logging
 const { addSentryToErrorLevel } = require('./sentry.js')
+const { getNamespace } = require('continuation-local-storage')
+const {
+  CORRELATION_ID,
+  PAYMENT_EXTERNAL_ID
+} = require('@govuk-pay/pay-js-commons').logging.keys
+const { NAMESPACE_NAME } = require('../../config/cls')
+
+const addSessionData = format((info) => {
+  const session = getNamespace(NAMESPACE_NAME)
+  if (session) {
+    info[CORRELATION_ID] = session.get(CORRELATION_ID)
+    info[PAYMENT_EXTERNAL_ID] = session.get(PAYMENT_EXTERNAL_ID)
+  }
+  return info
+})
 
 const logger = createLogger({
   format: format.combine(
     splat(),
     prettyPrint(),
     govUkPayLoggingFormat({ container: 'frontend', environment: process.env.ENVIRONMENT }),
+    addSessionData(),
     json()
   ),
   transports: [

--- a/config/cls.js
+++ b/config/cls.js
@@ -1,0 +1,4 @@
+module.exports = {
+  NAMESPACE_NAME: 'frontend',
+  XRAY_SEGMENT_KEY_NAME: 'xraysegment'
+}

--- a/config/xray-cls.js
+++ b/config/xray-cls.js
@@ -1,4 +1,0 @@
-module.exports = {
-  nameSpaceName: 'frontend',
-  segmentKeyName: 'xraysegment'
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -868,9 +868,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.17.0.tgz",
-      "integrity": "sha512-NzMT66E7sPiuD8t34x6azTUlAlDNh8Icv1QCOI54ffF7nDXpNBMSGEieFij0QxC9qiRk0YdsqaNve+ewc+nzlA==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.18.1.tgz",
+      "integrity": "sha512-MPFEhXczCmg1TRM2Gkt5j2n62kWDkugVLRVxhNr0vhdeqjCR8iZRD4L+K35GjOEJioj9PlKbmZy+XIMTnjK/mQ==",
       "requires": {
         "lodash": "4.17.15",
         "moment-timezone": "0.5.27",
@@ -2403,7 +2403,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -2838,7 +2838,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2852,7 +2852,7 @@
     },
     "browserify-cache-api": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cache-api/-/browserify-cache-api-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-cache-api/-/browserify-cache-api-3.0.1.tgz",
       "integrity": "sha1-liR+hT8Gj9bg1FzHPwuyzZd47wI=",
       "dev": true,
       "requires": {
@@ -2894,7 +2894,7 @@
     },
     "browserify-incremental": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/browserify-incremental/-/browserify-incremental-3.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-incremental/-/browserify-incremental-3.1.1.tgz",
       "integrity": "sha1-BxPLdYckemMqnwjPG9FpuHi2Koo=",
       "dev": true,
       "requires": {
@@ -2924,7 +2924,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -3163,7 +3163,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -3184,7 +3184,7 @@
     },
     "caporal": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/caporal/-/caporal-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/caporal/-/caporal-1.1.0.tgz",
       "integrity": "sha512-R5qo2QGoqBM6RvzHonGhUuEJSeqEa4lD1r+cPUEY2+YsXhpQVTS2TvScfIbi6ydFdhzFCNeNUB1v0YrRBvsbdg==",
       "dev": true,
       "requires": {
@@ -4378,7 +4378,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -4391,7 +4391,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -4458,7 +4458,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -4833,7 +4833,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -5227,7 +5227,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -5388,7 +5388,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -5683,7 +5683,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -6308,7 +6308,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
@@ -6673,7 +6673,7 @@
         },
         "mkdirp": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
@@ -6932,7 +6932,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
@@ -8210,7 +8210,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -8319,7 +8319,7 @@
         },
         "grunt-cli": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
@@ -8376,7 +8376,7 @@
     },
     "grunt-cli": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.3.2.tgz",
+      "resolved": "http://registry.npmjs.org/grunt-cli/-/grunt-cli-1.3.2.tgz",
       "integrity": "sha512-8OHDiZZkcptxVXtMfDxJvmN7MVJNE8L/yIcPb4HB7TlyFD1kDvjHrb62uhySsU14wJx9ORMnTuhRMQ40lH/orQ==",
       "dev": true,
       "requires": {
@@ -8876,7 +8876,7 @@
     },
     "htmlescape": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
@@ -9065,7 +9065,7 @@
     },
     "i18n": {
       "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.8.4.tgz",
+      "resolved": "http://registry.npmjs.org/i18n/-/i18n-0.8.4.tgz",
       "integrity": "sha512-PvMcG+yqYWXrwgdmCpL+APCGa8lRY0tdlo2cXp9UeR3u4h1bJGqFsgybfmG/MqtL1iDmdaPPPLJebXGrZ1XoMQ==",
       "requires": {
         "debug": "*",
@@ -9639,7 +9639,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -11165,7 +11165,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -11370,7 +11370,7 @@
     },
     "make-plural": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/make-plural/-/make-plural-6.0.1.tgz",
       "integrity": "sha512-h0uBNi4tpDkiWUyYKrJNj8Kif6q3Ba5zp/8jnfPy3pQE+4XcTj6h3eZM5SYVUyDNX9Zk69Isr/dx0I+78aJUaQ=="
     },
     "map-cache": {
@@ -11458,7 +11458,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memoizee": {
@@ -11483,7 +11483,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -11551,7 +11551,7 @@
       "dependencies": {
         "make-plural": {
           "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
           "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
           "requires": {
             "minimist": "^1.2.0"
@@ -11726,7 +11726,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -12223,7 +12223,7 @@
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "dev": true,
       "optional": true
@@ -12269,7 +12269,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
@@ -12409,7 +12409,7 @@
         },
         "tar": {
           "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
           "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
           "dev": true,
           "requires": {
@@ -12794,7 +12794,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -12862,7 +12862,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
@@ -13128,7 +13128,7 @@
     },
     "ora": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
@@ -13173,7 +13173,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -13187,7 +13187,7 @@
     },
     "os-name": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
       "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
       "dev": true,
       "requires": {
@@ -13203,7 +13203,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -13464,7 +13464,7 @@
         },
         "tar": {
           "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/tar/-/tar-4.4.0.tgz",
           "integrity": "sha512-gJlTiiErwo96K904FnoYWl+5+FBgS+FimU6GMh66XLdLa55al8+d4jeDfPoGwSNHdtWI5FJP6xurmVqhBuGJpQ==",
           "dev": true,
           "requires": {
@@ -13641,7 +13641,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -14475,7 +14475,7 @@
     },
     "regexpp": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
@@ -14635,7 +14635,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -14827,7 +14827,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -15015,7 +15015,7 @@
         },
         "eslint": {
           "version": "2.13.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
           "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
           "dev": true,
           "requires": {
@@ -15439,7 +15439,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -15472,7 +15472,7 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
@@ -15512,7 +15512,7 @@
     },
     "shelljs": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
       "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
       "dev": true
     },
@@ -16922,7 +16922,7 @@
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dev": true,
       "requires": {
@@ -17163,7 +17163,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -17434,7 +17434,7 @@
     },
     "tabtab": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tabtab/-/tabtab-2.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/tabtab/-/tabtab-2.2.2.tgz",
       "integrity": "sha1-egR/FDsBC0y9MfhX6ClhUSy/ThQ=",
       "dev": true,
       "requires": {
@@ -17591,7 +17591,7 @@
       "dependencies": {
         "bl": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
           "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
           "dev": true,
           "optional": true,
@@ -17862,7 +17862,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -18726,7 +18726,7 @@
     },
     "whatwg-fetch": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "2.17.0",
+    "@govuk-pay/pay-js-commons": "2.18.1",
     "@sentry/node": "5.9.0",
     "appmetrics": "5.0.5",
     "appmetrics-statsd": "3.0.0",

--- a/server.js
+++ b/server.js
@@ -26,8 +26,10 @@ const noCache = require('./app/utils/no_cache')
 const session = require('./app/utils/session')
 const i18nConfig = require('./config/i18n')
 const i18nPayTranslation = require('./config/pay-translation')
-const Sentry = require('./app/utils/sentry.js').initialiseSentry()
+const Sentry = require('./app/utils/sentry').initialiseSentry()
 const csp = require('./app/middleware/csp')
+const cls = require('./app/middleware/cls')
+const correlationHeader = require('./app/middleware/correlation_header')
 
 // Global constants
 const { NODE_ENV, PORT, ANALYTICS_TRACKING_ID, GOOGLE_PAY_MERCHANT_ID, APPLE_PAY_MERCHANT_ID_CERTIFICATE } = process.env
@@ -83,6 +85,9 @@ function initialiseGlobalMiddleware (app) {
   app.use(compression())
 
   app.disable('x-powered-by')
+
+  app.use(cls)
+  app.use(correlationHeader)
 }
 
 function initialisei18n (app) {

--- a/test/middleware/retrieve_charge_test.js
+++ b/test/middleware/retrieve_charge_test.js
@@ -20,7 +20,8 @@ const retrieveCharge = proxyquire(path.join(__dirname, '/../../app/middleware/re
       return {
         get: () => {
           return new AWSXRay.Segment('stub-segment')
-        }
+        },
+        set: () => {}
       }
     }
   }


### PR DESCRIPTION
Use continuation-local-storage to store values for keys that should be included in log lines when they are available in the middleware. Then in the logger, retrieve these values and add them to the logs.

We are using the continuation-local-storage package rather than cls-hooked as there have been some issues with async_hooks since our recent upgrade to node 12.

Use the namespace already used for storing the AWS xray segment to store the logging key values, and move the middleware that creates this namespace and binds it to the callback chain into its own file.

Add the following keys for now:
x_request_id (the request correlation id)
payment_external_id