### PR TITLE
PP-6127 Add frontend secret service

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -1,5 +1,7 @@
 env_vars:
-  ADMINUSERS_URL:  '."user-provided"[0].credentials.adminusers_url'
-  CARDID_HOST: '."user-provided"[0].credentials.cardid_url'
-  CONNECTOR_HOST: '."user-provided"[0].credentials.card_connector_url'
-  FRONTEND_URL: '."user-provided"[0].credentials.card_frontend_url'
+  ADMINUSERS_URL:         '.[][] | select(.name == "app-catalog") | .credentials.adminusers_url'
+  CARDID_HOST:            '.[][] | select(.name == "app-catalog") | .credentials.cardid_url'
+  CONNECTOR_HOST:         '.[][] | select(.name == "app-catalog") | .credentials.card_connector_url'
+  FRONTEND_URL:           '.[][] | select(.name == "app-catalog") | .credentials.card_frontend_url'
+  SESSION_ENCRYPTION_KEY: '.[][] | select(.name == "card-frontend-secret-service") | .credentials.card_frontend_session_encryption_key'
+  ANALYTICS_TRACKING_ID:  '.[][] | select(.name == "card-frontend-secret-service") | .credentials.card_frontend_analytics_tracking_id'

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,12 +11,11 @@ applications:
     disk_quota: ((disk_quota))
     services:
       - app-catalog
+      - card-frontend-secret-service
     command: npm start
     env:
       NODE_ENV: production
-      SESSION_ENCRYPTION_KEY: ((card_frontend_session_encryption_key))
       COOKIE_MAX_AGE: '5400000'
-      ANALYTICS_TRACKING_ID: ((card_connector_analytics_tracking_id))
       NODE_WORKER_COUNT: '1'
 
       # These are taken via bound service, see `env-map.yml`
@@ -24,3 +23,7 @@ applications:
       CARDID_HOST: ""
       CONNECTOR_HOST: ""
       FRONTEND_URL: ""
+
+      # These are provided via bound card-frontend-secret-service, see `env-map.yml`
+      SESSION_ENCRYPTION_KEY: ""
+      ANALYTICS_TRACKING_ID: ""


### PR DESCRIPTION
Env vars which are specific to card-frontend and differ by environment
are to be provided via the card-frontend-secret-service. The mapping
between these vars and their keys within the vars returned by
card-frontend-secret-service are defined within env-map.yml.
