### PR TITLE
PP-5762 Include correlation ID in incoming request logs

### DIFF
--- a/app/middleware/logging_middleware.js
+++ b/app/middleware/logging_middleware.js
@@ -1,9 +1,10 @@
 const morgan = require('morgan')
-const { requestLogFormat } = require('@govuk-pay/pay-js-commons').logging
 const logger = require('../utils/logger')(__filename)
+const { CORRELATION_HEADER } = require('../../config/correlation_header')
+const { format } = require('@govuk-pay/pay-js-commons').logging.requestLogFormat(CORRELATION_HEADER)
 
 module.exports = function () {
-  return morgan(requestLogFormat, {
+  return morgan(format, {
     stream: {
       write: message => {
         logger.info('Request received', JSON.parse(message))

--- a/package-lock.json
+++ b/package-lock.json
@@ -868,9 +868,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.18.1.tgz",
-      "integrity": "sha512-MPFEhXczCmg1TRM2Gkt5j2n62kWDkugVLRVxhNr0vhdeqjCR8iZRD4L+K35GjOEJioj9PlKbmZy+XIMTnjK/mQ==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.19.1.tgz",
+      "integrity": "sha512-6MSk5YE5ak/uIey91QS+N6PoD4O+bTDSJ04cdz6m7ug4m7aWV6x1igUEACKIUR5bC8fQeTU811+56rwF+crLNw==",
       "requires": {
         "lodash": "4.17.15",
         "moment-timezone": "0.5.27",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "2.18.1",
+    "@govuk-pay/pay-js-commons": "2.19.1",
     "@sentry/node": "5.10.1",
     "appmetrics": "5.0.5",
     "appmetrics-statsd": "3.0.0",


### PR DESCRIPTION
The new version of pay-js-commons adds a field for the request id
extracted from the request header in `request-log-format`.

Use the new version of pay-js-commons and change how we require the log
format to use this.