### PR TITLE
PP-5985 Fix `or` separator

### DIFF
--- a/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
+++ b/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
@@ -15,11 +15,18 @@ const toggleWaiting = () => {
     paymentMethodSubmitElement.classList.add('hidden')
   }
 
-  var paymentMethodDivider = document.getElementById('payment-method-divider')
+  var paymentMethodDivider = document.getElementById('apple-pay-payment-method-divider')
   if (typeof paymentMethodDivider !== 'undefined' && paymentMethodDivider !== null) {
     paymentMethodDivider.classList.add('hidden')
     paymentMethodDivider.classList.remove('pay-divider')
-    document.getElementById('payment-method-divider-word').classList.add('hidden')
+    document.getElementById('apple-pay-payment-method-divider-word').classList.add('hidden')
+  }
+
+  paymentMethodDivider = document.getElementById('google-pay-payment-method-divider')
+  if (typeof paymentMethodDivider !== 'undefined' && paymentMethodDivider !== null) {
+    paymentMethodDivider.classList.add('hidden')
+    paymentMethodDivider.classList.remove('pay-divider')
+    document.getElementById('google-pay-payment-method-divider-word').classList.add('hidden')
   }
 }
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -73,6 +73,7 @@
               }
             })
           }}
+          <span id="apple-pay-payment-method-divider" class="pay-divider"><span id="apple-pay-payment-method-divider-word" class="pay-divider--word">or</span></span>
       </form>
     {% endif %}
     {% if allowGooglePay %}
@@ -92,11 +93,8 @@
               }
             })
           }}
+          <span id="google-pay-payment-method-divider" class="pay-divider"><span id="google-pay-payment-method-divider-word" class="pay-divider--word">or</span></span>
       </form>
-    {% endif %}
-
-    {% if allowApplePay or allowGooglePay %}
-      <span id="payment-method-divider" class="pay-divider"><span id="payment-method-divider-word" class="pay-divider--word">or</span></span>
     {% endif %}
     <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
 


### PR DESCRIPTION
## WHAT
- Move `or` separator to apple/google pay forms, so it is only displayed if payment methods are shown to users and not when the feature is enabled on gateway account
- rename spans to have unique IDs and hide both during 3DS flex journey