### PR TITLE
PP-5762 Log fields added to request object

### DIFF
--- a/app/controllers/healthcheck_controller.js
+++ b/app/controllers/healthcheck_controller.js
@@ -1,9 +1,10 @@
 // NPM dependencies
 const _ = require('lodash')
 const logger = require('../utils/logger')(__filename)
+const { getLoggingFields } = require('../utils/logging_fields_helper')
 const baseClient = require('../services/clients/base_client/base_client')
 
-const healthyPingResponse = { 'ping': { 'healthy': true } }
+const healthyPingResponse = { ping: { healthy: true } }
 
 const respond = (res, statusCode, data) => {
   res.writeHead(statusCode, { 'Content-Type': 'application/json' })
@@ -15,7 +16,8 @@ module.exports.healthcheck = (req, res) => {
     baseClient.get(`${process.env.FORWARD_PROXY_URL}/nginx_status`, {}, (err, response) => {
       const statusCode = _.get(response, 'statusCode')
       if (err || statusCode !== 200) {
-        logger.error(`Healthchecking forward proxy returned error: ${err}, status code: ${statusCode}`)
+        logger.error(`Healthchecking forward proxy returned error: ${err}, status code: ${statusCode}`,
+          getLoggingFields(req))
         respond(res, 502, _.merge(healthyPingResponse, { proxy: { healthy: false } }))
       } else {
         respond(res, 200, _.merge(healthyPingResponse, { proxy: { healthy: true } }))

--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const logger = require('../utils/logger')(__filename)
-const logging = require('../utils/logging')
+const { getLoggingFields } = require('../utils/logging_fields_helper')
 const Charge = require('../models/charge')
 const responseRouter = require('../utils/response_router')
 const { CORRELATION_HEADER } = require('../../config/correlation_header')
@@ -16,12 +16,11 @@ exports.return = (req, res) => {
   const cookieKey = createChargeIdSessionKey(req.chargeId)
   cookies.deleteSessionVariable(req, cookieKey)
   if (charge.isCancellableCharge(req.chargeData.status)) {
-    return charge.cancel(req.chargeId)
-      .then(() => logger.warn('Return controller cancelled payment', { 'chargeId': req.chargeId }))
+    return charge.cancel(req.chargeId, getLoggingFields(req))
+      .then(() => logger.warn('Return controller cancelled payment', getLoggingFields(req)))
       .then(() => res.redirect(req.chargeData.return_url))
       .catch(() => {
-        logger.error('Return controller failed to cancel payment', { 'chargeId': req.chargeId })
-        logging.systemError('Cancelling charge on return', correlationId, req.chargeId)
+        logger.error('Return controller failed to cancel payment', getLoggingFields(req))
         responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalyticsError())
       })
   } else {

--- a/app/controllers/secure_controller.js
+++ b/app/controllers/secure_controller.js
@@ -27,7 +27,7 @@ exports.new = async function (req, res) {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   var chargeId
   try {
-    const chargeData = await Charge(correlationId).findByToken(chargeTokenId)
+    const chargeData = await Charge(correlationId).findByToken(chargeTokenId, getLoggingFields(req))
     chargeId = chargeData.charge.externalId
 
     setLoggingField(req, PAYMENT_EXTERNAL_ID, chargeId)
@@ -46,7 +46,7 @@ exports.new = async function (req, res) {
       })
     } else {
       logger.info('Payment token used for the first time', getLoggingFields(req))
-      await Token.markTokenAsUsed(chargeTokenId, correlationId)
+      await Token.markTokenAsUsed(chargeTokenId, correlationId, getLoggingFields(req))
       setSessionVariable(req, createChargeIdSessionKey(chargeId), { csrfSecret: csrf().secretSync() })
       res.redirect(303, generateRoute(resolveActionName(chargeData.charge.status, 'get'), { chargeId }))
     }

--- a/app/controllers/web-payments/apple-pay/merchant-validation-controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation-controller.js
@@ -2,6 +2,7 @@
 
 const request = require('requestretry')
 const logger = require('../../../utils/logger')(__filename)
+const { getLoggingFields } = require('../../../utils/logging_fields_helper')
 
 // Local constants
 const { APPLE_PAY_MERCHANT_ID, APPLE_PAY_MERCHANT_DOMAIN, APPLE_PAY_MERCHANT_ID_CERTIFICATE, APPLE_PAY_MERCHANT_ID_CERTIFICATE_KEY } = process.env
@@ -37,8 +38,12 @@ module.exports = (req, res) => {
 
   request(options, (err, response, body) => {
     if (err) {
-      logger.info('Error generating Apple Pay session')
-      logger.info(err, response, body)
+      logger.info('Error generating Apple Pay session', {
+        ...getLoggingFields(req),
+        error: err,
+        response: response,
+        body: body
+      })
       res.status(500).send(body)
     }
     res.status(200).send(body)

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -6,6 +6,7 @@ const lodash = require('lodash')
 
 // Local dependencies
 const logger = require('../utils/logger')(__filename)
+const { getLoggingFields } = require('../utils/logging_fields_helper')
 const responseRouter = require('../utils/response_router')
 const { CORRELATION_HEADER } = require('../../config/correlation_header')
 const { withAnalyticsError } = require('../utils/analytics')
@@ -29,14 +30,14 @@ module.exports = function resolveServiceMiddleware (req, res, next) {
     // @FIXME(sfount) tests shouldn't rely on middleware returning a value if
     //                it is not used by the middleware stack - revisit this structure
     return getAdminUsersClient({ correlationId: req.headers[CORRELATION_HEADER] })
-      .findServiceBy({ gatewayAccountId })
+      .findServiceBy({ gatewayAccountId }, getLoggingFields(req))
       .then(service => {
         serviceCache.put(gatewayAccountId, service, SERVICE_CACHE_MAX_AGE)
         res.locals.service = service
         next()
       })
       .catch(() => {
-        logger.error(`Failed to retrieve service information for service: ${req.chargeData.gateway_account.serviceName}`)
+        logger.error(`Failed to retrieve service information for service: ${req.chargeData.gateway_account.serviceName}`, getLoggingFields(req))
         next()
       })
   }

--- a/app/middleware/state_enforcer.js
+++ b/app/middleware/state_enforcer.js
@@ -5,6 +5,7 @@ const lodash = require('lodash')
 
 // Local dependencies
 const logger = require('../utils/logger')(__filename)
+const { getLoggingFields } = require('../utils/logging_fields_helper')
 const responseRouter = require('../utils/response_router')
 const stateService = require('../services/state_service')
 const State = require('../../config/state.js')
@@ -22,7 +23,7 @@ module.exports = (req, res, next) => {
   if (!correctStates.includes(currentState)) {
     logger.info(`State enforcer status doesn't match: current charge state from \
     connector [${currentState}], expected [${correctStates}] for charge [${req.chargeId}] \
-    with payment provider [${paymentProvider}]`)
+    with payment provider [${paymentProvider}]`, getLoggingFields(req))
     const stateName = currentState.toUpperCase().replace(/\s/g, '_')
     responseRouter.response(req, res, stateName, {
       chargeId: req.chargeId,

--- a/app/models/token.js
+++ b/app/models/token.js
@@ -3,10 +3,10 @@
 // Local dependencies
 const connectorClient = require('../services/clients/connector_client')
 
-const markTokenAsUsed = async function (tokenId, correlationId) {
+const markTokenAsUsed = async function (tokenId, correlationId, loggingFields = {}) {
   let response
   try {
-    response = await connectorClient({ correlationId }).markTokenAsUsed({ tokenId })
+    response = await connectorClient({ correlationId }).markTokenAsUsed({ tokenId }, loggingFields)
   } catch (err) {
     throw new Error('CLIENT_UNAVAILABLE', err)
   }

--- a/app/services/charge_param_retriever.js
+++ b/app/services/charge_param_retriever.js
@@ -1,19 +1,20 @@
 'use strict'
 
+const { PAYMENT_EXTERNAL_ID } = require('@govuk-pay/pay-js-commons').logging.keys
 const logger = require('../utils/logger')(__filename)
+const { setLoggingField, getLoggingFields } = require('../utils/logging_fields_helper')
 const cookie = require('../utils/cookies')
 
 exports.retrieve = req => {
   const chargeId = req.params.chargeId ? req.params.chargeId : req.body.chargeId
+  setLoggingField(req, PAYMENT_EXTERNAL_ID, chargeId)
 
   if (!chargeId) {
-    logger.error('ChargeId was not found in request', {
-      chargeId: 'undefined'
-    })
+    logger.error('ChargeId was not found in request', getLoggingFields(req))
     return false
   } else if (!cookie.getSessionCookieName() || !cookie.isSessionPresent(req)) {
     logger.info('Session cookie is not present', {
-      chargeId: chargeId,
+      ...getLoggingFields(req),
       referrer: req.get('Referrer'),
       url: req.originalUrl,
       method: req.method
@@ -21,7 +22,7 @@ exports.retrieve = req => {
     return false
   } else if (!cookie.getSessionVariable(req, 'ch_' + chargeId)) {
     logger.info('ChargeId was not found on the session', {
-      chargeId: chargeId,
+      ...getLoggingFields,
       referrer: req.get('Referrer'),
       url: req.originalUrl,
       method: req.method,

--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -21,7 +21,7 @@ const responseBodyToServiceTransformer = function responseBodyToServiceTransform
 let baseUrl
 let correlationId
 
-const findServiceBy = function findServiceBy (findOptions) {
+const findServiceBy = function findServiceBy (findOptions, loggingFields = {}) {
   return new Promise(function (resolve, reject) {
     const servicesResource = `${baseUrl}/v1/api/services`
     const params = {
@@ -44,8 +44,8 @@ const findServiceBy = function findServiceBy (findOptions) {
       description: 'find a service',
       service: SERVICE_NAME
     }
-    const callbackToPromiseConverter = createCallbackToPromiseConverter(context, responseBodyToServiceTransformer)
-    requestLogger.logRequestStart(context)
+    const callbackToPromiseConverter = createCallbackToPromiseConverter(context, responseBodyToServiceTransformer, loggingFields)
+    requestLogger.logRequestStart(context, loggingFields)
     baseClient.get(servicesResource, params, callbackToPromiseConverter)
       .on('error', callbackToPromiseConverter)
   })

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -65,7 +65,7 @@ const _putConnector = (url, payload, description, subSegment, loggingFields = {}
       description: description,
       service: SERVICE_NAME
     }
-    requestLogger.logRequestStart(context)
+    requestLogger.logRequestStart(context, loggingFields)
     baseClient.put(
       url,
       { payload, correlationId },
@@ -89,7 +89,7 @@ const _putConnector = (url, payload, description, subSegment, loggingFields = {}
 }
 
 /** @private */
-const _postConnector = (url, payload, description) => {
+const _postConnector = (url, payload, description, loggingFields = {}) => {
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
     const context = {
@@ -98,18 +98,19 @@ const _postConnector = (url, payload, description) => {
       description: description,
       service: SERVICE_NAME
     }
-    requestLogger.logRequestStart(context)
+    requestLogger.logRequestStart(context, loggingFields)
     baseClient.post(
       url,
       { payload, correlationId },
       null,
       null
     ).then(response => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime, loggingFields)
       resolve(response)
     }).catch(err => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime)
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime, loggingFields)
       logger.error('Calling connector threw exception', {
+        ...loggingFields,
         service: 'connector',
         method: 'POST',
         url: url,
@@ -121,7 +122,7 @@ const _postConnector = (url, payload, description) => {
 }
 
 /** @private */
-const _patchConnector = (url, payload, description) => {
+const _patchConnector = (url, payload, description, loggingFields = {}) => {
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
     const context = {
@@ -130,18 +131,19 @@ const _patchConnector = (url, payload, description) => {
       description: description,
       service: SERVICE_NAME
     }
-    requestLogger.logRequestStart(context)
+    requestLogger.logRequestStart(context, loggingFields)
     baseClient.patch(
       url,
       { payload, correlationId },
       null,
       null
     ).then(response => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', url, new Date() - startTime)
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', url, new Date() - startTime, loggingFields)
       resolve(response)
     }).catch(err => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', url, new Date() - startTime)
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', url, new Date() - startTime, loggingFields)
       logger.error('Calling connector threw exception', {
+        ...loggingFields,
         service: 'connector',
         method: 'PATCH',
         url: url,
@@ -153,7 +155,7 @@ const _patchConnector = (url, payload, description) => {
 }
 
 /** @private */
-const _getConnector = (url, description) => {
+const _getConnector = (url, description, loggingFields = {}) => {
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
     const context = {
@@ -162,16 +164,17 @@ const _getConnector = (url, description) => {
       description: description,
       service: SERVICE_NAME
     }
-    requestLogger.logRequestStart(context)
+    requestLogger.logRequestStart(context, loggingFields)
     baseClient.get(
       url,
       { correlationId },
       null,
       null
     ).then(response => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime, loggingFields)
       if (response.statusCode !== 200) {
         logger.warn('[%s] Calling connector to GET something returned a non http 200 response', correlationId, {
+          ...loggingFields,
           service: 'connector',
           method: 'GET',
           status: response.statusCode
@@ -179,8 +182,9 @@ const _getConnector = (url, description) => {
       }
       resolve(response)
     }).catch(err => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime)
+      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime, loggingFields)
       logger.error('Calling connector threw exception', {
+        ...loggingFields,
         service: 'connector',
         method: 'GET',
         url: url,
@@ -192,29 +196,29 @@ const _getConnector = (url, description) => {
 }
 
 // POST functions
-const threeDs = chargeOptions => {
+const threeDs = (chargeOptions, loggingFields = {}) => {
   const threeDsUrl = _getThreeDsFor(chargeOptions.chargeId)
-  return _postConnector(threeDsUrl, chargeOptions.payload, '3ds')
+  return _postConnector(threeDsUrl, chargeOptions.payload, '3ds', loggingFields)
 }
 
-const chargeAuth = chargeOptions => {
+const chargeAuth = (chargeOptions, loggingFields = {}) => {
   const authUrl = _getAuthUrlFor(chargeOptions.chargeId)
-  return _postConnector(authUrl, chargeOptions.payload, 'create charge')
+  return _postConnector(authUrl, chargeOptions.payload, 'create charge', loggingFields)
 }
 
-const chargeAuthWithWallet = chargeOptions => {
+const chargeAuthWithWallet = (chargeOptions, loggingFields = {}) => {
   const authUrl = _getWalletAuthUrlFor(chargeOptions.chargeId, chargeOptions.provider)
-  return _postConnector(authUrl, chargeOptions.payload, 'create charge using e-wallet payment')
+  return _postConnector(authUrl, chargeOptions.payload, 'create charge using e-wallet payment', loggingFields)
 }
 
-const capture = chargeOptions => {
+const capture = (chargeOptions, loggingFields = {}) => {
   const captureUrl = _getCaptureUrlFor(chargeOptions.chargeId)
-  return _postConnector(captureUrl, null, 'do capture')
+  return _postConnector(captureUrl, null, 'do capture', loggingFields)
 }
 
-const cancel = chargeOptions => {
+const cancel = (chargeOptions, loggingFields = {}) => {
   const cancelUrl = _getCancelUrlFor(chargeOptions.chargeId)
-  return _postConnector(cancelUrl, null, 'cancel charge')
+  return _postConnector(cancelUrl, null, 'cancel charge', loggingFields)
 }
 
 // PUT functions
@@ -224,30 +228,30 @@ const updateStatus = (chargeOptions, subSegment, loggingFields = {}) => {
 }
 
 // PATCH functions
-const patch = chargeOptions => {
+const patch = (chargeOptions, loggingFields = {}) => {
   const patchUrl = _getPatchUrlFor(chargeOptions.chargeId)
-  return _patchConnector(patchUrl, chargeOptions.payload, 'patch')
+  return _patchConnector(patchUrl, chargeOptions.payload, 'patch', loggingFields)
 }
 
 // GET functions
-const findCharge = chargeOptions => {
+const findCharge = (chargeOptions, loggingFields = {}) => {
   const findChargeUrl = _getFindChargeUrlFor(chargeOptions.chargeId)
-  return _getConnector(findChargeUrl, 'find charge')
+  return _getConnector(findChargeUrl, 'find charge', loggingFields)
 }
 
-const findByToken = chargeOptions => {
+const findByToken = (chargeOptions, loggingFields = {}) => {
   const findByTokenUrl = _getFindByTokenUrlFor(chargeOptions.tokenId)
-  return _getConnector(findByTokenUrl, 'find by token')
+  return _getConnector(findByTokenUrl, 'find by token', loggingFields)
 }
 
-const getWorldpay3dsFlexJwt = chargeOptions => {
+const getWorldpay3dsFlexJwt = (chargeOptions, loggingFields = {}) => {
   const getWorldpay3dsFlexJwtUrl = _getWorldpay3dsFlexUrlFor(chargeOptions.chargeId)
-  return _getConnector(getWorldpay3dsFlexJwtUrl, 'get Worldpay 3DS Flex DDC JWT')
+  return _getConnector(getWorldpay3dsFlexJwtUrl, 'get Worldpay 3DS Flex DDC JWT', loggingFields)
 }
 
-const markTokenAsUsed = chargeOptions => {
+const markTokenAsUsed = (chargeOptions, loggingFields = {}) => {
   const markUsedTokenUrl = _markUsedTokenUrl(chargeOptions.tokenId)
-  return _postConnector(markUsedTokenUrl, undefined, 'mark token as used')
+  return _postConnector(markUsedTokenUrl, undefined, 'mark token as used', loggingFields)
 }
 
 module.exports = function (clientOptions = {}) {

--- a/app/services/worldpay_3ds_flex_service.js
+++ b/app/services/worldpay_3ds_flex_service.js
@@ -2,11 +2,11 @@
 
 const connectorClient = require('./clients/connector_client')
 
-const getDdcJwt = async function getDdcJwt (charge, correlationId) {
+const getDdcJwt = async function getDdcJwt (charge, correlationId, loggingFields = {}) {
   if (charge.gatewayAccount.paymentProvider === 'worldpay' &&
     charge.gatewayAccount.requires3ds &&
     charge.gatewayAccount.integrationVersion3ds === 2) {
-    const response = await connectorClient({ correlationId }).getWorldpay3dsFlexJwt({ chargeId: charge.id })
+    const response = await connectorClient({ correlationId }).getWorldpay3dsFlexJwt({ chargeId: charge.id }, loggingFields)
     if (response.statusCode !== 200) {
       throw new Error('Failed to get DDC JWT from connector')
     }

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -2,52 +2,47 @@
 
 const logger = require('./logger')(__filename)
 
-exports.authChargePost = url => {
+exports.authChargePost = (url, loggingFields = {}) => {
   logger.debug('Calling connector to authorize a charge (post card details)', {
+    ...loggingFields,
     service: 'connector',
     method: 'POST',
     url: url
   })
 }
 
-exports.failedChargePost = status => {
+exports.failedChargePost = (status, loggingFields = {}) => {
   logger.warn('Calling connector to authorize a charge (post card details) failed', {
+    ...loggingFields,
     service: 'connector',
     method: 'POST',
     status: status
   })
 }
 
-exports.failedChargePostException = err => {
+exports.failedChargePostException = (err, loggingFields = {}) => {
   logger.error('Calling connector to authorize a charge (post card details) threw exception', {
+    ...loggingFields,
     service: 'connector',
     method: 'POST',
     error: err
   })
 }
 
-exports.failedChargePatch = err => {
+exports.failedChargePatch = (err, loggingFields = {}) => {
   logger.warn('Calling connector to patch a charge failed', {
+    ...loggingFields,
     service: 'connector',
     method: 'PATCH',
     err: err
   })
 }
 
-exports.failedGetWorldpayDdcJwt = err => {
+exports.failedGetWorldpayDdcJwt = (err, loggingFields = {}) => {
   logger.error('Calling connector to get a Worldpay 3DS Flex DDC JWT threw exception', {
+    ...loggingFields,
     service: 'connector',
     method: 'GET',
     error: err
   })
-}
-
-exports.systemError = function logSystemError (message, correlationId, chargeId, gatewayAccountId, gatewayAccountType) {
-  const correlationID = correlationId || 'no-correlation-id'
-  const chargeID = chargeId || 'no-charge-id'
-  const gatewayAccountID = gatewayAccountId || 'no-gateway-account-id'
-  const type = gatewayAccountType || 'no-gateway-account-type'
-  const context = { correlationID, chargeID, gatewayAccountID, type }
-
-  logger.error(`System error thrown, rendering technical problems page: ${message}`, context)
 }

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -2,27 +2,31 @@
 
 const logger = require('./logger')(__filename)
 
-exports.logRequestStart = context => {
+exports.logRequestStart = (context, loggingFields = {}) => {
   logger.info(`Calling ${context.service} ${context.description}`, {
+    ...loggingFields,
     service: context.service,
     method: context.method,
     url: context.url
   })
 }
-exports.logRequestEnd = context => {
+exports.logRequestEnd = (context, loggingFields = {}) => {
   const duration = new Date() - context.startTime
-  logger.info(`[${context.correlationId}] - ${context.method} to ${context.url} ended - elapsed time: ${duration} ms`)
+  logger.info(`[${context.correlationId}] - ${context.method} to ${context.url} ended - elapsed time: ${duration} ms`,
+    loggingFields)
 }
-exports.logRequestFailure = (context, response) => {
+exports.logRequestFailure = (context, response, loggingFields = {}) => {
   logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed`, {
+    ...loggingFields,
     service: context.service,
     method: context.method,
     url: context.url,
     status: response.statusCode
   })
 }
-exports.logRequestError = (context, error) => {
+exports.logRequestError = (context, error, loggingFields = {}) => {
   logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception`, {
+    ...loggingFields,
     service: context.service,
     method: context.method,
     url: context.url,

--- a/app/utils/response_converter.js
+++ b/app/utils/response_converter.js
@@ -18,14 +18,14 @@ exports.successCodes = () => SUCCESS_CODES
  * @param {function} transformer
  * @returns {function}
  */
-function createCallbackToPromiseConverter (context, transformer) {
+function createCallbackToPromiseConverter (context, transformer, loggingFields = {}) {
   const defer = context.defer
 
   return (error, response, body) => {
-    requestLogger.logRequestEnd(context)
+    requestLogger.logRequestEnd(context, loggingFields)
 
     if (error) {
-      requestLogger.logRequestError(context, error)
+      requestLogger.logRequestError(context, error, loggingFields)
       defer.reject({ error: error })
     } else if (response && SUCCESS_CODES.includes(response.statusCode)) {
       if (body && typeof transformer === 'function') {
@@ -34,7 +34,7 @@ function createCallbackToPromiseConverter (context, transformer) {
         defer.resolve(body)
       }
     } else {
-      requestLogger.logRequestFailure(context, response)
+      requestLogger.logRequestFailure(context, response, loggingFields)
       defer.reject({
         errorCode: response.statusCode,
         message: response.body

--- a/app/utils/response_router.js
+++ b/app/utils/response_router.js
@@ -2,6 +2,7 @@
 
 const lodash = require('lodash')
 const logger = require('./logger')(__filename)
+const { getLoggingFields } = require('../utils/logging_fields_helper')
 
 const expired = {
   view: 'errors/incorrect_state/session_expired',
@@ -238,7 +239,7 @@ exports.response = (req, res, actionName, options) => {
   options.viewName = actionName
   let action = lodash.result(actions, actionName)
   if (!action) {
-    logger.error('Response action ' + actionName + ' NOT FOUND')
+    logger.error('Response action ' + actionName + ' NOT FOUND', getLoggingFields(req))
     options = { viewName: 'error' }
     action = actions.ERROR
   }


### PR DESCRIPTION
In all places where we do logging, retrieve the logging fields that we've added to the request and pass them to the logger.

As part of doing this, have removed the `logging.systemError` method as the purpose of this was to log certain values in the error which are now added to the logging fields stored on the request.

