### PR TITLE
Revert "PP-5959 CSP: country autocomplete needs script-src 'unsafe-inline'"

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -24,8 +24,6 @@ const imgSourceCardDetails = ["'self'", 'https://www.google-analytics.com', 'htt
 const scriptSourceCardDetails = ["'self'", "'unsafe-inline'", 'https://www.google-analytics.com',
   (req, res) => `'nonce-${res.locals && res.locals.nonce}'`, govUkFrontendLayoutJsEnabledScriptHash]
 
-const styleSourceCardDetails = ["'self'", "'unsafe-eval'", "'unsafe-inline'"]
-
 const formActionWP3DS = ["'self'", 'https://centinelapi.cardinalcommerce.com/V1/Cruise/Collect',
   'https://secure-test.worldpay.com/shopper/3ds/ddc.html']
 
@@ -38,7 +36,7 @@ const formActionCardDetails = (req, res) => {
   return CSP_SELF[0]
 }
 
-// Script that is being used during zap test: https://github.com/alphagov/pay-endtoend/blob/d685d5bc38d639e8adef629673e5577cb923408e/src/test/resources/uk/gov/pay/pen/tests/frontend.feature#L23
+// Sript that is being used during zap test: https://github.com/alphagov/pay-endtoend/blob/d685d5bc38d639e8adef629673e5577cb923408e/src/test/resources/uk/gov/pay/pen/tests/frontend.feature#L23
 if (allowUnsafeEvalScripts) {
   scriptSourceCardDetails.push("'unsafe-eval'")
 }
@@ -56,7 +54,7 @@ const cardDetailsCSP = helmet.contentSecurityPolicy({
     imgSrc: imgSourceCardDetails,
     scriptSrc: scriptSourceCardDetails,
     connectSrc: connectSourceCardDetails,
-    styleSrc: styleSourceCardDetails,
+    styleSrc: [...CSP_SELF, "'unsafe-eval'"],
     formAction: [formActionCardDetails],
     fontSrc: CSP_SELF,
     frameAncestors: CSP_SELF,


### PR DESCRIPTION
Reverts alphagov/pay-frontend#1259 because ZAP tests fail in there’s a CSP with `style-src 'unsafe-inline'`.