### PR TITLE
PP-5762 Add correlation id to logging

### DIFF
--- a/app/middleware/correlation_header.js
+++ b/app/middleware/correlation_header.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { CORRELATION_ID } = require('@govuk-pay/pay-js-commons').logging.keys
+const { CORRELATION_HEADER } = require('../../config/correlation_header')
+const { setLoggingField } = require('../utils/logging_fields_helper')
+
+module.exports = (req, res, next) => {
+  req.correlationId = req.headers[CORRELATION_HEADER] || ''
+  setLoggingField(req, CORRELATION_ID, req.correlationId)
+  next()
+}

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ const i18nConfig = require('./config/i18n')
 const i18nPayTranslation = require('./config/pay-translation')
 const Sentry = require('./app/utils/sentry.js').initialiseSentry()
 const csp = require('./app/middleware/csp')
+const correlationHeader = require('./app/middleware/correlation_header')
 
 // Global constants
 const { NODE_ENV, PORT, ANALYTICS_TRACKING_ID, GOOGLE_PAY_MERCHANT_ID, APPLE_PAY_MERCHANT_ID_CERTIFICATE } = process.env
@@ -83,6 +84,7 @@ function initialiseGlobalMiddleware (app) {
   app.use(compression())
 
   app.disable('x-powered-by')
+  app.use(correlationHeader)
 }
 
 function initialisei18n (app) {


### PR DESCRIPTION
Add middleware to store the correlation on the commonLoggingFields object on the request so that it will be included in logs.


