### PR TITLE
PP-5762 Add appropriate keys to log lines

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -237,7 +237,10 @@ module.exports = {
               () => redirect(res).toReturn(req.chargeId),
               err => {
                 if (err.message === 'CAPTURE_FAILED') return responseRouter.response(req, res, 'CAPTURE_FAILURE', withAnalytics(charge))
-                logger.error('Error capturing charge for wallet payment', getLoggingFields(req))
+                logger.error('Error capturing charge for wallet payment', {
+                  ...getLoggingFields(req),
+                  error: err
+                })
                 responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalytics(
                   charge,
                   { returnUrl: routeFor('return', charge.id) }
@@ -268,7 +271,10 @@ module.exports = {
         (err) => {
           cookies.deleteSessionVariable(req, cookieKey)
           if (err.message === 'CAPTURE_FAILED') return responseRouter.response(req, res, 'CAPTURE_FAILURE', withAnalytics(charge))
-          logger.error('Error capturing charge', getLoggingFields(req))
+          logger.error('Error capturing charge', {
+            ...getLoggingFields(req),
+            error: err
+          })
           responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalytics(
             charge,
             { returnUrl: routeFor('return', charge.id) }
@@ -293,8 +299,11 @@ module.exports = {
       .cancel(req.chargeId, getLoggingFields(req))
       .then(
         () => responseRouter.response(req, res, 'USER_CANCELLED', withAnalytics(charge, { returnUrl: routeFor('return', charge.id) })),
-        () => {
-          logger.error('Error cancelling charge', getLoggingFields(req))
+        (err) => {
+          logger.error('Error cancelling charge', {
+            ...getLoggingFields(req),
+            error: err
+          })
           responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalytics(charge, { returnUrl: routeFor('return', charge.id) }))
         }
       )

--- a/app/controllers/healthcheck_controller.js
+++ b/app/controllers/healthcheck_controller.js
@@ -16,8 +16,11 @@ module.exports.healthcheck = (req, res) => {
     baseClient.get(`${process.env.FORWARD_PROXY_URL}/nginx_status`, {}, (err, response) => {
       const statusCode = _.get(response, 'statusCode')
       if (err || statusCode !== 200) {
-        logger.error(`Healthchecking forward proxy returned error: ${err}, status code: ${statusCode}`,
-          getLoggingFields(req))
+        logger.error('Healthchecking forward proxy returned error', {
+          ...getLoggingFields(req),
+          error: err,
+          status_code: statusCode
+        })
         respond(res, 502, _.merge(healthyPingResponse, { proxy: { healthy: false } }))
       } else {
         respond(res, 200, _.merge(healthyPingResponse, { proxy: { healthy: true } }))

--- a/app/controllers/return_controller.js
+++ b/app/controllers/return_controller.js
@@ -19,8 +19,11 @@ exports.return = (req, res) => {
     return charge.cancel(req.chargeId, getLoggingFields(req))
       .then(() => logger.warn('Return controller cancelled payment', getLoggingFields(req)))
       .then(() => res.redirect(req.chargeData.return_url))
-      .catch(() => {
-        logger.error('Return controller failed to cancel payment', getLoggingFields(req))
+      .catch((err) => {
+        logger.error('Return controller failed to cancel payment', {
+          ...getLoggingFields(req),
+          error: err
+        })
         responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalyticsError())
       })
   } else {

--- a/app/controllers/web-payments/payment-auth-request-controller.js
+++ b/app/controllers/web-payments/payment-auth-request-controller.js
@@ -33,7 +33,10 @@ module.exports = (req, res) => {
       })
       .catch(err => {
         subsegment.close('error')
-        logger.error(`Error while trying to authorise ${provider} Pay payment: ${err}`, getLoggingFields(req))
+        logger.error(`Error while trying to authorise ${provider} Pay payment`, {
+          ...getLoggingFields(req),
+          error: err
+        })
         res.status(200)
         res.send({ url: `/handle-payment-response/${chargeId}` })
       })

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -36,8 +36,11 @@ module.exports = function resolveServiceMiddleware (req, res, next) {
         res.locals.service = service
         next()
       })
-      .catch(() => {
-        logger.error(`Failed to retrieve service information for service: ${req.chargeData.gateway_account.serviceName}`, getLoggingFields(req))
+      .catch((err) => {
+        logger.error(`Failed to retrieve service information for service: ${req.chargeData.gateway_account.serviceName}`, {
+          ...getLoggingFields(req),
+          error: err
+        })
         next()
       })
   }

--- a/app/middleware/retrieve_charge.js
+++ b/app/middleware/retrieve_charge.js
@@ -41,7 +41,10 @@ module.exports = (req, res, next) => {
         })
         .catch((err) => {
           subsegment.close('error')
-          logger.error('Error finding charge in middleware: ' + err, getLoggingFields(req))
+          logger.error('Error finding charge in middleware', {
+            ...getLoggingFields(req),
+            error: err
+          })
           responseRouter.response(req, res, 'SYSTEM_ERROR', withAnalyticsError())
         })
     }, clsSegment)

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -105,7 +105,7 @@ module.exports = correlationId => {
       ...loggingFields,
       service: 'connector',
       method: 'POST',
-      status: code
+      status_code: code
     })
     if (code === 400) return defer.reject(new Error('CANCEL_FAILED'))
     return defer.reject(new Error('POST_FAILED'))
@@ -130,7 +130,7 @@ module.exports = correlationId => {
     if (response.statusCode !== 204) {
       logger.error('Calling connector to update charge status failed', {
         ...loggingFields,
-        status: response.statusCode
+        status_code: response.statusCode
       })
       defer.reject(new Error('UPDATE_FAILED'))
       return

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -177,7 +177,7 @@ const _getConnector = (url, description, loggingFields = {}) => {
           ...loggingFields,
           service: 'connector',
           method: 'GET',
-          status: response.statusCode
+          status_code: response.statusCode
         })
       }
       resolve(response)

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -16,7 +16,7 @@ exports.failedChargePost = (status, loggingFields = {}) => {
     ...loggingFields,
     service: 'connector',
     method: 'POST',
-    status: status
+    status_code: status
   })
 }
 
@@ -34,7 +34,7 @@ exports.failedChargePatch = (err, loggingFields = {}) => {
     ...loggingFields,
     service: 'connector',
     method: 'PATCH',
-    err: err
+    error: err
   })
 }
 

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -10,9 +10,16 @@ exports.logRequestStart = (context, loggingFields = {}) => {
     url: context.url
   })
 }
-exports.logRequestEnd = (context, loggingFields = {}) => {
+exports.logRequestEnd = (context, statusCode, loggingFields = {}) => {
   const duration = new Date() - context.startTime
-  logger.info(`${context.method} to ${context.url} ended - elapsed time: ${duration} ms`, loggingFields)
+  logger.info(`${context.method} to ${context.url} ended`, {
+    ...loggingFields,
+    service: context.service,
+    method: context.method,
+    url: context.url,
+    response_time: duration,
+    status_code: statusCode
+  })
 }
 exports.logRequestFailure = (context, response, loggingFields = {}) => {
   logger.error(`Calling ${context.service} to ${context.description} failed`, {
@@ -20,7 +27,7 @@ exports.logRequestFailure = (context, response, loggingFields = {}) => {
     service: context.service,
     method: context.method,
     url: context.url,
-    status: response.statusCode
+    status_code: response.statusCode
   })
 }
 exports.logRequestError = (context, error, loggingFields = {}) => {

--- a/app/utils/response_converter.js
+++ b/app/utils/response_converter.js
@@ -22,7 +22,8 @@ function createCallbackToPromiseConverter (context, transformer, loggingFields =
   const defer = context.defer
 
   return (error, response, body) => {
-    requestLogger.logRequestEnd(context, loggingFields)
+    const statusCode = response && response.statusCode
+    requestLogger.logRequestEnd(context, statusCode, loggingFields)
 
     if (error) {
       requestLogger.logRequestError(context, error, loggingFields)


### PR DESCRIPTION
Add keys to log lines containing useful information, such as the error.

Make it so that when we log a http status code, we always use "status_code" as the key.

