### PR TITLE
PP-5901 remove trailing slashes from hosts

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -17,12 +17,12 @@ const CSP_NONE = ["'none'"]
 const CSP_SELF = ["'self'"]
 
 // Worldpay 3ds flex iframe - frame and child must be kept in sync
-const frameAndChildSourceCardDetails = ["'self'", 'https://secure-test.worldpay.com/',
-  'https://centinelapi.cardinalcommerce.com/']
+const frameAndChildSourceCardDetails = ["'self'", 'https://secure-test.worldpay.com',
+  'https://centinelapi.cardinalcommerce.com']
 
-const imgSourceCardDetails = ["'self'", 'https://www.google-analytics.com/', 'https://www.gstatic.com/']
+const imgSourceCardDetails = ["'self'", 'https://www.google-analytics.com', 'https://www.gstatic.com']
 
-const scriptSourceCardDetails = ["'self'", "'unsafe-inline'", 'https://www.google-analytics.com/',
+const scriptSourceCardDetails = ["'self'", "'unsafe-inline'", 'https://www.google-analytics.com',
   (req, res) => `'nonce-${res.locals && res.locals.nonce}'`, govUkFrontendLayoutJsEnabledScriptHash]
 
 const formActionWP3DS = ["'self'", 'https://centinelapi.cardinalcommerce.com/V1/Cruise/Collect',
@@ -33,24 +33,24 @@ if (allowUnsafeEvalScripts) {
 }
 
 // Google analytics, Apple pay, Google pay uses standard Payment Request API so requires no exceptions
-const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com/',
-  'https://apple-pay-gateway.apple.com/', 'https://apple-pay-gateway-nc-pod1.apple.com/',
-  'https://apple-pay-gateway-nc-pod2.apple.com/', 'https://apple-pay-gateway-nc-pod3.apple.com/',
-  'https://apple-pay-gateway-nc-pod4.apple.com/', 'https://apple-pay-gateway-nc-pod5.apple.com/',
-  'https://apple-pay-gateway-pr-pod1.apple.com/', 'https://apple-pay-gateway-pr-pod2.apple.com/',
-  'https://apple-pay-gateway-pr-pod3.apple.com/', 'https://apple-pay-gateway-pr-pod4.apple.com/',
-  'https://apple-pay-gateway-pr-pod5.apple.com/', 'https://apple-pay-gateway-nc-pod1-dr.apple.com/',
-  'https://apple-pay-gateway-nc-pod2-dr.apple.com/', 'https://apple-pay-gateway-nc-pod3-dr.apple.com/',
-  'https://apple-pay-gateway-nc-pod4-dr.apple.com/', 'https://apple-pay-gateway-nc-pod5-dr.apple.com/',
-  'https://apple-pay-gateway-pr-pod1-dr.apple.com/', 'https://apple-pay-gateway-pr-pod2-dr.apple.com/',
-  'https://apple-pay-gateway-pr-pod3-dr.apple.com/', 'https://apple-pay-gateway-pr-pod4-dr.apple.com/',
-  'https://apple-pay-gateway-pr-pod5-dr.apple.com/',
-  'https://cn-applepay-gateway-sh-pod1.apple.com/', 'https://cn-applepay-gateway-sh-pod1-dr.apple.com/',
-  'https://cn-applepay-gateway-sh-pod2.apple.com/', 'https://cn-applepay-gateway-sh-pod2-dr.apple.com/',
-  'https://cn-applepay-gateway-sh-pod3.apple.com/', 'https://cn-applepay-gateway-sh-pod3-dr.apple.com/',
-  'https://cn-applepay-gateway-tj-pod1.apple.com/', 'https://cn-applepay-gateway-tj-pod1-dr.apple.com/',
-  'https://cn-applepay-gateway-tj-pod2.apple.com/', 'https://cn-applepay-gateway-tj-pod2-dr.apple.com/',
-  'https://cn-applepay-gateway-tj-pod3.apple.com/', 'https://cn-applepay-gateway-tj-pod3-dr.apple.com/']
+const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com',
+  'https://apple-pay-gateway.apple.com', 'https://apple-pay-gateway-nc-pod1.apple.com',
+  'https://apple-pay-gateway-nc-pod2.apple.com', 'https://apple-pay-gateway-nc-pod3.apple.com',
+  'https://apple-pay-gateway-nc-pod4.apple.com', 'https://apple-pay-gateway-nc-pod5.apple.com',
+  'https://apple-pay-gateway-pr-pod1.apple.com', 'https://apple-pay-gateway-pr-pod2.apple.com',
+  'https://apple-pay-gateway-pr-pod3.apple.com', 'https://apple-pay-gateway-pr-pod4.apple.com',
+  'https://apple-pay-gateway-pr-pod5.apple.com', 'https://apple-pay-gateway-nc-pod1-dr.apple.com',
+  'https://apple-pay-gateway-nc-pod2-dr.apple.com', 'https://apple-pay-gateway-nc-pod3-dr.apple.com',
+  'https://apple-pay-gateway-nc-pod4-dr.apple.com', 'https://apple-pay-gateway-nc-pod5-dr.apple.com',
+  'https://apple-pay-gateway-pr-pod1-dr.apple.com', 'https://apple-pay-gateway-pr-pod2-dr.apple.com',
+  'https://apple-pay-gateway-pr-pod3-dr.apple.com', 'https://apple-pay-gateway-pr-pod4-dr.apple.com',
+  'https://apple-pay-gateway-pr-pod5-dr.apple.com',
+  'https://cn-applepay-gateway-sh-pod1.apple.com', 'https://cn-applepay-gateway-sh-pod1-dr.apple.com',
+  'https://cn-applepay-gateway-sh-pod2.apple.com', 'https://cn-applepay-gateway-sh-pod2-dr.apple.com',
+  'https://cn-applepay-gateway-sh-pod3.apple.com', 'https://cn-applepay-gateway-sh-pod3-dr.apple.com',
+  'https://cn-applepay-gateway-tj-pod1.apple.com', 'https://cn-applepay-gateway-tj-pod1-dr.apple.com',
+  'https://cn-applepay-gateway-tj-pod2.apple.com', 'https://cn-applepay-gateway-tj-pod2-dr.apple.com',
+  'https://cn-applepay-gateway-tj-pod3.apple.com', 'https://cn-applepay-gateway-tj-pod3-dr.apple.com']
 
 const skipSendingCspHeader = (req, res, next) => { next() }
 


### PR DESCRIPTION
## WHAT
- remove the trailing slashes from urls for host sources. This is necessary as some old browsers with CSP V1 support will not understand it and thus going to ignore it (path was introduced in CSP V2)
