### PR TITLE
PP-5903 Allow eval of style for mobile browsers

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -62,7 +62,7 @@ const cardDetailsCSP = helmet.contentSecurityPolicy({
     imgSrc: imgSourceCardDetails,
     scriptSrc: scriptSourceCardDetails,
     connectSrc: connectSourceCardDetails,
-    styleSrc: CSP_SELF,
+    styleSrc: [...CSP_SELF, "'unsafe-eval'"],
     formAction: CSP_SELF,
     fontSrc: CSP_SELF,
     frameAncestors: CSP_SELF,


### PR DESCRIPTION
The country autocomplete injects styles by replacing an elements `cssText` attribute. 

This evaluation is blocked on mobile browsers but allowed on modern Desktop. 

As we will be restricting the scripts that can execute at page load, allow this eval on mobile.


