### PR TITLE
[PP-5900] remove apple pay whitelisted hosts

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -32,25 +32,8 @@ if (allowUnsafeEvalScripts) {
   scriptSourceCardDetails.push("'unsafe-eval'")
 }
 
-// Google analytics, Apple pay, Google pay uses standard Payment Request API so requires no exceptions
-const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com',
-  'https://apple-pay-gateway.apple.com', 'https://apple-pay-gateway-nc-pod1.apple.com',
-  'https://apple-pay-gateway-nc-pod2.apple.com', 'https://apple-pay-gateway-nc-pod3.apple.com',
-  'https://apple-pay-gateway-nc-pod4.apple.com', 'https://apple-pay-gateway-nc-pod5.apple.com',
-  'https://apple-pay-gateway-pr-pod1.apple.com', 'https://apple-pay-gateway-pr-pod2.apple.com',
-  'https://apple-pay-gateway-pr-pod3.apple.com', 'https://apple-pay-gateway-pr-pod4.apple.com',
-  'https://apple-pay-gateway-pr-pod5.apple.com', 'https://apple-pay-gateway-nc-pod1-dr.apple.com',
-  'https://apple-pay-gateway-nc-pod2-dr.apple.com', 'https://apple-pay-gateway-nc-pod3-dr.apple.com',
-  'https://apple-pay-gateway-nc-pod4-dr.apple.com', 'https://apple-pay-gateway-nc-pod5-dr.apple.com',
-  'https://apple-pay-gateway-pr-pod1-dr.apple.com', 'https://apple-pay-gateway-pr-pod2-dr.apple.com',
-  'https://apple-pay-gateway-pr-pod3-dr.apple.com', 'https://apple-pay-gateway-pr-pod4-dr.apple.com',
-  'https://apple-pay-gateway-pr-pod5-dr.apple.com',
-  'https://cn-applepay-gateway-sh-pod1.apple.com', 'https://cn-applepay-gateway-sh-pod1-dr.apple.com',
-  'https://cn-applepay-gateway-sh-pod2.apple.com', 'https://cn-applepay-gateway-sh-pod2-dr.apple.com',
-  'https://cn-applepay-gateway-sh-pod3.apple.com', 'https://cn-applepay-gateway-sh-pod3-dr.apple.com',
-  'https://cn-applepay-gateway-tj-pod1.apple.com', 'https://cn-applepay-gateway-tj-pod1-dr.apple.com',
-  'https://cn-applepay-gateway-tj-pod2.apple.com', 'https://cn-applepay-gateway-tj-pod2-dr.apple.com',
-  'https://cn-applepay-gateway-tj-pod3.apple.com', 'https://cn-applepay-gateway-tj-pod3-dr.apple.com']
+// Google analytics, Google pay uses standard Payment Request API so requires no exceptions
+const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com']
 
 const skipSendingCspHeader = (req, res, next) => { next() }
 


### PR DESCRIPTION
Why?
We've introduced them thinking it's required for csp to work on apple pay.
When re-reading documentation (https://developer.apple.com/documentation/apple_pay_on_the_web/setting_up_your_server#3172427)
it seems we need to wihtelist the domains only for server talking to apple.
The frontend side of things talks only to backend, not to apple directly.

Changes:
* remove whitelisted apple-pay domains