### PR TITLE
PP-6194 Log when there is an error redirecting to 3DS

### DIFF
--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -122,6 +122,7 @@ module.exports = {
     } else if (issuerUrl) {
       res.redirect(303, issuerUrl)
     } else {
+      logger.error('3DS data is missing for charge, unable to begin 3DS', getLoggingFields(req))
       responseRouter.response(req, res, 'ERROR', withAnalytics(charge))
     }
   },


### PR DESCRIPTION
We've noticed several ePDQ payments are dropping out when redirecting to the `3ds_required_out` route in frontend. There's nothing in the logs to suggest what might be happening here, so log an error when this happens.

If it is dropping out at this point it's probably because we aren't handling an authorisation response from ePDQ correctly (or maybe there's an issue on their end).

