### PR TITLE
PP-6259 Make frontend send user to do 3DS again if necessary

### DIFF
--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -52,7 +52,12 @@ const handleThreeDsResponse = (req, res, charge) => response => {
   switch (response.statusCode) {
     case 200:
     case 400:
-      redirect(res).toConfirm(charge.id)
+      if (_.get(response, 'body.status', '') === 'AUTHORISATION 3DS REQUIRED') {
+        logger.info('3DS required again', getLoggingFields(req))
+        redirect(res).toAuth3dsRequired(charge.id)
+      } else {
+        redirect(res).toConfirm(charge.id)
+      }
       break
     case 202:
     case 409:

--- a/test/integration/three_d_secure_ft_tests.js
+++ b/test/integration/three_d_secure_ft_tests.js
@@ -395,6 +395,19 @@ describe('chargeTests', function () {
         .end(done)
     })
 
+    it('should send 3ds data to connector and redirect to 3ds required if connector says so', function (done) {
+      const cookieValue = cookie.create(chargeId)
+      nock(process.env.CONNECTOR_HOST)
+        .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
+        .post(`${connectorChargePath}${chargeId}/3ds`, { pa_response: 'aPaResponse' }).reply(400, { status: 'AUTHORISATION 3DS REQUIRED' })
+      defaultAdminusersResponseForGetService(gatewayAccountId)
+
+      postChargeRequest(app, cookieValue, { PaRes: 'aPaResponse' }, chargeId, true, '/3ds_handler')
+        .expect(303)
+        .expect('Location', `${frontendCardDetailsPath}/${chargeId}/3ds_required`)
+        .end(done)
+    })
+
     it('should send 3ds data to connector and redirect to auth_waiting if connector returns a 202', function (done) {
       const cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)


### PR DESCRIPTION
When frontend calls connector to authorise a 3D Secure result with the payment gateway, redirect the user to the 3DS Secure page again if connector’s response indicates that this is required.

Connector indicates this by sending a response body of `{"status": "AUTHORISATION 3DS REQUIRED"}` when `/v1/frontend/charges/{chargeId}/3ds` is called (this isn’t actually implemented in connector yet but will be soon).

with @SandorArpa