### PR TITLE
PP-6330: Make frontend use two google pay merchant ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ GOV.UK Pay Frontend application (Node.js)
 | `CSP_ENFORCE`                            |            | false/undefined                                                 | Browser will block content security policy violations if set to true, default is to only report on violations.                                        |
 | `CSP_REPORT_URI`                         |            |                                                                 | URI to receive CSP violation reports.                                                                                                                 |
 | `GOOGLE_PAY_MERCHANT_ID`                 |            |                                                                 | Merchant ID used to identify GOV.UK Pay to Google when making a payment request. This ID is got from the Google Pay Developer Profile.                |
+| `GOOGLE_PAY_MERCHANT_ID_2`               |            |                                                                 | The same as GOOGLE_PAY_MERCHANT_ID, but used to rotate to a new merchant id in a safe way.                                                            |
 
 ## Licence
 

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -6,7 +6,6 @@ const i18n = require('i18n')
 
 // Local dependencies
 const {
-  GOOGLE_PAY_MERCHANT_ID,
   WORLDPAY_3DS_FLEX_DDC_TEST_URL,
   WORLDPAY_3DS_FLEX_DDC_LIVE_URL,
   DECRYPT_AND_OMIT_CARD_DATA
@@ -23,6 +22,7 @@ const paths = require('../paths')
 const { countries } = require('../services/countries')
 const { commonTypos } = require('../utils/email_tools')
 const { withAnalyticsError, withAnalytics } = require('../utils/analytics')
+const { getMerchantId } = require('../utils/google_pay_merchant_id_selector')
 const connectorClient = require('../services/clients/connector_client')
 const cookies = require('../utils/cookies')
 const { getGooglePayMethodData, googlePayDetails } = require('../utils/google-pay-check-request')
@@ -52,7 +52,7 @@ const appendChargeForNewView = async function appendChargeForNewView(charge, req
   charge.googlePayGatewayMerchantID = charge.gatewayAccount.gatewayMerchantId
   charge.googlePayRequestMethodData = getGooglePayMethodData({
     allowedCardTypes: supportedNetworksFormattedByProvider(cardModel.allowed, 'google'),
-    merchantId: GOOGLE_PAY_MERCHANT_ID,
+    merchantId: getMerchantId(charge.gatewayAccount.gatewayAccountId),
     gatewayMerchantId: charge.gatewayAccount.gatewayMerchantId
   })
   charge.googlePayRequestDetails = googlePayDetails

--- a/app/utils/google_pay_merchant_id_selector.js
+++ b/app/utils/google_pay_merchant_id_selector.js
@@ -1,0 +1,18 @@
+const {
+  GOOGLE_PAY_MERCHANT_ID,
+  GOOGLE_PAY_MERCHANT_ID_2
+} = process.env
+
+const { gatewayAccountIdsForGooglePayMerchantId2 } = require('../../config/google_merchant_id_to_gateway_account_id')
+
+const getMerchantId = (gatewayAccountId) => {
+  if (GOOGLE_PAY_MERCHANT_ID_2 && gatewayAccountIdsForGooglePayMerchantId2.includes(gatewayAccountId)) {
+    return GOOGLE_PAY_MERCHANT_ID_2
+  } else {
+    return GOOGLE_PAY_MERCHANT_ID
+  }
+}
+
+module.exports = {
+  getMerchantId
+}

--- a/app/utils/google_pay_merchant_id_selector.js
+++ b/app/utils/google_pay_merchant_id_selector.js
@@ -1,11 +1,16 @@
 const {
   GOOGLE_PAY_MERCHANT_ID,
-  GOOGLE_PAY_MERCHANT_ID_2
+  GOOGLE_PAY_MERCHANT_ID_2,
+  GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2
 } = process.env
 
-const { gatewayAccountIdsForGooglePayMerchantId2 } = require('../../config/google_merchant_id_to_gateway_account_id')
-
 const getMerchantId = (gatewayAccountId) => {
+  var gatewayAccountIdsForGooglePayMerchantId2 = []
+  
+  if (GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2) {
+    gatewayAccountIdsForGooglePayMerchantId2 = GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2.trim().split(' ')
+  }
+  
   if (GOOGLE_PAY_MERCHANT_ID_2 && gatewayAccountIdsForGooglePayMerchantId2.includes(gatewayAccountId)) {
     return GOOGLE_PAY_MERCHANT_ID_2
   } else {

--- a/config/google_merchant_id_to_gateway_account_id.js
+++ b/config/google_merchant_id_to_gateway_account_id.js
@@ -1,0 +1,6 @@
+// This config lists the gateway account ids that should use the GOOGLE_PAY_MERCHANT_ID_2
+// environment variable as the merchant id when making a payment request to google.
+
+module.exports = {
+  gateway_account_ids_for_google_pay_merchant_id_2: []
+}

--- a/config/google_merchant_id_to_gateway_account_id.js
+++ b/config/google_merchant_id_to_gateway_account_id.js
@@ -1,6 +1,0 @@
-// This config lists the gateway account ids that should use the GOOGLE_PAY_MERCHANT_ID_2
-// environment variable as the merchant id when making a payment request to google.
-
-module.exports = {
-  gateway_account_ids_for_google_pay_merchant_id_2: []
-}

--- a/test/utils/google_pay_merchant_id_test.js
+++ b/test/utils/google_pay_merchant_id_test.js
@@ -1,9 +1,9 @@
 // npm dependencies
-const {expect} = require('chai')
+const { expect } = require('chai')
 const proxyquire = require('proxyquire').noPreserveCache()
 
-const googlePayMerchantId = '123'
-const googlePayMerchantId2 = 'abc'
+const googlePayMerchantId = 'google_pay_merchant_id'
+const googlePayMerchantId2 = 'google_pay_merchant_id_2'
 const gatewayAccountForGooglePayMerchantId2 = 'ga4merchantId2'
 
 describe('google pay merchant id test', function () {
@@ -11,14 +11,27 @@ describe('google pay merchant id test', function () {
     process.env.GOOGLE_PAY_MERCHANT_ID = googlePayMerchantId
   })
 
+  afterEach(() => {
+    delete process.env.GOOGLE_PAY_MERCHANT_ID_2
+    delete process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2
+  })
+
   describe('return GOOGLE_PAY_MERCHANT_ID', () => {
+    it('when GOOGLE_PAY_MERCHANT_ID_2 env var is set but GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 is not set', () => {
+      process.env.GOOGLE_PAY_MERCHANT_ID_2 = googlePayMerchantId2
+      const { getMerchantId } = newGooglePayMerchantIdCalculator()
+      expect(getMerchantId(gatewayAccountForGooglePayMerchantId2)).to.equal(googlePayMerchantId)
+    })
+
     it('when GOOGLE_PAY_MERCHANT_ID_2 env var is empty', () => {
+      process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 = gatewayAccountForGooglePayMerchantId2
       const { getMerchantId } = newGooglePayMerchantIdCalculator()
       expect(getMerchantId(gatewayAccountForGooglePayMerchantId2)).to.equal(googlePayMerchantId)
     })
 
     it('when GOOGLE_PAY_MERCHANT_ID_2 env var is set but gateway account is irrelevant', () => {
       process.env.GOOGLE_PAY_MERCHANT_ID_2 = googlePayMerchantId2
+      process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 = gatewayAccountForGooglePayMerchantId2
       const { getMerchantId } = newGooglePayMerchantIdCalculator()
       expect(getMerchantId('irrelevant')).to.equal(googlePayMerchantId)
     })
@@ -27,6 +40,7 @@ describe('google pay merchant id test', function () {
   describe('should return GOOGLE_PAY_MERCHANT_ID_2', () => {
     it('when GOOGLE_PAY_MERCHANT_ID_2 env var is set and gateway account is relevant', () => {
       process.env.GOOGLE_PAY_MERCHANT_ID_2 = googlePayMerchantId2
+      process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 = gatewayAccountForGooglePayMerchantId2
       const { getMerchantId } = newGooglePayMerchantIdCalculator()
       expect(getMerchantId(gatewayAccountForGooglePayMerchantId2)).to.equal(googlePayMerchantId2)
     })
@@ -34,9 +48,5 @@ describe('google pay merchant id test', function () {
 })
 
 function newGooglePayMerchantIdCalculator() {
-  return proxyquire('../../app/utils/google_pay_merchant_id_selector.js', {
-    '../../config/google_merchant_id_to_gateway_account_id': {
-      gatewayAccountIdsForGooglePayMerchantId2: [gatewayAccountForGooglePayMerchantId2]
-    }
-  })
+  return proxyquire('../../app/utils/google_pay_merchant_id_selector.js', {})
 }

--- a/test/utils/google_pay_merchant_id_test.js
+++ b/test/utils/google_pay_merchant_id_test.js
@@ -1,0 +1,42 @@
+// npm dependencies
+const {expect} = require('chai')
+const proxyquire = require('proxyquire').noPreserveCache()
+
+const googlePayMerchantId = '123'
+const googlePayMerchantId2 = 'abc'
+const gatewayAccountForGooglePayMerchantId2 = 'ga4merchantId2'
+
+describe('google pay merchant id test', function () {
+  beforeEach(() => {
+    process.env.GOOGLE_PAY_MERCHANT_ID = googlePayMerchantId
+  })
+
+  describe('return GOOGLE_PAY_MERCHANT_ID', () => {
+    it('when GOOGLE_PAY_MERCHANT_ID_2 env var is empty', () => {
+      const { getMerchantId } = newGooglePayMerchantIdCalculator()
+      expect(getMerchantId(gatewayAccountForGooglePayMerchantId2)).to.equal(googlePayMerchantId)
+    })
+
+    it('when GOOGLE_PAY_MERCHANT_ID_2 env var is set but gateway account is irrelevant', () => {
+      process.env.GOOGLE_PAY_MERCHANT_ID_2 = googlePayMerchantId2
+      const { getMerchantId } = newGooglePayMerchantIdCalculator()
+      expect(getMerchantId('irrelevant')).to.equal(googlePayMerchantId)
+    })
+  })
+
+  describe('should return GOOGLE_PAY_MERCHANT_ID_2', () => {
+    it('when GOOGLE_PAY_MERCHANT_ID_2 env var is set and gateway account is relevant', () => {
+      process.env.GOOGLE_PAY_MERCHANT_ID_2 = googlePayMerchantId2
+      const { getMerchantId } = newGooglePayMerchantIdCalculator()
+      expect(getMerchantId(gatewayAccountForGooglePayMerchantId2)).to.equal(googlePayMerchantId2)
+    })
+  })
+})
+
+function newGooglePayMerchantIdCalculator() {
+  return proxyquire('../../app/utils/google_pay_merchant_id_selector.js', {
+    '../../config/google_merchant_id_to_gateway_account_id': {
+      gatewayAccountIdsForGooglePayMerchantId2: [gatewayAccountForGooglePayMerchantId2]
+    }
+  })
+}


### PR DESCRIPTION
This is so we can rotate the merchant id in a safe way and assign the usage of
a new merchant id to a specific gateway account to test it out in production.
