### PR TITLE
PP-5762 Remove correlation id from log message

### DIFF
--- a/app/models/card.js
+++ b/app/models/card.js
@@ -38,7 +38,7 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
       cardIdClient.post({ payload: data, correlationId: correlationId }, postSubsegment)
         .then((response) => {
           postSubsegment.close()
-          logger.info(`[${correlationId}]  - %s to %s ended - total time %dms`, 'POST', cardIdClient.CARD_URL, new Date() - startTime, loggingFields)
+          logger.info('POST to %s ended - total time %dms', cardIdClient.CARD_URL, new Date() - startTime, loggingFields)
 
           if (response.statusCode === 404) {
             return reject(new Error('Your card is not supported'))
@@ -60,7 +60,7 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
             prepaid: body.prepaid
           }
 
-          logger.debug(`[${correlationId}] Checking card brand`, {
+          logger.debug('Checking card brand', {
             ...loggingFields,
             card_brand: card.brand,
             card_type: card.type
@@ -83,11 +83,11 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
         })
         .catch(error => {
           postSubsegment.close(error)
-          logger.error(`[${correlationId}] ERROR CALLING CARDID AT ${cardIdClient.CARD_URL}`, {
+          logger.error('Error calling card id to check card', {
             ...loggingFields,
             error
           })
-          logger.info(`[${correlationId}] - %s to %s ended - total time %dms`, 'POST', cardIdClient.cardUrl, new Date() - startTime, loggingFields)
+          logger.info('POST to %s ended - total time %dms', cardIdClient.cardUrl, new Date() - startTime, loggingFields)
           resolve()
         })
     }, subSegment)

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -101,7 +101,7 @@ module.exports = correlationId => {
   const cancelComplete = function (response, defer, loggingFields = {}) {
     const code = response.statusCode
     if (code === 204) return defer.resolve()
-    logger.error('[%s] Calling connector cancel a charge failed', correlationId, {
+    logger.error('Calling connector cancel a charge failed', {
       ...loggingFields,
       service: 'connector',
       method: 'POST',
@@ -128,7 +128,7 @@ module.exports = correlationId => {
 
   const updateComplete = function (response, defer, loggingFields = {}) {
     if (response.statusCode !== 204) {
-      logger.error('[%s] Calling connector to update charge status failed', correlationId, {
+      logger.error('Calling connector to update charge status failed', {
         ...loggingFields,
         status: response.statusCode
       })

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -72,10 +72,10 @@ const _putConnector = (url, payload, description, subSegment, loggingFields = {}
       null,
       subSegment
     ).then(response => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PUT', url, new Date() - startTime, loggingFields)
+      logger.info('PUT to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       resolve(response)
     }).catch(err => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PUT', url, new Date() - startTime, loggingFields)
+      logger.info('PUT to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       logger.error('Calling connector threw exception', {
         ...loggingFields,
         service: 'connector',
@@ -105,10 +105,10 @@ const _postConnector = (url, payload, description, loggingFields = {}) => {
       null,
       null
     ).then(response => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime, loggingFields)
+      logger.info('POST to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       resolve(response)
     }).catch(err => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'POST', url, new Date() - startTime, loggingFields)
+      logger.info('POST to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       logger.error('Calling connector threw exception', {
         ...loggingFields,
         service: 'connector',
@@ -138,10 +138,10 @@ const _patchConnector = (url, payload, description, loggingFields = {}) => {
       null,
       null
     ).then(response => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', url, new Date() - startTime, loggingFields)
+      logger.info('PATCH to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       resolve(response)
     }).catch(err => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'PATCH', url, new Date() - startTime, loggingFields)
+      logger.info('PATCH %s to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       logger.error('Calling connector threw exception', {
         ...loggingFields,
         service: 'connector',
@@ -171,9 +171,9 @@ const _getConnector = (url, description, loggingFields = {}) => {
       null,
       null
     ).then(response => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime, loggingFields)
+      logger.info('GET to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       if (response.statusCode !== 200) {
-        logger.warn('[%s] Calling connector to GET something returned a non http 200 response', correlationId, {
+        logger.warn('Calling connector to GET something returned a non http 200 response', correlationId, {
           ...loggingFields,
           service: 'connector',
           method: 'GET',
@@ -182,7 +182,7 @@ const _getConnector = (url, description, loggingFields = {}) => {
       }
       resolve(response)
     }).catch(err => {
-      logger.info('[%s] - %s to %s ended - total time %dms', correlationId, 'GET', url, new Date() - startTime, loggingFields)
+      logger.info('GET to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       logger.error('Calling connector threw exception', {
         ...loggingFields,
         service: 'connector',

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -12,11 +12,10 @@ exports.logRequestStart = (context, loggingFields = {}) => {
 }
 exports.logRequestEnd = (context, loggingFields = {}) => {
   const duration = new Date() - context.startTime
-  logger.info(`[${context.correlationId}] - ${context.method} to ${context.url} ended - elapsed time: ${duration} ms`,
-    loggingFields)
+  logger.info(`${context.method} to ${context.url} ended - elapsed time: ${duration} ms`, loggingFields)
 }
 exports.logRequestFailure = (context, response, loggingFields = {}) => {
-  logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed`, {
+  logger.error(`Calling ${context.service} to ${context.description} failed`, {
     ...loggingFields,
     service: context.service,
     method: context.method,
@@ -25,7 +24,7 @@ exports.logRequestFailure = (context, response, loggingFields = {}) => {
   })
 }
 exports.logRequestError = (context, error, loggingFields = {}) => {
-  logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception`, {
+  logger.error(`Calling ${context.service} to ${context.description} threw exception`, {
     ...loggingFields,
     service: context.service,
     method: context.method,


### PR DESCRIPTION
The correlation id is now added as a structured argument. Remove it from log messages where it is in square brackets at the start of the message for consistency.