### PR TITLE
PP-5805: Remove aws xray from base_client and tests

### DIFF
--- a/app/services/clients/cardid_client.js
+++ b/app/services/clients/cardid_client.js
@@ -12,5 +12,5 @@ const CARD_URL = process.env.CARDID_HOST + '/v1/api/card'
  *
  * @returns {Request}
  */
-exports.post = (args, subSegment) => baseClient.post(CARD_URL, args, null, subSegment)
+exports.post = (args, subSegment) => baseClient.post(CARD_URL, args, null)
 exports.CARD_URL = CARD_URL

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -69,8 +69,7 @@ const _putConnector = (url, payload, description, subSegment, loggingFields = {}
     baseClient.put(
       url,
       { payload, correlationId },
-      null,
-      subSegment
+      null
     ).then(response => {
       logger.info('PUT to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       resolve(response)
@@ -102,7 +101,6 @@ const _postConnector = (url, payload, description, loggingFields = {}) => {
     baseClient.post(
       url,
       { payload, correlationId },
-      null,
       null
     ).then(response => {
       logger.info('POST to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
@@ -135,7 +133,6 @@ const _patchConnector = (url, payload, description, loggingFields = {}) => {
     baseClient.patch(
       url,
       { payload, correlationId },
-      null,
       null
     ).then(response => {
       logger.info('PATCH to %s ended - total time %dms', url, new Date() - startTime, loggingFields)

--- a/test/controllers/web-payments/handle-auth-response-controller.test.js
+++ b/test/controllers/web-payments/handle-auth-response-controller.test.js
@@ -5,7 +5,6 @@ const { expect } = require('chai')
 // NPM dependencies
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-const AWSXRay = require('aws-xray-sdk')
 // Local dependencies
 require('../../test_helpers/html_assertions')
 
@@ -34,21 +33,7 @@ const requireHandleAuthResponseController = (mockedCharge, mockedNormaliseCharge
   const proxyquireMocks = {
     '../../models/charge': mockedCharge,
     '../../utils/cookies': mockedCookies,
-    '../../services/normalise_charge': mockedNormaliseCharge,
-    'aws-xray-sdk': {
-      captureAsyncFunc: (name, callback) => {
-        return callback({close: () => {}}) // eslint-disable-line
-      }
-    },
-    'continuation-local-storage': {
-      getNamespace: () => {
-        return {
-          get: function () {
-            return new AWSXRay.Segment('stub-segment')
-          }
-        }
-      }
-    }
+    '../../services/normalise_charge': mockedNormaliseCharge
   }
 
   return proxyquire('../../../app/controllers/web-payments/handle-auth-response-controller', proxyquireMocks)

--- a/test/integration/charge_billing_address_ft_tests.js
+++ b/test/integration/charge_billing_address_ft_tests.js
@@ -6,8 +6,6 @@ const nock = require('nock')
 const chai = require('chai')
 const cheerio = require('cheerio')
 const expect = chai.expect
-const proxyquire = require('proxyquire')
-const AWSXRay = require('aws-xray-sdk')
 
 // Local dependencies
 const logger = require('../../app/utils/logger')(__filename)
@@ -22,33 +20,7 @@ const {
 const State = require('../../config/state')
 
 // Constants
-const app = proxyquire('../../server', {
-  'aws-xray-sdk': {
-    enableManualMode: () => {},
-    setLogger: () => {},
-    middleware: {
-      setSamplingRules: () => {}
-    },
-    config: () => {},
-    express: {
-      openSegment: () => (req, res, next) => next(),
-      closeSegment: () => (req, rest, next) => next()
-    },
-    captureAsyncFunc: (name, callback) => callback(new AWSXRay.Segment('stub-subsegment')),
-    '@global': true
-  },
-  'continuation-local-storage': {
-    getNamespace: function () {
-      return {
-        get: () => new AWSXRay.Segment('stub-segment'),
-        bindEmitter: () => {},
-        run: callback => callback(),
-        set: () => {}
-      }
-    },
-    '@global': true
-  }
-}).getApp()
+const app = require('../../server.js').getApp()
 
 const gatewayAccount = {
   gatewayAccountId: '12345',

--- a/test/integration/charge_ft_tests.js
+++ b/test/integration/charge_ft_tests.js
@@ -9,7 +9,6 @@ const cheerio = require('cheerio')
 const logger = require('../../app/utils/logger')(__filename)
 const expect = chai.expect
 const proxyquire = require('proxyquire')
-const AWSXRay = require('aws-xray-sdk')
 const should = chai.should()
 
 // Local dependencies
@@ -27,33 +26,15 @@ const serviceFixtures = require('../fixtures/service_fixtures')
 const random = require('../../app/utils/random')
 
 // Constants
-const app = proxyquire('../../server', {
-  'aws-xray-sdk': {
-    enableManualMode: () => {},
-    setLogger: () => {},
-    middleware: {
-      setSamplingRules: () => {}
-    },
-    config: () => {},
-    express: {
-      openSegment: () => (req, res, next) => next(),
-      closeSegment: () => (req, rest, next) => next()
-    },
-    captureAsyncFunc: (name, callback) => callback(new AWSXRay.Segment('stub-subsegment')),
-    '@global': true
-  },
-  'continuation-local-storage': {
-    getNamespace: function () {
-      return {
-        get: () => new AWSXRay.Segment('stub-segment'),
-        bindEmitter: () => {},
-        run: callback => callback(),
-        set: () => {}
-      }
-    },
-    '@global': true
-  }
-}).getApp()
+const app = proxyquire('../../server.js',
+  {
+    'memory-cache': {
+      get: function () { 
+        return false 
+      },
+      '@global': true
+    }
+  }).getApp()
 
 const EMPTY_BODY = ''
 const defaultCorrelationHeader = {

--- a/test/integration/charge_validation_ft_tests.js
+++ b/test/integration/charge_validation_ft_tests.js
@@ -1,9 +1,19 @@
 const nock = require('nock')
-const app = require('../../server.js').getApp()
+const proxyquire = require('proxyquire')
 const expect = require('chai').expect
 const cheerio = require('cheerio')
 const State = require('../../config/state.js')
 const cookie = require('../test_helpers/session.js')
+
+const app = proxyquire('../../server.js',
+  {
+    'memory-cache': {
+      get: function () { 
+        return false 
+      },
+      '@global': true
+    }
+  }).getApp()
 
 let { postChargeRequest, defaultConnectorResponseForGetCharge, defaultAdminusersResponseForGetService } = require('../test_helpers/test_helpers.js')
 

--- a/test/integration/three_d_secure_ft_tests.js
+++ b/test/integration/three_d_secure_ft_tests.js
@@ -5,40 +5,12 @@ const nock = require('nock')
 const chai = require('chai')
 const cheerio = require('cheerio')
 const expect = chai.expect
-const proxyquire = require('proxyquire')
-const AWSXRay = require('aws-xray-sdk')
 
 // Local dependencies
 const logger = require('../../app/utils/logger')(__filename)
 const paymentFixtures = require('../fixtures/payment_fixtures')
 
-const app = proxyquire('../../server.js', {
-  'aws-xray-sdk': {
-    enableManualMode: () => { },
-    setLogger: () => { },
-    middleware: {
-      setSamplingRules: () => { }
-    },
-    config: () => { },
-    express: {
-      openSegment: () => (req, res, next) => next(),
-      closeSegment: () => (req, rest, next) => next()
-    },
-    captureAsyncFunc: (name, callback) => callback(new AWSXRay.Segment('stub-subsegment')),
-    '@global': true
-  },
-  'continuation-local-storage': {
-    getNamespace: function () {
-      return {
-        get: () => new AWSXRay.Segment('stub-segment'),
-        bindEmitter: () => { },
-        run: callback => callback(),
-        set: () => { }
-      }
-    },
-    '@global': true
-  }
-}).getApp()
+const app = require('../../server.js').getApp()
 const cookie = require('../test_helpers/session.js')
 const { getChargeRequest, postChargeRequest } = require('../test_helpers/test_helpers.js')
 const { defaultAdminusersResponseForGetService } = require('../test_helpers/test_helpers.js')

--- a/test/unit/base_client_test.js
+++ b/test/unit/base_client_test.js
@@ -32,10 +32,7 @@ describe('base client', () => {
       .reply(200)
 
     // literally just making sure data is passed to mocked service correctly
-    baseClient.post(url, {
-      payload: arbitraryRequestData,
-      correlationId: arbitraryCorrelationId
-    }, null, null).then(() => {
+    baseClient.post(url, { payload: arbitraryRequestData, correlationId: arbitraryCorrelationId }).then(() => {
       done()
     })
   })
@@ -50,10 +47,13 @@ describe('base client', () => {
       .reply(200)
 
     // literally just making sure data is passed to mocked service correctly
-    baseClient.post(urlWithoutPort, {
-      payload: arbitraryRequestData,
-      correlationId: arbitraryCorrelationId
-    }, null, null).then(() => done())
+    baseClient.post(
+      urlWithoutPort,
+      {
+        payload: arbitraryRequestData,
+        correlationId: arbitraryCorrelationId
+      },
+      null).then(() => done())
   })
 
   it('should post data correctly', (done) => {
@@ -62,10 +62,7 @@ describe('base client', () => {
       .reply(200)
 
     // literally just making sure data is passed to mocked service correctly
-    baseClient.post(url, {
-      payload: arbitraryRequestData,
-      correlationId: arbitraryCorrelationId
-    }, null, null).then(() => done())
+    baseClient.post(url, { payload: arbitraryRequestData, correlationId: arbitraryCorrelationId }).then(() => done())
   })
 
   it('should put data correctly', (done) => {
@@ -73,10 +70,13 @@ describe('base client', () => {
       .put('/', arbitraryRequestData)
       .reply(200)
 
-    baseClient.put(url, {
-      payload: arbitraryRequestData,
-      correlationId: arbitraryCorrelationId
-    }, null, null).then(() => done())
+    baseClient.put(
+      url,
+      {
+        payload: arbitraryRequestData,
+        correlationId: arbitraryCorrelationId
+      },
+      null).then(() => done())
   })
 
   it('should patch data correctly', (done) => {
@@ -84,10 +84,13 @@ describe('base client', () => {
       .patch('/', arbitraryRequestData)
       .reply(200)
 
-    baseClient.patch(url, {
-      payload: arbitraryRequestData,
-      correlationId: arbitraryCorrelationId
-    }, null, null).then(() => done())
+    baseClient.patch(
+      url,
+      {
+        payload: arbitraryRequestData,
+        correlationId: arbitraryCorrelationId
+      },
+      null).then(() => done())
   })
 
   it('should get correctly', (done) => {
@@ -95,7 +98,7 @@ describe('base client', () => {
       .get('/')
       .reply(200, arbitraryResponseData)
 
-    baseClient.get(url, { correlationId: arbitraryCorrelationId }, null, null).then(response => {
+    baseClient.get(url, { correlationId: arbitraryCorrelationId }, null).then(response => {
       assert.strictEqual(response.body.response, 'I am a response')
       done()
     })
@@ -117,7 +120,7 @@ describe('base client', () => {
       .post('/', arbitraryRequestData)
       .reply(200, arbitraryResponseData)
 
-    baseClient.post(url, { payload: arbitraryRequestData, correlationId: '123' }, null, null).then(response => {
+    baseClient.post(url, { payload: arbitraryRequestData, correlationId: '123' }, null).then(response => {
       assert.strictEqual(response.body.response, 'I am a response')
       done()
     })
@@ -128,7 +131,7 @@ describe('base client', () => {
       .post('/', arbitraryRequestData)
       .reply(200)
 
-    baseClient.post(url, { payload: arbitraryRequestData, correlationId: '123' }, null, null).then(response => {
+    baseClient.post(url, { payload: arbitraryRequestData, correlationId: '123' }).then(response => {
       assert.strictEqual(response.body, undefined)
       done()
     })
@@ -139,7 +142,7 @@ describe('base client', () => {
       .get('/')
       .reply(200, '{}')
 
-    baseClient.get(url, { correlationId: 'reee' }, null, null).then(response => {
+    baseClient.get(url, { correlationId: 'reee' }, null).then(response => {
       assert.strictEqual(response.request.headers['x-request-id'], 'reee')
       done()
     })
@@ -150,7 +153,7 @@ describe('base client', () => {
       .get('/')
       .reply(200, '{}')
 
-    baseClient.get(url, {}, null, null).then(response => {
+    baseClient.get(url, {}, null).then(response => {
       assert.strictEqual(response.request.headers['Content-Type'], 'application/json')
       done()
     })
@@ -161,7 +164,7 @@ describe('base client', () => {
       .get('/')
       .reply(200, arbitraryResponseData, { 'content-type': 'text/html' })
 
-    baseClient.get(url, { correlationId: arbitraryCorrelationId }, null, null).then(response => {
+    baseClient.get(url, { correlationId: arbitraryCorrelationId }, null).then(response => {
       assert.strictEqual(response.body.response, 'I am a response')
       done()
     })


### PR DESCRIPTION
As part of this commit the following needed to be added to charge_ft_tests and
charge_validation_ft_tests

```
const app = proxyquire('../../server.js',
  {
    'memory-cache': {
      get: function () {
        return false
      },
      '@global': true
    }
  }).getApp()
```
This mocks out the memory-cache in the resolve_service (https://github.com/alphagov/pay-frontend/blob/master/app/middleware/resolve_service.js#L4).

It turns out:
- most of the tests across the project uses the same gatewayAccountId
- there is some test somewhere (I don't know where) that associates a service
  to this gateway account which sets collectBillingAddress to false

This has a knock on effect on the rest of the tests where the billing address
needs to be collected and causes the following code in the charge_controller to
be executed
https://github.com/alphagov/pay-frontend/blob/master/app/controllers/charge_controller.js#L187-L189:
```
    if (res.locals.collectBillingAddress === false) {
      delete payload.address
    }
```

This caches the service causes the tests to fail because the expectation at
https://github.com/alphagov/pay-frontend/blob/master/test/integration/charge_ft_tests.js#L104-L116
fails.

Some solutions:
- mock out the memory-cache globally (the chosen solution)
- make every gateway account id random so as to bypass the cache in the
  resolve_service (too much effort)
- set the SERVICE_CACHE_MAX_AGE which is used in resolve_service to 0 (hard to
  do)