### PR TITLE
BAU Bump pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2305,9 +2305,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.25.0.tgz",
-      "integrity": "sha512-89MvXzEFj2UmuvetDZmyERqvYZ8Wgi4rOhHtqnDDtbpZeTB+SBbnGr+KVSAT5ay4mbkW3QLXHJ9hEeTxb0oKfg==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.26.0.tgz",
+      "integrity": "sha512-pykSzyjBmmhLh5DvZw8AvUCd3He6PJsGBg8B53GzoyQbhIBSQ0jlP32h1ebOuO79v7dF2vlIK6kbiMgBrRr/XQ==",
       "requires": {
         "lodash": "4.17.15",
         "moment-timezone": "0.5.28",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "2.25.0",
+    "@govuk-pay/pay-js-commons": "2.26.0",
     "@sentry/node": "5.13.1",
     "appmetrics": "5.1.1",
     "appmetrics-statsd": "3.0.0",


### PR DESCRIPTION
- Bump `pay-js-commons` from 2.25.0 > 2.26.0
