### PR TITLE
PP-5977 Remove Google Analytics Front end

### DIFF
--- a/app/views/includes/analytics.njk
+++ b/app/views/includes/analytics.njk
@@ -1,11 +1,27 @@
 <script nonce="{{ nonce }}">
+    {#
+    The below code is commented out so we don't store Google Analytic cookies for ICO compliance.
+    We create a empty ga() function so not to throw a ReferenceError
+    Uncomment when we enable opt-in for cookies and remove the ga() function.
+    #}
+
+    function ga() {
+
+    }
+    
+    
+    {#
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function()
             { (i[r].q=i[r].q||[]).push(arguments)}
             ,i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    #}
+    
 
     {# GOV.UK Pay google analytics #}
+    
+    {#
     ga('create', '{{analyticsTrackingId}}', 'auto');
     ga('set', 'anonymizeIp', true);
     ga('set', 'transport', 'beacon');
@@ -18,11 +34,15 @@
       'dimension3': '{{ analytics.paymentProvider }}',
       'dimension4': '{{ analytics.testingVariant }}',
     });
+    #}
 
     {# X-Gov google analtyics #}
+    {#
     ga('create', 'UA-145652997-1', 'auto', 'govuk_shared', {'allowLinker': true});
     ga('govuk_shared.require', 'linker');
     ga('govuk_shared.linker.set', 'anonymizeIp', true);
     ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
     ga('govuk_shared.send', 'pageview');
+    #}
+    
 </script>

--- a/test/analytics_ui_tests.js
+++ b/test/analytics_ui_tests.js
@@ -1,3 +1,5 @@
+// Test disabled temporarily whilst Google Analytics is disabled
+/*
 var path = require('path')
 var renderTemplate = require(path.join(__dirname, '/test_helpers/html_assertions.js')).render
 var should = require('chai').should() // eslint-disable-line
@@ -5,9 +7,9 @@ var should = require('chai').should() // eslint-disable-line
 describe('Frontend analytics', function () {
   var googleAnalyticsScript = '//www.google-analytics.com/analytics.js'
   var googleAnalyticsCustomDimensions = {
-    'analyticsId': 'testId',
-    'type': 'testType',
-    'paymentProvider': 'paymentProvider'
+    analyticsId: 'testId',
+    type: 'testType',
+    paymentProvider: 'paymentProvider'
   }
 
   var checkGACustomDimensions = function (body) {
@@ -18,8 +20,8 @@ describe('Frontend analytics', function () {
 
   it('should be enabled in charge view', function () {
     var templateData = {
-      'amount': '50.00',
-      'analytics': googleAnalyticsCustomDimensions
+      amount: '50.00',
+      analytics: googleAnalyticsCustomDimensions
     }
     var body = renderTemplate('charge', templateData)
     body.should.containSelector('script').withText(googleAnalyticsScript)
@@ -28,14 +30,14 @@ describe('Frontend analytics', function () {
 
   it('should be enabled in confirm view', function () {
     var templateData = {
-      'cardNumber': '●●●●●●●●●●●●5100',
-      'expiryDate': '11/99',
-      'amount': '10.00',
-      'description': 'Payment Description',
-      'cardholderName': 'Random dude',
-      'address': '1 street lane, avenue city, AB1 3DF',
-      'serviceName': 'Service 1',
-      'analytics': googleAnalyticsCustomDimensions
+      cardNumber: '●●●●●●●●●●●●5100',
+      expiryDate: '11/99',
+      amount: '10.00',
+      description: 'Payment Description',
+      cardholderName: 'Random dude',
+      address: '1 street lane, avenue city, AB1 3DF',
+      serviceName: 'Service 1',
+      analytics: googleAnalyticsCustomDimensions
     }
 
     var body = renderTemplate('confirm', templateData)
@@ -46,8 +48,8 @@ describe('Frontend analytics', function () {
   it('should be enabled in error view', function () {
     var msg = 'error processing your payment!'
     var body = renderTemplate('error', {
-      'message': msg,
-      'analytics': googleAnalyticsCustomDimensions
+      message: msg,
+      analytics: googleAnalyticsCustomDimensions
     })
     body.should.containSelector('script').withText(googleAnalyticsScript)
     checkGACustomDimensions(body)
@@ -57,9 +59,9 @@ describe('Frontend analytics', function () {
     var msg = 'error processing your payment!'
     var returnUrl = 'http://some.return.url'
     var body = renderTemplate('error_with_return_url', {
-      'message': msg,
-      'return_url': returnUrl,
-      'analytics': googleAnalyticsCustomDimensions
+      message: msg,
+      return_url: returnUrl,
+      analytics: googleAnalyticsCustomDimensions
     })
     body.should.containSelector('script').withText(googleAnalyticsScript)
     checkGACustomDimensions(body)
@@ -67,7 +69,7 @@ describe('Frontend analytics', function () {
 
   it('should be enabled when waiting for auth', function () {
     var body = renderTemplate('auth_waiting', {
-      'analytics': googleAnalyticsCustomDimensions
+      analytics: googleAnalyticsCustomDimensions
     })
     body.should.containSelector('script').withText(googleAnalyticsScript)
     checkGACustomDimensions(body)
@@ -75,7 +77,7 @@ describe('Frontend analytics', function () {
 
   it('should be enabled when waiting for capture', function () {
     var body = renderTemplate('capture_waiting', {
-      'analytics': googleAnalyticsCustomDimensions
+      analytics: googleAnalyticsCustomDimensions
     })
     body.should.containSelector('script').withText(googleAnalyticsScript)
     checkGACustomDimensions(body)
@@ -83,9 +85,10 @@ describe('Frontend analytics', function () {
 
   it('should be enabled when user cancels a payment', function () {
     var body = renderTemplate('user_cancelled', {
-      'analytics': googleAnalyticsCustomDimensions
+      analytics: googleAnalyticsCustomDimensions
     })
     body.should.containSelector('script').withText(googleAnalyticsScript)
     checkGACustomDimensions(body)
   })
 })
+*/


### PR DESCRIPTION
Description:
- Complying with ICO guidance around cookie consent we can't set non-essential cookies without consent being granted. In the short term then we have to disable Google Analytics as it stores cookies

- Uncomment when we have enabled opt-in and remove the empty ga() function
- Renable analytics_ui_tests.js when Google Analytics is enabled



