### PR TITLE
PP-6031 Bump engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": "12.11.1"
+    "node": "^12.11.1"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
PaaS node buildpack no longer supports 12.11.1. To avoid having to keep
bumping the engine version whilst maintaining compatibility with our
existing docker image build process, this pins the major version whilst
accepting minor and pataches releases greater than 12.11.1.
