### PR TITLE
PP-5885 Add unsafe-inline to script-src directive

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -21,7 +21,7 @@ const frameAndChildSourceCardDetails = ["'self'", 'https://secure-test.worldpay.
 
 const imgSourceCardDetails = ["'self'", 'https://www.google-analytics.com/']
 
-const scriptSourceCardDetails = ["'self'", 'https://www.google-analytics.com/',
+const scriptSourceCardDetails = ["'self'",  "'unsafe-inline'", 'https://www.google-analytics.com/',
   (req, res) => `'nonce-${res.locals && res.locals.nonce}'`, govUkFrontendLayoutJsEnabledScriptHash]
 
 const formActionWP3DS = ["'self'", 'https://centinelapi.cardinalcommerce.com/V1/Cruise/Collect', 'https://secure-test.worldpay.com/shopper/3ds']


### PR DESCRIPTION
## WHAT
- Added `unsafe-inline`source to script-src directive to allow execution of inline scripts. This is required for browsers that only support CSP level 1 as nonce/hash is not supported in these browsers. Browsers that support CSP level 2, ignores `unsafe-inline` if nonce/hash is available.