### PR TITLE
PP-6029: Update PaaS manifest

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,4 @@
+memory: 500M
+disk_quota: 500M
+card_frontend_session_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw
+card_connector_analytics_tracking_id: testing-123

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,33 +1,23 @@
 ---
 applications:
   - name: card-frontend
-    buildpack: nodejs_buildpack
+    buildpacks:
+      - nodejs_buildpack
     health-check-type: http
     health-check-http-endpoint: '/healthcheck'
     health-check-invocation-timeout: 5
-    memory: 1G
-    disk_quota: 1G
-    command: node start.js
+    memory: ((memory))
+    disk_quota: ((disk_quota))
+    command: npm start
     env:
       NODE_ENV: production
-      http_proxy: ((http_proxy_url))
-      HTTP_PROXY: ((http_proxy_url))
-      HTTP_PROXY_HOST: ((http_proxy_host))
-      HTTP_PROXY_PORT: ((http_proxy_port))
-      https_proxy: ((http_proxy_url))
-      HTTPS_PROXY: ((http_proxy_url))
-      HTTPS_PROXY_HOST: ((http_proxy_host))
-      HTTPS_PROXY_PORT: ((http_proxy_port))
-      HTTP_PROXY_ENABLED: ((http_proxy_enabled))
-      NO_PROXY: ((http_no_proxy))
       SESSION_ENCRYPTION_KEY: ((card_frontend_session_encryption_key))
       COOKIE_MAX_AGE: '5400000'
-      CONNECTOR_TOKEN_URL: http://card-connector-((space)).apps.internal:8080/v1/frontend/tokens/{chargeTokenId}
-      CONNECTOR_URL: http://card-connector-((space)).apps.internal:8080
-      CONNECTOR_HOST: http://card-connector-((space)).apps.internal:8080
+      CONNECTOR_HOST: ((card_connector_url))
       ANALYTICS_TRACKING_ID: ((card_connector_analytics_tracking_id))
-      CARDID_HOST: http://cardid-((space)).apps.internal:8080
+      CARDID_HOST: ((cardid_url))
       NODE_WORKER_COUNT: '1'
       FRONTEND_URL: https://((card_frontend_url))
-      ADMINUSERS_URL: http://adminusers-((space)).apps.internal:8080
-
+      ADMINUSERS_URL: ((adminusers_url))
+    routes:
+      - route: ((card_frontend_url))

--- a/package-lock.json
+++ b/package-lock.json
@@ -4960,19 +4960,19 @@
           }
         },
         "chokidar": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-          "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+          "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
           "dev": true,
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
-            "fsevents": "~2.1.1",
+            "fsevents": "~2.1.2",
             "glob-parent": "~5.1.0",
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.2.0"
+            "readdirp": "~3.3.0"
           }
         },
         "cliui": {
@@ -5033,12 +5033,12 @@
           "dev": true
         },
         "readdirp": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-          "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+          "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
           "dev": true,
           "requires": {
-            "picomatch": "^2.0.4"
+            "picomatch": "^2.0.7"
           }
         },
         "string-width": {
@@ -7210,7 +7210,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -8459,7 +8459,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
@@ -13105,7 +13105,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memoizee": {
@@ -13355,7 +13355,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -13986,7 +13986,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
@@ -15444,7 +15444,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -16636,7 +16636,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": "12.2.0"
+    "node": "12.11.1"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
## WHAT
I've updated the Node version to 12.11.1 which is a supported PaaS
version. The Docker image builds successfully with this version.

I simplified the manifest, removing the proxy environment variables
because I think those should be set during the "infrastructure"
provisioning step globally for all apps. Also they're not needed in the
dev environments. I've added a `dev.yml` which just defines dummy values
for some of the variables.

## HOW 
Push this app to your dev environment (you may have to delete the existing app with `cf delete card-frontend`):

```
cf push \
  --vars-file dev.yml \
  --var space=dev-yourname \
  --var card_frontend_url=pay-card-frontend-dev-yourname.london.cloudapps.digital
```

PaaS will take care of running `npm install`.


