### PR TITLE
PP-6254: Add carbon relay config

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -3,6 +3,8 @@ env_vars:
   CARDID_HOST:                     '.[][] | select(.name == "app-catalog") | .credentials.cardid_url'
   CONNECTOR_HOST:                  '.[][] | select(.name == "app-catalog") | .credentials.card_connector_url'
   FRONTEND_URL:                    '.[][] | select(.name == "app-catalog") | .credentials.card_frontend_url'
+  METRICS_HOST:                    '.[][] | select(.name == "app-catalog") | .credentials.carbon_relay_route'
+  METRICS_PORT:                    '.[][] | select(.name == "app-catalog") | .credentials.carbon_relay_port'
   SESSION_ENCRYPTION_KEY:          '.[][] | select(.name == "card-frontend-secret-service") | .credentials.card_frontend_session_encryption_key'
   ANALYTICS_TRACKING_ID:           '.[][] | select(.name == "card-frontend-secret-service") | .credentials.card_frontend_analytics_tracking_id'
   DECRYPT_CARD_DATA_PRIVATE_KEY:   '.[][] | select(.name == "card-frontend-secret-service") | .credentials.field_level_encryption_private_key'

--- a/manifest.yml
+++ b/manifest.yml
@@ -18,11 +18,13 @@ applications:
       COOKIE_MAX_AGE: '5400000'
       NODE_WORKER_COUNT: '1'
 
-      # These are taken via bound service, see `env-map.yml`
+      # These are provided by app-catalog, see `env-map.yml`
       ADMINUSERS_URL: ""
       CARDID_HOST: ""
       CONNECTOR_HOST: ""
       FRONTEND_URL: ""
+      METRICS_HOST: ""
+      METRICS_PORT: ""
 
       # These are provided via bound card-frontend-secret-service, see `env-map.yml`
       SESSION_ENCRYPTION_KEY: ""


### PR DESCRIPTION
Set the `METRICS_HOST` and `METRICS_PORT` from the app-catalog to send
metrics to the carbon-relay app.


