### PR TITLE
PP-5940 Hide Wallet/Error containers during Worldpay 3DS flex payments

### DIFF
--- a/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
+++ b/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
@@ -3,6 +3,18 @@
 const toggleWaiting = () => {
   document.getElementById('card-details-wrap').classList.toggle('hidden')
   document.getElementById('spinner').classList.toggle('hidden')
+  document.getElementById('error-summary').classList.add('hidden')
+
+  var paymentMethodSubmitElement = document.getElementById('payment-method-submit')
+  if (typeof paymentMethodSubmitElement !== 'undefined' && paymentMethodSubmitElement !== null) {
+    paymentMethodSubmitElement.classList.add('hidden')
+  }
+
+  var payDividerElements = document.getElementsByClassName('pay-divider')
+  if (typeof payDividerElements !== 'undefined' && payDividerElements.length > 0) {
+    payDividerElements[0].classList.remove('pay-divider')
+    payDividerElements[0].classList.add('hidden')
+  }
 }
 
 const addWorldpaySessionIdToForm = (form, worldpaySessionId) => {


### PR DESCRIPTION
## WHAT
- When submitting card details to Worldpay flex, wallet options (google/apple pay) & any previous error messages were still shown
  to users.
- Changes hides wallet options and error container if Worldpay 3DS flex payment is in progress

with @sandorarpa