### PR TITLE
PP-5930 prefetch-src directive for ZAP tests

### DIFF
--- a/test/middleware/csp_test.js
+++ b/test/middleware/csp_test.js
@@ -62,4 +62,16 @@ describe('CSP middleware', () => {
 
     sinon.assert.calledWith(response.setHeader, 'Content-Security-Policy', sinon.match(/'unsafe-eval'/g))
   })
+
+  it('should add `prefetch-src` to Content-Security-Policy header when CSP_ADD_PREFETCH_DIRECTIVE is true', () => {
+    process.env.CSP_SEND_HEADER = 'true'
+    process.env.CSP_ADD_PREFETCH_DIRECTIVE = 'true'
+    const csp = requireHelper('../../app/middleware/csp')
+
+    const next = sinon.spy()
+    const response = { setHeader: sinon.spy() }
+    csp.cardDetails(mockRequest, response, next)
+
+    sinon.assert.calledWith(response.setHeader, 'Content-Security-Policy', sinon.match(/prefetch-src/g))
+  })
 })


### PR DESCRIPTION
## WHAT
- `prefetch-src` directive is an experimental and CSP level 3 directive which is not required on card details page.
       However, ZAP tests fails on directive being not defined.

- Adds a flag `CSP_ADD_PREFETCH_DIRECTIVE` to add prefetch-src directive to card details page (set to `true` to add directive and end to end environment only)