### PR TITLE
PP-5987 Remove prefetch-src directive from enter card details CSP

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -63,7 +63,6 @@ const cardDetailsCSP = helmet.contentSecurityPolicy({
     manifestSrc: CSP_NONE,
     mediaSrc: CSP_NONE,
     objectSrc: CSP_NONE,
-    prefetchSrc: CSP_SELF,
     baseUri: CSP_NONE,
     blockAllMixedContent: true
   },


### PR DESCRIPTION
The `prefetch-src` directive was added to the CSP for the enter card details page in commit 65017dd4864b12c5ddddf753ad06fee6a9a62f9c because the ZAP CSP Scanner complains if it finds a CSP that has a lax `prefetch-src` (not specifying one allows prefetches from anywhere, so is considered lax).

However, we disabled the ZAP CSP Scanner because it was complaining about other directives we are not in a position to modify.

Therefore, we can now remove `prefetch-src` from the CSP for the enter card details page. It’s an experimental CSP3 directive and we decided not to support those yet. In addition, no browsers support it yet:

- https://caniuse.com/#search=prefetch-src
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src#Browser_compatibility

Furthermore, browsers tend to complain in their developer tools consoles when they encounter `prefetch-src`, which is annoying.