### PR TITLE
PP-6240 Log all times we show error page

### DIFF
--- a/app/utils/response_router.js
+++ b/app/utils/response_router.js
@@ -28,7 +28,7 @@ const systemError = {
   view: 'errors/system_error',
   analyticsPage: '/error',
   terminal: true,
-  logErrorPageShown: true
+  shouldLogErrorPageShown: true
 }
 
 const error = {
@@ -39,7 +39,7 @@ const error = {
   },
   analyticsPage: '/error',
   terminal: true,
-  logErrorPageShown: true
+  shouldLogErrorPageShown: true
 }
 
 const actions = {
@@ -91,7 +91,7 @@ const actions = {
       message: 'There is a problem, please try again later'
     },
     terminal: true,
-    logErrorPageShown: true
+    shouldLogErrorPageShown: true
   },
 
   SESSION_INCORRECT: {
@@ -110,7 +110,7 @@ const actions = {
       message: 'Please try again later'
     },
     terminal: true,
-    logErrorPageShown: true
+    shouldLogErrorPageShown: true
   },
 
   HUMANS: {
@@ -213,7 +213,7 @@ const actions = {
     view: 'errors/system_error',
     analyticsPage: '/error',
     terminal: true,
-    logErrorPageShown: true
+    shouldLogErrorPageShown: true
   },
 
   AUTHORISATION_READY: {
@@ -259,7 +259,7 @@ exports.response = function response (req, res, actionName, options) {
   let action = lodash.result(actions, actionName)
 
   if (action) {
-    if (action.logErrorPageShown) {
+    if (action.shouldLogErrorPageShown) {
       logErrorPageShown(action.view, `Action: ${actionName}`, getLoggingFields(req))
     }
   } else {

--- a/app/utils/response_router.js
+++ b/app/utils/response_router.js
@@ -27,7 +27,8 @@ const systemError = {
   code: 500,
   view: 'errors/system_error',
   analyticsPage: '/error',
-  terminal: true
+  terminal: true,
+  logErrorPageShown: true
 }
 
 const error = {
@@ -37,7 +38,8 @@ const error = {
     message: 'There is a problem, please try again later'
   },
   analyticsPage: '/error',
-  terminal: true
+  terminal: true,
+  logErrorPageShown: true
 }
 
 const actions = {
@@ -88,7 +90,8 @@ const actions = {
     locals: {
       message: 'There is a problem, please try again later'
     },
-    terminal: true
+    terminal: true,
+    logErrorPageShown: true
   },
 
   SESSION_INCORRECT: {
@@ -106,7 +109,8 @@ const actions = {
     locals: {
       message: 'Please try again later'
     },
-    terminal: true
+    terminal: true,
+    logErrorPageShown: true
   },
 
   HUMANS: {
@@ -208,7 +212,8 @@ const actions = {
   AUTHORISATION_ERROR: {
     view: 'errors/system_error',
     analyticsPage: '/error',
-    terminal: true
+    terminal: true,
+    logErrorPageShown: true
   },
 
   AUTHORISATION_READY: {
@@ -234,35 +239,47 @@ const actions = {
   }
 }
 
-exports.errorResponse = function errorReponse (req, res, reason, options, error) {
-  logger.error('Rendering error response', {
-    page: 'ERROR',
-    reason,
-    error,
-    ...getLoggingFields(req)
-  })
-  this.response(req, res, 'ERROR', options)
+exports.errorResponse = function errorReponse (req, res, reason, options = {}, error) {
+  const action = actions.ERROR
+  logErrorPageShown(action.view, reason, getLoggingFields(req), error)
+  options.viewName = 'ERROR'
+  redirectOrRender(req, res, actions.ERROR, options)
 }
 
-exports.systemErrorResponse = function systemErrorResponse (req, res, reason, options, error) {
-  logger.error('Rendering error response', {
-    page: 'SYSTEM_ERROR',
-    reason,
-    error,
-    ...getLoggingFields(req)
-  })
-  this.response(req, res, 'SYSTEM_ERROR', options)
+exports.systemErrorResponse = function systemErrorResponse (req, res, reason, options = {}, error) {
+  const action = actions.SYSTEM_ERROR
+  logErrorPageShown(action.view, reason, getLoggingFields(req), error)
+  options.viewName = 'SYSTEM_ERROR'
+  redirectOrRender(req, res, actions.SYSTEM_ERROR, options)
 }
 
 exports.response = function response (req, res, actionName, options) {
   options = options || {}
   options.viewName = actionName
   let action = lodash.result(actions, actionName)
-  if (!action) {
-    logger.error('Response action ' + actionName + ' NOT FOUND', getLoggingFields(req))
+
+  if (action) {
+    if (action.logErrorPageShown) {
+      logErrorPageShown(action.view, `Action: ${actionName}`, getLoggingFields(req))
+    }
+  } else {
     options = { viewName: 'error' }
     action = actions.ERROR
+    logErrorPageShown(action.view, `Response action ${actionName} NOT FOUND`, getLoggingFields(req))
   }
+  redirectOrRender(req, res, action, options)
+}
+
+function logErrorPageShown (page, reason, loggingFields, error) {
+  logger.error('Rendering error response', {
+    page,
+    reason,
+    error,
+    ...loggingFields
+  })
+}
+
+function redirectOrRender (req, res, action, options) {
   if (shouldRedirect(req, res, action)) {
     res.redirect(req.chargeData.return_url)
   } else {

--- a/test/controllers/secure_controller_test.js
+++ b/test/controllers/secure_controller_test.js
@@ -72,7 +72,7 @@ const requireSecureController = function (mockedCharge, mockedToken, mockedRespo
     '../utils/response_router': mockedResponseRouter,
     '../models/charge.js': mockedCharge,
     '../models/token.js': mockedToken,
-    'csrf': function () {
+    csrf: function () {
       return {
         secretSync: function () {
           return 'foo'
@@ -103,21 +103,22 @@ describe('secure controller', function () {
       }
 
       chargeObject = {
-        'used': false,
-        'charge': {
-          'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
-          'status': 'CREATED',
-          'gatewayAccount': {
-            'service_name': 'Service Name',
-            'analytics_id': 'bla-1234',
-            'type': 'live',
-            'payment_provider': 'worldpay'
+        used: false,
+        charge: {
+          externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
+          status: 'CREATED',
+          gatewayAccount: {
+            service_name: 'Service Name',
+            analytics_id: 'bla-1234',
+            type: 'live',
+            payment_provider: 'worldpay'
           }
         }
       }
 
       responseRouter = {
-        response: sinon.spy()
+        response: sinon.spy(),
+        systemErrorResponse: sinon.spy()
       }
     })
 
@@ -132,7 +133,7 @@ describe('secure controller', function () {
       describe('and not marked as used successfully', function () {
         it('should display the generic error page', async function () {
           await requireSecureController(mockCharge.withSuccess(), mockToken.withFailure(), responseRouter).new(request, response)
-          expect(responseRouter.response.calledWith(request, response, 'SYSTEM_ERROR', withAnalyticsError())).to.be.true // eslint-disable-line
+          expect(responseRouter.systemErrorResponse.calledWith(request, response, 'Error exchanging payment token', withAnalyticsError())).to.be.true // eslint-disable-line
         })
       })
 
@@ -141,8 +142,8 @@ describe('secure controller', function () {
           await requireSecureController(mockCharge.withSuccess(chargeObject), mockToken.withSuccess(), responseRouter).new(request, response)
           expect(response.redirect.calledWith(303, paths.generateRoute('card.new', { chargeId: chargeObject.charge.externalId }))).to.be.true // eslint-disable-line
           expect(request.frontend_state).to.have.all.keys('ch_dh6kpbb4k82oiibbe4b9haujjk')
-          expect(request.frontend_state['ch_dh6kpbb4k82oiibbe4b9haujjk']).to.eql({
-            'csrfSecret': 'foo'
+          expect(request.frontend_state.ch_dh6kpbb4k82oiibbe4b9haujjk).to.eql({
+            csrfSecret: 'foo'
           })
         })
       })
@@ -155,15 +156,15 @@ describe('secure controller', function () {
             headers: { 'x-Request-id': 'unique-id' }
           }
           const charge = {
-            'used': true,
-            'charge': {
-              'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
-              'status': 'AUTHORISATION SUCCESS',
-              'gatewayAccount': {
-                'service_name': 'Service Name',
-                'analytics_id': 'bla-1234',
-                'type': 'live',
-                'payment_provider': 'worldpay'
+            used: true,
+            charge: {
+              externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
+              status: 'AUTHORISATION SUCCESS',
+              gatewayAccount: {
+                service_name: 'Service Name',
+                analytics_id: 'bla-1234',
+                type: 'live',
+                payment_provider: 'worldpay'
               }
             }
           }
@@ -179,15 +180,15 @@ describe('secure controller', function () {
             headers: { 'x-Request-id': 'unique-id' }
           }
           const charge = {
-            'used': true,
-            'charge': {
-              'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
-              'status': 'AUTHORISATION SUCCESS',
-              'gatewayAccount': {
-                'service_name': 'Service Name',
-                'analytics_id': 'bla-1234',
-                'type': 'live',
-                'payment_provider': 'worldpay'
+            used: true,
+            charge: {
+              externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
+              status: 'AUTHORISATION SUCCESS',
+              gatewayAccount: {
+                service_name: 'Service Name',
+                analytics_id: 'bla-1234',
+                type: 'live',
+                payment_provider: 'worldpay'
               }
             }
           }
@@ -200,23 +201,23 @@ describe('secure controller', function () {
         it('should display the "Your payment session has expired" page', async function () {
           const requestWithWrongCookie = {
             frontend_state: {
-              'ch_xxxx': {
-                'csrfSecret': 'foo'
+              ch_xxxx: {
+                csrfSecret: 'foo'
               }
             },
             params: { chargeTokenId: 1 },
             headers: { 'x-Request-id': 'unique-id' }
           }
           const charge = {
-            'used': true,
-            'charge': {
-              'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
-              'status': 'AUTHORISATION SUCCESS',
-              'gatewayAccount': {
-                'service_name': 'Service Name',
-                'analytics_id': 'bla-1234',
-                'type': 'live',
-                'payment_provider': 'worldpay'
+            used: true,
+            charge: {
+              externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
+              status: 'AUTHORISATION SUCCESS',
+              gatewayAccount: {
+                service_name: 'Service Name',
+                analytics_id: 'bla-1234',
+                type: 'live',
+                payment_provider: 'worldpay'
               }
             }
           }
@@ -229,23 +230,23 @@ describe('secure controller', function () {
         it('should redirect to the appropriate page based on the charge state', async function () {
           const requestWithFrontendStateCookie = {
             frontend_state: {
-              'ch_dh6kpbb4k82oiibbe4b9haujjk': {
-                'csrfSecret': 'foo'
+              ch_dh6kpbb4k82oiibbe4b9haujjk: {
+                csrfSecret: 'foo'
               }
             },
             params: { chargeTokenId: 1 },
             headers: { 'x-Request-id': 'unique-id' }
           }
           const charge = {
-            'used': true,
-            'charge': {
-              'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
-              'status': 'AUTHORISATION SUCCESS',
-              'gatewayAccount': {
-                'service_name': 'Service Name',
-                'analytics_id': 'bla-1234',
-                'type': 'live',
-                'payment_provider': 'worldpay'
+            used: true,
+            charge: {
+              externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
+              status: 'AUTHORISATION SUCCESS',
+              gatewayAccount: {
+                service_name: 'Service Name',
+                analytics_id: 'bla-1234',
+                type: 'live',
+                payment_provider: 'worldpay'
               }
             }
           }
@@ -256,8 +257,8 @@ describe('secure controller', function () {
           }
           expect(responseRouter.response.calledWith(requestWithFrontendStateCookie, response, 'AUTHORISATION_SUCCESS', opts)).to.be.true // eslint-disable-line
           expect(requestWithFrontendStateCookie.frontend_state).to.have.all.keys('ch_dh6kpbb4k82oiibbe4b9haujjk')
-          expect(requestWithFrontendStateCookie.frontend_state['ch_dh6kpbb4k82oiibbe4b9haujjk']).to.eql({
-            'csrfSecret': 'foo'
+          expect(requestWithFrontendStateCookie.frontend_state.ch_dh6kpbb4k82oiibbe4b9haujjk).to.eql({
+            csrfSecret: 'foo'
           })
         })
       })


### PR DESCRIPTION
Log all times we show either the "An error occurred" or
"We’re experiencing technical problems" pages.

This is to drive an SLI that will cover all times we display and error
to the user that will probably mean they can't complete their payment.
