### PR TITLE
PP-6085 Add env-map buildpack

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -1,0 +1,5 @@
+env_vars:
+  ADMINUSERS_URL:  '."user-provided"[0].credentials.adminusers_url'
+  CARDID_HOST: '."user-provided"[0].credentials.cardid_url'
+  CONNECTOR_HOST: '."user-provided"[0].credentials.card_connector_url'
+  FRONTEND_URL: '."user-provided"[0].credentials.card_frontend_url'

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,22 +2,25 @@
 applications:
   - name: card-frontend
     buildpacks:
+      - https://github.com/alphagov/env-map-buildpack.git#v1
       - nodejs_buildpack
     health-check-type: http
     health-check-http-endpoint: '/healthcheck'
     health-check-invocation-timeout: 5
     memory: ((memory))
     disk_quota: ((disk_quota))
+    services:
+      - app-catalog
     command: npm start
     env:
       NODE_ENV: production
       SESSION_ENCRYPTION_KEY: ((card_frontend_session_encryption_key))
       COOKIE_MAX_AGE: '5400000'
-      CONNECTOR_HOST: ((card_connector_url))
       ANALYTICS_TRACKING_ID: ((card_connector_analytics_tracking_id))
-      CARDID_HOST: ((cardid_url))
       NODE_WORKER_COUNT: '1'
-      FRONTEND_URL: https://((card_frontend_url))
-      ADMINUSERS_URL: ((adminusers_url))
-    routes:
-      - route: ((card_frontend_url))
+
+      # These are taken via bound service, see `env-map.yml`
+      ADMINUSERS_URL: ""
+      CARDID_HOST: ""
+      CONNECTOR_HOST: ""
+      FRONTEND_URL: ""


### PR DESCRIPTION
Add a build pack that extracts values from within VCAP_SERVICES which is
where the credentials from bound services will be provided to the app
running on PaaS. Using this buildpack means we do not need to alter how
our app works, but rather provide a mapping from the VCAP_SERVICES var to its
current name.

## WHAT
Tested by pushing manually to staging and the correct vars are set.
```
GDS5062 > cf ssh card-frontend -c "/tmp/lifecycle/shell /home/vcap/app 'env | sort'" | grep URL
ADMINUSERS_URL=http://adminusers-stg.apps.internal:8080
FRONTEND_URL=https://card-frontend.staging.gdspay.uk
GDS5062 > cf ssh card-frontend -c "/tmp/lifecycle/shell /home/vcap/app 'env | sort'" | grep HOST
CARDID_HOST=http://cardid-stg.apps.internal:8080
CONNECTOR_HOST=http://card-connector-stg.apps.internal:8080
```

