### PR TITLE
PP-6368 Remove explicit correlation ID from get charge call 

### DIFF
--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -170,7 +170,7 @@ const _getConnector = (url, description, loggingFields = {}) => {
     ).then(response => {
       logger.info('GET to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       if (response.statusCode !== 200) {
-        logger.warn('Calling connector to GET something returned a non http 200 response', correlationId, {
+        logger.warn('Calling connector to GET something returned a non http 200 response', {
           ...loggingFields,
           service: 'connector',
           method: 'GET',


### PR DESCRIPTION
The `x-request-id` is already available to the logging context as this
uses the `getCommonLoggingFields` utility added during structured
logging.

This fixes an issue where `correlationId` is destructured into individual
characters in the logs.
