### PR TITLE
PP-5940 Rename payment-method-submit button

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -39,10 +39,10 @@ module.exports = () => {
 
   session.onpaymentauthorized = event => {
     const { payment } = event
-    toggleWaiting()
+    toggleWaiting('apple-pay-payment-method-submit')
 
     if (!rfc822Validator(payment.shippingContact.emailAddress)) {
-      toggleWaiting()
+      toggleWaiting('apple-pay-payment-method-submit')
       showErrorSummary(i18n.fieldErrors.summary, i18n.fieldErrors.fields.email.message)
 
       const emailError = new ApplePayError('shippingContactInvalid', 'emailAddress', i18n.fieldErrors.fields.email.message)
@@ -68,13 +68,13 @@ module.exports = () => {
         })
       } else {
         session.abort()
-        toggleWaiting()
+        toggleWaiting('apple-pay-payment-method-submit')
         showErrorSummary(i18n.fieldErrors.webPayments.apple)
         ga('send', 'event', 'Apple Pay', 'Error', 'During authorisation/capture')
       }
     }).catch(err => {
       session.abort()
-      toggleWaiting()
+      toggleWaiting('apple-pay-payment-method-submit')
       showErrorSummary(i18n.fieldErrors.webPayments.apple)
       ga('send', 'event', 'Apple Pay', 'Error', 'Couldn’t post to /web-payments-auth-request/apple/{chargeId}')
       return err

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -4,7 +4,7 @@ const { getGooglePaymentsConfiguration, showErrorSummary, toggleWaiting } = requ
 const { email_collection_mode } = window.Charge // eslint-disable-line camelcase
 
 const processPayment = paymentData => {
-  toggleWaiting()
+  toggleWaiting('google-pay-payment-method-submit')
 
   return fetch(`/web-payments-auth-request/google/${window.paymentDetails.chargeID}`, {
     method: 'POST',
@@ -23,7 +23,7 @@ const processPayment = paymentData => {
       }
     })
     .catch(err => {
-      toggleWaiting()
+      toggleWaiting('google-pay-payment-method-submit')
       showErrorSummary(i18n.fieldErrors.webPayments.failureTitle, i18n.fieldErrors.webPayments.failureBody)
       ga('send', 'event', 'Google Pay', 'Error', 'During authorisation/capture')
       return err

--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -21,8 +21,8 @@ const clearErrorSummary = () => {
   errorSummary.classList.add('hidden')
 }
 
-const toggleWaiting = status => {
-  const button = document.getElementById('payment-method-submit')
+const toggleWaiting = (paymentMethodSubmitId) => {
+  const button = document.getElementById(paymentMethodSubmitId)
   button[button.getAttribute('disabled') ? 'removeAttribute' : 'setAttribute']('disabled', 'disabled')
   document.getElementById('spinner').classList.toggle('hidden')
 }

--- a/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
+++ b/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
@@ -5,7 +5,12 @@ const toggleWaiting = () => {
   document.getElementById('spinner').classList.toggle('hidden')
   document.getElementById('error-summary').classList.add('hidden')
 
-  var paymentMethodSubmitElement = document.getElementById('payment-method-submit')
+  var paymentMethodSubmitElement = document.getElementById('apple-pay-payment-method-submit')
+  if (typeof paymentMethodSubmitElement !== 'undefined' && paymentMethodSubmitElement !== null) {
+    paymentMethodSubmitElement.classList.add('hidden')
+  }
+
+  paymentMethodSubmitElement = document.getElementById('google-pay-payment-method-submit')
   if (typeof paymentMethodSubmitElement !== 'undefined' && paymentMethodSubmitElement !== null) {
     paymentMethodSubmitElement.classList.add('hidden')
   }

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -69,12 +69,10 @@
               html: ApplePayButtonHTML,
               classes: "web-payments-button apple-pay",
               attributes: {
-                id: "payment-method-submit"
+                id: "apple-pay-payment-method-submit"
               }
             })
           }}
-        <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
-        <span id="payment-method-divider" class="pay-divider"><span id="payment-method-divider-word" class="pay-divider--word">or</span></span>
       </form>
     {% endif %}
     {% if allowGooglePay %}
@@ -90,16 +88,18 @@
               html: GooglePayButtonHTML,
               classes: "web-payments-button google-pay",
               attributes: {
-                id: "payment-method-submit"
+                id: "google-pay-payment-method-submit"
               }
             })
           }}
-        <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
-        <span id="payment-method-divider" class="pay-divider"><span id="payment-method-divider-word" class="pay-divider--word">or</span></span>
       </form>
-    {% else %}
-      <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
     {% endif %}
+
+    {% if allowApplePay or allowGooglePay %}
+      <span id="payment-method-divider" class="pay-divider"><span id="payment-method-divider-word" class="pay-divider--word">or</span></span>
+    {% endif %}
+    <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
+
     <div id="card-details-wrap">
       <h1 class="govuk-heading-l">{{ __p("cardDetails.title") }}</h1>
 

