### PR TITLE
PP-6079 Don't collect billing address for moto payments

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -122,7 +122,7 @@ module.exports = {
     const cardModel = Card(req.chargeData.gateway_account.card_types, req.chargeData.gateway_account.block_prepaid_cards, req.headers[CORRELATION_HEADER])
     const chargeOptions = {
       email_collection_mode: charge.gatewayAccount.emailCollectionMode,
-      collect_billing_address: res.locals.service.collectBillingAddress
+      collect_billing_address: res.locals.collectBillingAddress
     }
     const validator = chargeValidator(i18n.__('fieldErrors'), logger, cardModel, chargeOptions, getLoggingFields(req))
 

--- a/app/middleware/resolve_service.js
+++ b/app/middleware/resolve_service.js
@@ -25,6 +25,7 @@ module.exports = function resolveServiceMiddleware (req, res, next) {
   const cachedService = serviceCache.get(gatewayAccountId)
   if (cachedService) {
     res.locals.service = cachedService
+    res.locals.collectBillingAddress = res.locals.service.collectBillingAddress && !req.chargeData.moto
     next()
   } else {
     // @FIXME(sfount) tests shouldn't rely on middleware returning a value if
@@ -34,6 +35,7 @@ module.exports = function resolveServiceMiddleware (req, res, next) {
       .then(service => {
         serviceCache.put(gatewayAccountId, service, SERVICE_CACHE_MAX_AGE)
         res.locals.service = service
+        res.locals.collectBillingAddress = res.locals.service.collectBillingAddress && !req.chargeData.moto
         next()
       })
       .catch((err) => {

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -272,7 +272,7 @@
           </span>
           <img src="/images/amex-security-code.png" class="amex-cvc hidden" alt="{{ __p("cardDetails.amexcvcTip") }}"/>
         </div>
-        {% if service.collectBillingAddress %}
+        {% if collectBillingAddress %}
           <div class="govuk-form-group govuk-!-width-three-quarters govuk-!-padding-top-4 govuk-!-margin-top-8 pay-!-border-top {% if highlightErrorFields.addressCountry %} govuk-form-group--error{% endif %}" data-validation="addressCountry">
             <legend for="address-country" class="govuk-!-margin-bottom-6">
               <h2 class="govuk-heading-m govuk-!-margin-bottom-1">{{ __p("cardDetails.billingAddress") }}</h2>

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -30,7 +30,7 @@
   };
   window.Charge = {
     email_collection_mode: '{{ gatewayAccount.emailCollectionMode | safe }}',
-    collect_billing_address: {{ "true" if service.collectBillingAddress else "false" }},
+    collect_billing_address: {{ "true" if collectBillingAddress else "false" }},
     worldpay_3ds_flex_ddc_jwt: '{{ worldpay3dsFlexDdcJwt }}',
     worldpay_3ds_flex_ddc_url: '{{ worldpay3dsFlexDdcUrl }}'
   }
@@ -41,7 +41,7 @@
     if (mainWrap.classList.contains('charge-new')) {
       window.payScripts.helpers.setGlobalChargeId();
       showCardType().init();
-      {% if service.collectBillingAddress %}
+      {% if collectBillingAddress %}
         window.payScripts.helpers.initialiseAddressCountryAutocomplete();
       {% endif %}
       window.payScripts.inputConfirm.init();

--- a/test/charge_ui_tests.js
+++ b/test/charge_ui_tests.js
@@ -41,7 +41,7 @@ const generateConfirmViewTemplateData = (templateData = {}) => {
 describe('The charge view', function () {
   it('should render the amount', function () {
     const templateData = {
-      'amount': '50.00'
+      amount: '50.00'
     }
 
     const body = renderTemplate('charge', templateData)
@@ -51,7 +51,7 @@ describe('The charge view', function () {
   it('should have a submit form.', function () {
     const postAction = '/post_card_path'
     const templateData = {
-      'post_card_action': postAction
+      post_card_action: postAction
     }
 
     const body = renderTemplate('charge', templateData)
@@ -72,9 +72,7 @@ describe('The charge view', function () {
   it('should show all input fields.', function () {
     const body = renderTemplate('charge', {
       id: '1234',
-      service: {
-        collectBillingAddress: true
-      }
+      collectBillingAddress: true
     })
     body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
     body.should.containInputWithIdAndName('card-no', 'cardNo', 'text').withAttribute('maxlength', '26').withLabel('card-no-lbl', 'Card number')
@@ -91,30 +89,8 @@ describe('The charge view', function () {
     body.should.not.containSelector('.custom-branding-image')
   })
 
-  it('should not show billing address for services not wanting to capture it', function () {
-    const body = renderTemplate('charge', {
-      id: '1234',
-      service: {
-        collectBillingAddress: false
-      }
-    })
-    body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
-    body.should.containInputWithIdAndName('card-no', 'cardNo', 'text').withAttribute('maxlength', '26').withLabel('card-no-lbl', 'Card number')
-    body.should.containInputWithIdAndName('cvc', 'cvc', 'text').withLabel('cvc-lbl', 'Card security code')
-    body.should.containInputWithIdAndName('expiry-month', 'expiryMonth', 'text')
-    body.should.containInputWithIdAndName('expiry-year', 'expiryYear', 'text')
-    body.should.containInputWithIdAndName('cardholder-name', 'cardholderName', 'text').withAttribute('maxlength', '200').withLabel('cardholder-name-lbl', 'Name on card')
-    body.should.not.containSelector('#address-country')
-    body.should.not.containSelector('#address-line-1')
-    body.should.not.containSelector('#address-line-2')
-    body.should.not.containSelector('#address-city')
-    body.should.not.containSelector('#address-postcode')
-    body.should.containInputWithIdAndName('charge-id', 'chargeId', 'hidden').withAttribute('value', '1234')
-    body.should.not.containSelector('.custom-branding-image')
-  })
-
   it('should display custom branding', () => {
-    const templateData = lodash.merge('charge', { 'id': '1234' }, customBrandingData)
+    const templateData = lodash.merge('charge', { id: '1234' }, customBrandingData)
     const body = renderTemplate('charge', templateData)
     body.should.containSelector('.custom-branding-image')
 
@@ -133,9 +109,7 @@ describe('The charge view', function () {
       addressLine2: 'blah blah',
       addressCity: 'Leicester City',
       addressPostcode: 'CT16 1FB',
-      service: {
-        collectBillingAddress: true
-      }
+      collectBillingAddress: true
     }
     const body = renderTemplate('charge', responseData)
 
@@ -164,28 +138,6 @@ describe('The confirm view', function () {
     body.should.containSelector('#address').withText('1 street lane, avenue city, AB1 3DF')
   })
 
-  it('should not show billing address for services not wanting to capture it', function () {
-    const body = renderTemplate('confirm', generateConfirmViewTemplateData({
-      service: {
-        collectBillingAddress: false
-      },
-      charge: {
-        cardDetails: {
-          billingAddress: null
-        }
-      }
-    }))
-    const $ = cheerio.load(body)
-    $('#payment-description').html().should.contain('Payment Description &amp; &lt;xss attack&gt; assessment')
-    body.should.containInputWithIdAndName('csrf', 'csrfToken', 'hidden')
-    body.should.containSelector('#card-number').withText('●●●●●●●●●●●●5100')
-    body.should.containSelector('#expiry-date').withText('11/99')
-    body.should.containSelector('#cardholder-name').withText('Francisco Blaya-Gonzalvez')
-    body.should.not.containSelector('#address').withText('1 street lane, avenue city, AB1 3DF')
-    body.should.containSelector('#payment-description').withText('Payment Description')
-    body.should.containSelector('#amount').withText('£10.00')
-  })
-
   it('should display custom branding', () => {
     const templateData = lodash.merge(successTemplateDataWithCollectBillingAddress, customBrandingData)
     const body = renderTemplate('confirm', templateData)
@@ -199,7 +151,7 @@ describe('The confirm view', function () {
   })
 
   it('should render a confirm button', function () {
-    const body = renderTemplate('confirm', { confirmPath: '/card_details/123/confirm', 'charge': { id: 1234, amount: 50 } })
+    const body = renderTemplate('confirm', { confirmPath: '/card_details/123/confirm', charge: { id: 1234, amount: 50 } })
     const $ = cheerio.load(body)
     body.should.containSelector('form#confirmation').withAttributes(
       {
@@ -213,7 +165,7 @@ describe('The confirm view', function () {
   it('should have a cancel form.', function () {
     const postAction = '/post_cancel_path'
     const templateData = {
-      'post_cancel_action': postAction
+      post_cancel_action: postAction
     }
 
     const body = renderTemplate('charge', templateData)

--- a/test/cypress/integration/card/billing-address-collection.spec.js
+++ b/test/cypress/integration/card/billing-address-collection.spec.js
@@ -1,0 +1,142 @@
+const lodash = require('lodash')
+const cardPaymentStubs = require('../../utils/card-payment-stubs')
+
+const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
+const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
+
+const validPayment = {
+  cardNumber: '4444333322221111',
+  expiryMonth: '01',
+  expiryYear: '30',
+  name: 'Valid Paying Name',
+  securityCode: '012',
+  email: 'foo@example.com',
+  noBillingAddress: true
+}
+
+describe('Billing address collection', () => {
+  describe('Billing address collection enabled for service', () => {
+    // get a random gateway account per test as service is cached against gateway account
+    const gatewayAccountId = lodash.random(999999999)
+    const serviceOpts = { collect_billing_address: true }
+    const chargeOpts = { moto: false }
+    const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(
+      tokenId, chargeId, 'en', gatewayAccountId, serviceOpts, {}, {}, chargeOpts)
+
+    it('Should show the billing address section', () => {
+      cy.task('setupStubs', createPaymentChargeStubs)
+      cy.visit(`/secure/${tokenId}`)
+
+      cy.get('h2').contains('Billing address').should('exist')
+      cy.get('#address-country-select').should('exist')
+      cy.get('#address-line-1').should('exist')
+      cy.get('#address-line-2').should('exist')
+      cy.get('#address-city').should('exist')
+      cy.get('#address-postcode').should('exist')
+    })
+  })
+
+  describe('Billing address collection disabled for service', () => {
+    // get a random gateway account per test as service is cached against gateway account
+    const gatewayAccountId = lodash.random(999999999)
+    const serviceOpts = { collect_billing_address: false }
+    const chargeOpts = { moto: false }
+    const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(
+      tokenId, chargeId, 'en', gatewayAccountId, serviceOpts, {}, {}, chargeOpts)
+
+    beforeEach(() => {
+      // preserve cookies so we can prodeed with payment flow
+      Cypress.Cookies.preserveOnce('frontend_state')
+    })
+
+    it('Should not show the billing address section', () => {
+      cy.task('setupStubs', createPaymentChargeStubs)
+      cy.visit(`/secure/${tokenId}`)
+
+      cy.get('h2').contains('Billing address').should('not.exist')
+      cy.get('#address-country-select').should('not.exist')
+      cy.get('#address-line-1').should('not.exist')
+      cy.get('#address-line-2').should('not.exist')
+      cy.get('#address-city').should('not.exist')
+      cy.get('#address-postcode').should('not.exist')
+    })
+
+    it('Should enter card details', () => {
+      const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
+      cy.task('setupStubs', checkCardDetailsStubs)
+
+      cy.server()
+      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.get('#card-no').type(validPayment.cardNumber)
+      cy.get('#card-no').blur()
+      cy.wait('@checkCard')
+      cy.get('#expiry-month').type(validPayment.expiryMonth)
+      cy.get('#expiry-year').type(validPayment.expiryYear)
+      cy.get('#cardholder-name').type(validPayment.name)
+      cy.get('#cvc').type(validPayment.securityCode)
+      cy.get('#email').type(validPayment.email)
+    })
+
+    it('Submitting confirmation with valid details should redirect to confirmation page', () => {
+      const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment, gatewayAccountId, chargeOpts, serviceOpts)
+      cy.task('setupStubs', confirmPaymentDetailsStubs)
+      cy.get('#card-details').submit()
+      cy.location('pathname').should('eq', `/card_details/${chargeId}/confirm`)
+
+      cy.get('th').contains('Billing address').should('not.exist')
+    })
+  })
+
+  describe('MOTO payment with billing address enabled for service', () => {
+    // get a random gateway account per test as service is cached against gateway account
+    const gatewayAccountId = lodash.random(999999999)
+    const serviceOpts = { collect_billing_address: true }
+    const chargeOpts = { moto: true }
+    const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(
+      tokenId, chargeId, 'en', gatewayAccountId, serviceOpts, {}, {}, chargeOpts)
+
+    beforeEach(() => {
+      // preserve cookies so we can proceed with payment flow
+      Cypress.Cookies.preserveOnce('frontend_state')
+    })
+
+    it('Should not show the billing address section', () => {
+      cy.task('setupStubs', createPaymentChargeStubs)
+      cy.visit(`/secure/${tokenId}`)
+
+      cy.get('h2').contains('Billing address').should('not.exist')
+      cy.get('#address-country-select').should('not.exist')
+      cy.get('#address-line-1').should('not.exist')
+      cy.get('#address-line-2').should('not.exist')
+      cy.get('#address-city').should('not.exist')
+      cy.get('#address-postcode').should('not.exist')
+    })
+
+    it('Should enter card details', () => {
+      const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
+      cy.task('setupStubs', checkCardDetailsStubs)
+
+      cy.server()
+      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.get('#card-no').type(validPayment.cardNumber)
+      cy.get('#card-no').blur()
+      cy.wait('@checkCard')
+      cy.get('#expiry-month').type(validPayment.expiryMonth)
+      cy.get('#expiry-year').type(validPayment.expiryYear)
+      cy.get('#cardholder-name').type(validPayment.name)
+      cy.get('#cvc').type(validPayment.securityCode)
+      cy.get('#email').type(validPayment.email)
+    })
+
+    it('Submitting confirmation with valid details should redirect to confirmation page', () => {
+      const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment, gatewayAccountId, chargeOpts, serviceOpts)
+      cy.task('setupStubs', confirmPaymentDetailsStubs)
+      cy.get('#card-details').submit()
+      cy.location('pathname').should('eq', `/card_details/${chargeId}/confirm`)
+
+      cy.get('th').contains('Billing address').should('not.exist')
+    })
+  })
+})

--- a/test/cypress/integration/card/email-collection.spec.js
+++ b/test/cypress/integration/card/email-collection.spec.js
@@ -3,6 +3,7 @@ const cardPaymentStubs = require('../../utils/card-payment-stubs')
 const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
 const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
 const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
+const gatewayAccountId = 42
 
 const validPayment = {
   cardNumber: '4444333322221111',
@@ -24,8 +25,8 @@ describe('Standard card payment flow', () => {
 
   describe('Email collection off', () => {
     const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(
-      tokenId, chargeId, 'en', 42, {}, {}, { emailCollectionMode: 'OFF' })
-    const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment, 'OFF')
+      tokenId, chargeId, 'en', gatewayAccountId, {}, {}, { emailCollectionMode: 'OFF' })
+    const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment, gatewayAccountId, { emailCollectionMode: 'OFF' })
 
     it('Should setup the payment and load the page', () => {
       cy.task('setupStubs', createPaymentChargeStubs)
@@ -66,8 +67,8 @@ describe('Standard card payment flow', () => {
   })
 
   describe('Email collection mandatory', () => {
-    const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', 42, {}, {})
-    const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment)
+    const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', gatewayAccountId, {}, {})
+    const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment, gatewayAccountId, { emailCollectionMode: 'MANDATORY' })
 
     it('Should setup the payment and load the page', () => {
       cy.task('setupStubs', createPaymentChargeStubs)
@@ -108,8 +109,8 @@ describe('Standard card payment flow', () => {
 
   describe('Email collection optional', () => {
     const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(
-      tokenId, chargeId, 'en', 42, {}, {}, { emailCollectionMode: 'OPTIONAL' })
-    const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment, 'OPTIONAL')
+      tokenId, chargeId, 'en', gatewayAccountId, {}, {}, { emailCollectionMode: 'OPTIONAL' })
+    const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment, gatewayAccountId, { emailCollectionMode: 'OPTIONAL' })
 
     it('Should setup the payment and load the page', () => {
       cy.task('setupStubs', createPaymentChargeStubs)

--- a/test/cypress/utils/card-payment-stubs.js
+++ b/test/cypress/utils/card-payment-stubs.js
@@ -1,17 +1,20 @@
 'use strict'
 
-const confirmPaymentDetailsStubs = function confirmPaymentDetailsStubs (chargeId, validPayment = {}, emailCollectionMode) {
+const confirmPaymentDetailsStubs = function confirmPaymentDetailsStubs (chargeId, validPayment = {}, gatewayAccountId = 42, additionalChargeOpts = {}, serviceOpts = {}) {
   return [
-    { name: 'adminUsersGetService', opts: {} },
+    { name: 'adminUsersGetService', opts: serviceOpts },
     {
       name: 'connectorMultipleSubsequentChargeDetails',
       opts: [{
+        ...additionalChargeOpts,
         chargeId,
+        gatewayAccountId,
         status: 'ENTERING CARD DETAILS',
-        state: { finished: false, status: 'started' },
-        emailCollectionMode: emailCollectionMode || 'MANDATORY'
+        state: { finished: false, status: 'started' }
       }, {
+        ...additionalChargeOpts,
         chargeId,
+        gatewayAccountId,
         paymentDetails: {
           cardNumber: validPayment.cardNumber,
           expiryMonth: validPayment.expiryMonth,
@@ -21,11 +24,11 @@ const confirmPaymentDetailsStubs = function confirmPaymentDetailsStubs (chargeId
           addressLine1: validPayment.addressLine1,
           city: validPayment.city,
           postcode: validPayment.postcode,
-          email: validPayment.email
+          email: validPayment.email,
+          noBillingAddress: validPayment.noBillingAddress
         },
         status: 'AUTHORISATION SUCCESS',
-        state: { finished: false, status: 'submitted' },
-        emailCollectionMode: emailCollectionMode || 'MANDATORY'
+        state: { finished: false, status: 'submitted' }
       }]
     },
     { name: 'cardIdValidCardDetails' },
@@ -33,12 +36,13 @@ const confirmPaymentDetailsStubs = function confirmPaymentDetailsStubs (chargeId
   ]
 }
 
-const checkCardDetailsStubs = function checkCardDetailsStubs (chargeId) {
+const checkCardDetailsStubs = function checkCardDetailsStubs (chargeId, gatewayAccountId = 42) {
   return [
     {
       name: 'connectorGetChargeDetails',
       opts: {
         chargeId,
+        gatewayAccountId,
         status: 'ENTERING CARD DETAILS',
         state: { finished: false, status: 'started' }
       }
@@ -68,7 +72,7 @@ const buildCancelChargeStub = function buildCancelChargeStub (chargeId, gatewayA
 }
 
 const buildCreatePaymentChargeStubs = function buildCreatePaymentChargeStubs (tokenId, chargeId, language = 'en', gatewayAccountId = 42,
-  serviceOpts = {}, providerOpts = {}, gatewayAccountOpts = {}) {
+  serviceOpts = {}, providerOpts = {}, gatewayAccountOpts = {}, additionalChargeOpts = {}) {
   return [
     {
       name: 'connectorCreateChargeFromToken',
@@ -83,6 +87,7 @@ const buildCreatePaymentChargeStubs = function buildCreatePaymentChargeStubs (to
     {
       name: 'connectorGetChargeDetails',
       opts: {
+        ...additionalChargeOpts,
         chargeId,
         gatewayAccountId,
         status: 'CREATED',

--- a/test/fixtures/payment_fixtures.js
+++ b/test/fixtures/payment_fixtures.js
@@ -117,16 +117,20 @@ const utilFormatPaymentDetails = function utilFormatPaymentDetails (details) {
     first_digits_card_number: details.cardNumber.substr(6),
     cardholder_name: details.name,
     expiry_date: `${details.expiryMonth}/${details.expiryYear}`,
-    billing_address: {
+    card_brand: 'Visa'
+  }
+
+  if (!details.noBillingAddress) {
+    structure.billing_address = {
       line1: details.addressLine1,
-      line2: '',
+      line2: details.addressLine2 || '',
       postcode: details.postcode,
       city: details.city,
       county: null,
-      country: 'GB'
-    },
-    card_brand: 'Visa'
+      country: details.country || 'GB'
+    }
   }
+
   return structure
 }
 
@@ -182,6 +186,7 @@ const buildChargeDetails = function buildChargeDetails (opts) {
     return_url: opts.returnUrl || '/?confirm',
     created_date: '2019-02-12T17:53:31.307Z',
     delayed_capture: false,
+    moto: opts.moto || false,
     gateway_account: buildGatewayAccount(opts)
   }
 
@@ -231,6 +236,7 @@ const buildChargeDetailsWithPrefilledCardHolderDeatils = (opts) => {
     return_url: opts.returnUrl || '/?confirm',
     // 'created_date': '2019-02-12T17:53:31.307Z',
     delayed_capture: false,
+    moto: opts.moto || false,
     gateway_account: buildGatewayAccount(opts)
   }
 
@@ -285,6 +291,7 @@ const fixtures = {
         status: opts.status || 'CREATED',
         version: 1,
         walletType: null,
+        moto: opts.moto || false,
         events: [{
           gatewayEventDate: null,
           status: 'CREATED',


### PR DESCRIPTION
Currently, we don't show fields to collect the billing address on the card details page if billing address collection is disabled for the service.

Now, we also won't show these fields if a payment is a MOTO payment even if billing address collection is enabled for the service. Determine whether we should collect the address in the resolve_service middleware and add a field to res.locals so that we can access it in all templates
and controllers that need this value.

Add Cypress tests to test this and remove tests from charge_ui_tests which are now better covered by Cypress tests.
