### PR TITLE
PP-6191 Product Pages - Fix typo in copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15458,8 +15458,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.0.5/pay-product-page-4.0.5.tgz",
-      "integrity": "sha512-YinqCdOXJ3/q2Vj1u9sTK6F7EpdDD06qL45Ocm8RMKnS475SN4u78lgtV66gyfZGL8X4CaP+faxGT6a5pC3eHQ==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.0.6/pay-product-page-4.0.6.tgz",
+      "integrity": "sha512-0kS0e+ubMMJao1rYOJ8bCW0syvVsYCGX8G7pVE5QIp8oq4xFlBZRReZ1FB9A8KIoUcTGHpHZZnzSEFj+cSqx6g==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "nodemon": "^2.0.2",
     "nyc": "15.0.x",
     "pact": "4.3.2",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.0.5/pay-product-page-4.0.5.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.0.6/pay-product-page-4.0.6.tgz",
     "proxyquire": "~2.1.3",
     "sass-lint": "^1.13.1",
     "sinon": "8.1.x",


### PR DESCRIPTION
- Update Product Page module to use v4.0.6 which fixes the typo.