--- a/test/cypress/integration/web-payments/apple-pay.spec.js
+++ b/test/cypress/integration/web-payments/apple-pay.spec.js
@@ -38,7 +38,8 @@ describe('Apple Pay payment flow', () => {
   const createPaymentChargeStubs = [
     { name: 'connectorCreateChargeFromToken', opts: { tokenId } },
     { name: 'connectorMarkTokenAsUsed', opts: { tokenId } },
-    { name: 'connectorGetChargeDetails',
+    {
+      name: 'connectorGetChargeDetails',
       opts: {
         chargeId,
         status: 'CREATED',
@@ -73,7 +74,7 @@ describe('Apple Pay payment flow', () => {
     if (path === '/apple-pay-merchant-validation') {
       return new Promise(resolve => resolve({
         status: 200,
-        json: () => new Promise(resolve => resolve({ signature: `legit` }))
+        json: () => new Promise(resolve => resolve({ signature: 'legit' }))
       }))
     }
     // Mock payment auth response
@@ -117,8 +118,8 @@ describe('Apple Pay payment flow', () => {
       })
 
       // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Apple Pay
-      cy.get('#payment-method-submit.apple-pay').should('be.visible')
-      cy.get('#payment-method-submit.apple-pay').click()
+      cy.get('#apple-pay-payment-method-submit.apple-pay').should('be.visible')
+      cy.get('#apple-pay-payment-method-submit.apple-pay').click()
 
       // 8. User clicks though the native payment UI and passes their tokenised card data to the auth request handler
       // 9. The auth response comes back from connector and frontend sends capture request and redirects the user the success page
@@ -155,7 +156,7 @@ describe('Apple Pay payment flow', () => {
       })
 
       // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Apple Pay
-      cy.get('#payment-method-submit.apple-pay').should('be.visible')
+      cy.get('#apple-pay-payment-method-submit.apple-pay').should('be.visible')
 
       // 8. User should see normal payment form
       cy.get('#card-no').should('be.visible')
@@ -189,8 +190,8 @@ describe('Apple Pay payment flow', () => {
       })
 
       // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Apple Pay
-      cy.get('#payment-method-submit.apple-pay').should('be.visible')
-      cy.get('#payment-method-submit').click()
+      cy.get('#apple-pay-payment-method-submit.apple-pay').should('be.visible')
+      cy.get('#apple-pay-payment-method-submit').click()
 
       // 8. User clicks though the native payment UI but the email is invalid and we throw an error
       cy.get('#error-summary').should('be.visible')
@@ -214,7 +215,7 @@ describe('Apple Pay payment flow', () => {
       cy.visit(`/card_details/${chargeId}`)
 
       // 7. Javascript will not detect browser has Apple Pay and won’t show it as an option
-      cy.get('#payment-method-submit.apple-pay').should('be.not.visible')
+      cy.get('#apple-pay-payment-method-submit.apple-pay').should('be.not.visible')
 
       // 8. User should see normal payment form
       cy.get('#card-no').should('be.visible')
@@ -247,8 +248,8 @@ describe('Apple Pay payment flow', () => {
       })
 
       // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Apple Pay
-      cy.get('#payment-method-submit.apple-pay').should('be.visible')
-      cy.get('#payment-method-submit.apple-pay').click()
+      cy.get('#apple-pay-payment-method-submit.apple-pay').should('be.visible')
+      cy.get('#apple-pay-payment-method-submit.apple-pay').click()
 
       // 8. User clicks though the native payment UI and passes their tokenised card data to the auth request handler
       // 9. The auth response comes back from connector and frontend sends capture request and redirects the user the success page

--- a/test/cypress/integration/web-payments/google-pay.spec.js
+++ b/test/cypress/integration/web-payments/google-pay.spec.js
@@ -30,7 +30,8 @@ describe('Google Pay payment flow', () => {
   const createPaymentChargeStubs = [
     { name: 'connectorCreateChargeFromToken', opts: { tokenId } },
     { name: 'connectorMarkTokenAsUsed', opts: { tokenId } },
-    { name: 'connectorGetChargeDetails',
+    {
+      name: 'connectorGetChargeDetails',
       opts: {
         chargeId,
         status: 'CREATED',
@@ -105,8 +106,8 @@ describe('Google Pay payment flow', () => {
       })
 
       // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Google Pay
-      cy.get('#payment-method-submit.google-pay').should('be.visible')
-      cy.get('#payment-method-submit.google-pay').click()
+      cy.get('#google-pay-payment-method-submit.google-pay').should('be.visible')
+      cy.get('#google-pay-payment-method-submit.google-pay').click()
 
       // 8. User clicks though the native payment UI and passes their tokenised card data to the auth request handler
       // 9. The auth response comes back from connector and frontend sends capture request and redirects the user the success page
@@ -147,7 +148,7 @@ describe('Google Pay payment flow', () => {
       })
 
       // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Google Pay
-      cy.get('#payment-method-submit.google-pay').should('be.visible')
+      cy.get('#google-pay-payment-method-submit.google-pay').should('be.visible')
 
       // 8. User should see normal payment form
       cy.get('#card-no').should('be.visible')
@@ -158,7 +159,7 @@ describe('Google Pay payment flow', () => {
       cy.visit(`/card_details/${chargeId}`)
 
       // 7. Javascript will not detect browser has Apple Pay and won’t show it as an option
-      cy.get('#payment-method-submit.google-pay').should('be.not.visible')
+      cy.get('#google-pay-payment-method-submit.google-pay').should('be.not.visible')
 
       // 8. User should see normal payment form
       cy.get('#card-no').should('be.visible')
@@ -195,8 +196,8 @@ describe('Google Pay payment flow', () => {
       })
 
       // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Google Pay
-      cy.get('#payment-method-submit.google-pay').should('be.visible')
-      cy.get('#payment-method-submit.google-pay').click()
+      cy.get('#google-pay-payment-method-submit.google-pay').should('be.visible')
+      cy.get('#google-pay-payment-method-submit.google-pay').click()
 
       // 8. User clicks though the native payment UI and passes their tokenised card data to the auth request handler
       // 9. The auth response comes back from connector and frontend sends capture request and redirects the user the success page


### PR DESCRIPTION
## WHAT
- Rename `payment-method-submit` to payment method specific as buttons for both apple/google pay uses same ID which is against HTML guidelines and interferes with using `document.getElementById` method.

with @sandorarpa