### PR TITLE
PP-5490 Hide payment method divider word and refactoring

### DIFF
--- a/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
+++ b/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
@@ -10,10 +10,11 @@ const toggleWaiting = () => {
     paymentMethodSubmitElement.classList.add('hidden')
   }
 
-  var payDividerElements = document.getElementsByClassName('pay-divider')
-  if (typeof payDividerElements !== 'undefined' && payDividerElements.length > 0) {
-    payDividerElements[0].classList.remove('pay-divider')
-    payDividerElements[0].classList.add('hidden')
+  var paymentMethodDivider = document.getElementById('payment-method-divider')
+  if (typeof paymentMethodDivider !== 'undefined' && paymentMethodDivider !== null) {
+    paymentMethodDivider.classList.add('hidden')
+    paymentMethodDivider.classList.remove('pay-divider')
+    document.getElementById('payment-method-divider-word').classList.add('hidden')
   }
 }
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -74,7 +74,7 @@
             })
           }}
         <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
-        <span class="pay-divider"><span class="pay-divider--word">or</span></span>
+        <span id="payment-method-divider" class="pay-divider"><span id="payment-method-divider-word" class="pay-divider--word">or</span></span>
       </form>
     {% endif %}
     {% if allowGooglePay %}
@@ -95,7 +95,7 @@
             })
           }}
         <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
-        <span class="pay-divider"><span class="pay-divider--word">or</span></span>
+        <span id="payment-method-divider" class="pay-divider"><span id="payment-method-divider-word" class="pay-divider--word">or</span></span>
       </form>
     {% else %}
       <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>


### PR DESCRIPTION
## WHAT
- Refactor payment method divider on card details page - assigned IDs and used the same in 3DS flex javascript, instead of processing by class name which can break if more components are added with same class name
- Hide `or` element within divider