### PR TITLE
PP-5933 add form action covering direct redirect feature

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -12,7 +12,6 @@ const sentryCspReportUri = `${cspReportUri}&sentry_environment=${environment}`
 // and never changes
 const govUkFrontendLayoutJsEnabledScriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
 
-// Worldpay 3ds flex iframe
 const CSP_NONE = ["'none'"]
 const CSP_SELF = ["'self'"]
 
@@ -27,6 +26,16 @@ const scriptSourceCardDetails = ["'self'", "'unsafe-inline'", 'https://www.googl
 
 const formActionWP3DS = ["'self'", 'https://centinelapi.cardinalcommerce.com/V1/Cruise/Collect',
   'https://secure-test.worldpay.com/shopper/3ds/ddc.html']
+
+// Direct redirect use case lets post to any given site
+const formActionCardDetails = (req, res) => {
+  if (res.locals && res.locals.service &&
+      res.locals.service.redirectToServiceImmediatelyOnTerminalState === true) {
+    return '*'
+  }
+  return CSP_SELF[0]
+}
+
 // Sript that is being used during zap test: https://github.com/alphagov/pay-endtoend/blob/d685d5bc38d639e8adef629673e5577cb923408e/src/test/resources/uk/gov/pay/pen/tests/frontend.feature#L23
 if (allowUnsafeEvalScripts) {
   scriptSourceCardDetails.push("'unsafe-eval'")
@@ -46,7 +55,7 @@ const cardDetailsCSP = helmet.contentSecurityPolicy({
     scriptSrc: scriptSourceCardDetails,
     connectSrc: connectSourceCardDetails,
     styleSrc: [...CSP_SELF, "'unsafe-eval'"],
-    formAction: CSP_SELF,
+    formAction: [formActionCardDetails],
     fontSrc: CSP_SELF,
     frameAncestors: CSP_SELF,
     manifestSrc: CSP_NONE,

--- a/app/routes.js
+++ b/app/routes.js
@@ -70,7 +70,7 @@ exports.bind = function (app) {
     stateEnforcer
   ]
 
-  app.get(card.new.path, csp.cardDetails, middlewareStack, charge.new)
+  app.get(card.new.path, middlewareStack, csp.cardDetails, charge.new)
   app.get(card.authWaiting.path, middlewareStack, charge.authWaiting)
   app.get(card.captureWaiting.path, middlewareStack, charge.captureWaiting)
   app.post(card.create.path, middlewareStack, charge.create)


### PR DESCRIPTION
## WHAT
- redirect is blocked on some browsers when the site that we're redirecting to is redirecting to a different domain, eg on cancel we redirect the user to example.com/abc and that site redirects the user to example.org/abc. hence the need to use * for form action in case the redirectToServiceImmediatelyOnTerminalState flag is true
- if redirectToServiceImmediatelyOnTerminalState is false, we let the to be posted to self and products (when the user is coming from a payment link, the page automatically redirects the user back to products)
