### PR TITLE
PP-5937 Frontend blocks prepaid cards

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -36,7 +36,7 @@ const { createChargeIdSessionKey } = require('../utils/session')
 const { getLoggingFields } = require('../utils/logging_fields_helper')
 
 const appendChargeForNewView = async function appendChargeForNewView (charge, req, chargeId) {
-  const cardModel = Card(charge.gatewayAccount.cardTypes, req.headers[CORRELATION_HEADER])
+  const cardModel = Card(charge.gatewayAccount.cardTypes, charge.gatewayAccount.block_prepaid_cards, req.headers[CORRELATION_HEADER])
   charge.withdrawalText = cardModel.withdrawalTypes.join('_')
   charge.allowedCards = cardModel.allowed
   charge.cardsAsStrings = JSON.stringify(cardModel.allowed)

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -119,7 +119,7 @@ module.exports = {
   },
   create: async (req, res) => {
     const charge = normalise.charge(req.chargeData, req.chargeId)
-    const cardModel = Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER])
+    const cardModel = Card(req.chargeData.gateway_account.card_types, req.chargeData.gateway_account.block_prepaid_cards, req.headers[CORRELATION_HEADER])
     const chargeOptions = {
       email_collection_mode: charge.gatewayAccount.emailCollectionMode,
       collect_billing_address: res.locals.service.collectBillingAddress
@@ -200,7 +200,7 @@ module.exports = {
     const namespace = getNamespace(clsXrayConfig.nameSpaceName)
     const clsSegment = namespace.get(clsXrayConfig.segmentKeyName)
     AWSXRay.captureAsyncFunc('Card_checkCard', function (subSegment) {
-      Card(req.chargeData.gateway_account.card_types, req.headers[CORRELATION_HEADER])
+      Card(req.chargeData.gateway_account.card_types, req.chargeData.gateway_account.block_prepaid_cards, req.headers[CORRELATION_HEADER])
         .checkCard(normalise.creditCard(req.body.cardNo), req.chargeData.language, subSegment, getLoggingFields(req))
         .then(
           card => {

--- a/app/models/card.js
+++ b/app/models/card.js
@@ -80,6 +80,7 @@ const checkCard = function (cardNo, allowed, blockPrepaidCards, language, correl
           }
 
           if(blockPrepaidCards && card.prepaid === 'PREPAID') {
+            logger.info('Card validation blocked prepaid card', { card_brand: card.brand, card_type: card.type, corporate: card.corporate, x_request_id: correlationId })
             return reject(new Error(i18n.__('fieldErrors.fields.cardNo.unsupportedPrepaidCard', changeCase.titleCase(card.brand))))
           }
 

--- a/app/models/card.js
+++ b/app/models/card.js
@@ -17,7 +17,7 @@ const i18nConfig = require('../../config/i18n')
 
 i18n.configure(i18nConfig)
 
-const checkCard = function (cardNo, allowed, language, correlationId, subSegment, loggingFields = {}) {
+const checkCard = function (cardNo, allowed, blockPrepaidCards, language, correlationId, subSegment, loggingFields = {}) {
   return new Promise(function (resolve, reject) {
     const startTime = new Date()
     const data = { cardNumber: parseInt(cardNo) }
@@ -79,6 +79,10 @@ const checkCard = function (cardNo, allowed, language, correlationId, subSegment
             }
           }
 
+          if(blockPrepaidCards && card.prepaid === 'PREPAID') {
+            return reject(new Error(i18n.__('fieldErrors.fields.cardNo.unsupportedPrepaidCard', changeCase.titleCase(card.brand))))
+          }
+
           resolve(card)
         })
         .catch(error => {
@@ -106,7 +110,7 @@ const normaliseCardType = function (cardType) {
   return undefined
 }
 
-module.exports = function (allowedCards, correlationId) {
+module.exports = function (allowedCards, blockPrepaidCards, correlationId) {
   const withdrawalTypes = []
   const allowed = _.clone(allowedCards)
   correlationId = correlationId || ''
@@ -118,7 +122,7 @@ module.exports = function (allowedCards, correlationId) {
     withdrawalTypes: withdrawalTypes,
     allowed: _.clone(allowed),
     checkCard: (cardNo, language, subSegment, loggingFields = {}) => {
-      return checkCard(cardNo, allowed, language, correlationId, subSegment, loggingFields)
+      return checkCard(cardNo, allowed, blockPrepaidCards, language, correlationId, subSegment, loggingFields)
     }
   }
 }

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -116,7 +116,8 @@
 				"nonNumeric": "Rhowch rif cerdyn dilys",
 				"unsupportedBrand": "Ni dderbynnir %s",
 				"unsupportedDebitCard": "Ni dderbynnir cardiau debyd %s",
-				"unsupportedCreditCard": "Ni dderbynnir cardiau credyd %s"
+				"unsupportedCreditCard": "Ni dderbynnir cardiau credyd %s",
+				"unsupportedPrepaidCard": "Ni dderbynnir cardiau rhagdaledig"
 			},
 			"cvc": {
 				"name": "god diogelwch cerdyn",

--- a/locales/en.json
+++ b/locales/en.json
@@ -114,7 +114,7 @@
 				"unsupportedBrand": "%s is not supported",
 				"unsupportedDebitCard": "%s debit cards are not supported",
 				"unsupportedCreditCard": "%s credit cards are not supported",
-				"unsupportedPrepaidCard": "Prepaid card payments are not accepted"
+				"unsupportedPrepaidCard": "Prepaid cards are not accepted"
 			},
 			"cvc": {
 				"name": "card security code",

--- a/locales/en.json
+++ b/locales/en.json
@@ -113,7 +113,8 @@
 				"nonNumeric": "Enter a valid card number",
 				"unsupportedBrand": "%s is not supported",
 				"unsupportedDebitCard": "%s debit cards are not supported",
-				"unsupportedCreditCard": "%s credit cards are not supported"
+				"unsupportedCreditCard": "%s credit cards are not supported",
+				"unsupportedPrepaidCard": "Prepaid card payments are not accepted"
 			},
 			"cvc": {
 				"name": "card security code",

--- a/test/cypress/integration/card/payment.spec.js
+++ b/test/cypress/integration/card/payment.spec.js
@@ -179,7 +179,7 @@ describe('Standard card payment flow', () => {
   })
 
   describe('Prepaid card blocking', () => {
-    it('should block a prepaid card if gateway account is configured not allow them', () => {
+    it('should block a prepaid card if gateway account is configured to not allow them', () => {
       const blockedPrepaidStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', 42, {}, { blockPrepaidCards: true })
       cy.task('setupStubs', blockedPrepaidStubs)
 
@@ -194,7 +194,7 @@ describe('Standard card payment flow', () => {
       cy.get('#card-no-lbl').should('contain', 'Prepaid cards are not accepted')
     })
 
-    it('should allow prepaid cards if gateway account is confgirued to allow', () => {
+    it('should allow prepaid cards if gateway account is configured to allow', () => {
       const blockedPrepaidStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', 42, {}, { blockPrepaidCards: false })
       cy.task('setupStubs', blockedPrepaidStubs)
 

--- a/test/cypress/integration/card/payment.spec.js
+++ b/test/cypress/integration/card/payment.spec.js
@@ -178,6 +178,38 @@ describe('Standard card payment flow', () => {
     })
   })
 
+  describe('Prepaid card blocking', () => {
+    it('should block a prepaid card if gateway account is configured not allow them', () => {
+      const blockedPrepaidStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', 42, {}, { blockPrepaidCards: true })
+      cy.task('setupStubs', blockedPrepaidStubs)
+
+      cy.visit(`/secure/${tokenId}`)
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      cy.server()
+
+      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.get('#card-no').type('4000160000000004')
+      cy.get('#card-no').blur()
+      cy.wait('@checkCard')
+      cy.get('#card-no-lbl').should('contain', 'Prepaid cards are not accepted')
+    })
+
+    it('should allow prepaid cards if gateway account is confgirued to allow', () => {
+      const blockedPrepaidStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', 42, {}, { blockPrepaidCards: false })
+      cy.task('setupStubs', blockedPrepaidStubs)
+
+      cy.visit(`/secure/${tokenId}`)
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      cy.server()
+
+      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.get('#card-no').type('4000160000000004')
+      cy.get('#card-no').blur()
+      cy.wait('@checkCard')
+      cy.get('#card-no-lbl').should('not.contain', 'Prepaid cards are not accepted')
+    })
+  })
+
   describe('Secure card payment page should show error', () => {
     it('Should setup the payment and load the page', () => {
       cy.task('setupStubs', createPaymentChargeStubsEnglish)

--- a/test/cypress/utils/card-payment-stubs.js
+++ b/test/cypress/utils/card-payment-stubs.js
@@ -14,9 +14,11 @@ const buildCreatePaymentChargeStubs = function buildCreatePaymentChargeStubs (to
         language: language || 'en',
         paymentProvider: providerOpts.paymentProvider,
         requires3ds: providerOpts.requires3ds,
-        integrationVersion3ds: providerOpts.integrationVersion3ds
+        integrationVersion3ds: providerOpts.integrationVersion3ds,
+        blockPrepaidCards: providerOpts.blockPrepaidCards
       }
     },
+    { name: 'cardIdValidCardDetails' },
     { name: 'connectorUpdateChargeStatus', opts: { chargeId } },
 
     // @TODO(sfount) this should pass the service to be queried relative to the charge - right now it just returns a default service

--- a/test/fixtures/payment_fixtures.js
+++ b/test/fixtures/payment_fixtures.js
@@ -17,6 +17,7 @@ const buildGatewayAccount = function buildGatewayAccount (opts = {}) {
     'corporate_prepaid_credit_card_surcharge_amount': 0,
     'corporate_prepaid_debit_card_surcharge_amount': 0,
     'email_collection_mode': opts.emailCollectionMode || 'MANDATORY',
+    'block_prepaid_cards': opts.blockPrepaidCards || false,
     'live': false,
     'payment_provider': opts.paymentProvider || 'sandbox',
     'requires3ds': opts.requires3ds || false,
@@ -347,7 +348,7 @@ const fixtures = {
       'type': 'C',
       'label': 'VISA CREDIT',
       'corporate': false,
-      'prepaid': 'UNKNOWN'
+      'prepaid': 'PREPAID'
     }
     return data
   }

--- a/test/models/card_test.js
+++ b/test/models/card_test.js
@@ -119,7 +119,7 @@ describe('card', function () {
 
         const scenario = CardModel(gatewayAccountAllowCardsConfiguration, gatewayAccountBlockedPrepaid).checkCard(1234)
 
-        return expect(scenario).to.be.rejectedWith('Prepaid card payments are not accepted')
+        return expect(scenario).to.be.rejectedWith('Prepaid cards are not accepted')
       })
 
       it('should allow if gateway account `block_prepaid_cards` is set to false', async () => {


### PR DESCRIPTION
* add error code key for prepaid cards (en)
* logic for blocking cards if the gateway account configuration is set
to block
* validate behaviour with cypress

