### PR TITLE
PP-6360 - Send additional ePDQ 3DS2 browser data from enter card details page

### DIFF
--- a/app/assets/javascripts/browsered/epdq-3ds2.js
+++ b/app/assets/javascripts/browsered/epdq-3ds2.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const init = () => {
+  if (window.Charge.collect_additional_browser_data_for_epdq_3ds) {
+    addAdditionalInformation()
+  }
+}
+
+const addAdditionalInformation = () => {
+  if (typeof navigator.language === 'string') {
+    appendHiddenInputToForm('jsNavigatorLanguage', navigator.language)
+  }
+
+  if (window.screen) {
+    if (typeof window.screen.colorDepth === 'number') {
+      appendHiddenInputToForm('jsScreenColorDepth', window.screen.colorDepth)
+    }
+
+    if (typeof window.screen.height === 'number') {
+      appendHiddenInputToForm('jsScreenColorHeight', window.screen.height)
+    }
+
+    if (typeof window.screen.width === 'number') {
+      appendHiddenInputToForm('jsScreenColorWidth', window.screen.width)
+    }
+  }
+
+  const date = new Date()
+  appendHiddenInputToForm('jsTimezoneOffsetMins', date.getTimezoneOffset())
+}
+
+const appendHiddenInputToForm = (name, value) => {
+  const hiddenInput = document.createElement('input')
+  hiddenInput.type = 'hidden'
+  hiddenInput.name = name
+  hiddenInput.value = value
+  document.getElementById('card-details').appendChild(hiddenInput)
+}
+
+module.exports = {
+  init
+}

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -2,6 +2,7 @@ const inputConfirm = require('./assets/javascripts/browsered/form-input-confirm'
 const webPayments = require('./assets/javascripts/browsered/web-payments')
 const analytics = require('gaap-analytics')
 const formValidation = require('./assets/javascripts/browsered/form-validation')
+const epdq3ds2 = require('./assets/javascripts/browsered/epdq-3ds2')
 const helpers = require('./assets/javascripts/browsered/helpers')
 
 exports.chargeValidation = require('./utils/charge_validation')
@@ -12,7 +13,8 @@ window.payScripts = { // eslint-disable-line no-unused-vars
   helpers,
   inputConfirm,
   webPayments,
-  formValidation
+  formValidation,
+  epdq3ds2
 }
 
 // GA tracking if an email typo is spotted

--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -33,7 +33,7 @@ const { CORRELATION_HEADER } = require('../../config/correlation_header')
 const { createChargeIdSessionKey } = require('../utils/session')
 const { getLoggingFields } = require('../utils/logging_fields_helper')
 
-const appendChargeForNewView = async function appendChargeForNewView(charge, req, chargeId) {
+const appendChargeForNewView = async function appendChargeForNewView (charge, req, chargeId) {
   const cardModel = Card(charge.gatewayAccount.cardTypes, charge.gatewayAccount.block_prepaid_cards, req.headers[CORRELATION_HEADER])
   charge.withdrawalText = cardModel.withdrawalTypes.join('_')
   charge.allowedCards = cardModel.allowed
@@ -60,6 +60,9 @@ const appendChargeForNewView = async function appendChargeForNewView(charge, req
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   charge.worldpay3dsFlexDdcJwt = await worlpay3dsFlexService.getDdcJwt(charge, correlationId, getLoggingFields(req))
   charge.worldpay3dsFlexDdcUrl = charge.gatewayAccount.type !== 'live' ? WORLDPAY_3DS_FLEX_DDC_TEST_URL : WORLDPAY_3DS_FLEX_DDC_LIVE_URL
+
+  charge.collectAdditionalBrowserDataForEpdq3ds = charge.gatewayAccount.paymentProvider === 'epdq' &&
+      charge.gatewayAccount.requires3ds && charge.gatewayAccount.integrationVersion3ds === 2
 }
 
 const routeFor = (resource, chargeId) => paths.generateRoute(`card.${resource}`, { chargeId: chargeId })

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -31,6 +31,7 @@
   window.Charge = {
     email_collection_mode: '{{ gatewayAccount.emailCollectionMode | safe }}',
     collect_billing_address: {{ "true" if collectBillingAddress else "false" }},
+    collect_additional_browser_data_for_epdq_3ds: {{"true" if collectAdditionalBrowserDataForEpdq3ds else "false" }},
     worldpay_3ds_flex_ddc_jwt: '{{ worldpay3dsFlexDdcJwt }}',
     worldpay_3ds_flex_ddc_url: '{{ worldpay3dsFlexDdcUrl }}'
   }
@@ -46,6 +47,7 @@
       {% endif %}
       window.payScripts.inputConfirm.init();
       window.payScripts.formValidation.init();
+      window.payScripts.epdq3ds2.init();
     } else if (mainWrap.classList.contains('confirm-page')) {
       analyticsTrackConfirmClick().init('{{analytics.analyticsId}}', '{{analytics.type}}', '{{analytics.paymentProvider}}', '{{analytics.amount}}', '{{hitPage}}');
     }

--- a/test/cypress/integration/epdq-3ds2/payment-with-epdq-3ds2.spec.js
+++ b/test/cypress/integration/epdq-3ds2/payment-with-epdq-3ds2.spec.js
@@ -1,0 +1,140 @@
+const cardPaymentStubs = require('../../utils/card-payment-stubs')
+
+describe('Enter card details page', () => {
+  const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
+  const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
+  const gatewayAccountId = 42
+  const sessionOpts = {}
+
+  const setUpAndCheckCardPaymentPage = () => {
+    describe('ePDQ gateway account with 3DS2 enabled', () => {
+      const providerOpts = {
+        paymentProvider: 'epdq',
+        requires3ds: true,
+        integrationVersion3ds: 2
+      }
+      const createPaymentChargeStubsEnglish = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', gatewayAccountId, sessionOpts, providerOpts)
+      it('Should setup the payment and load the page', () => {
+        cy.task('setupStubs', createPaymentChargeStubsEnglish)
+        cy.visit(`/secure/${tokenId}`)
+
+        // 1. Charge will be created using this id as a token (GET)
+        // 2. Token will be deleted (DELETE)
+        // 3. Charge will be fetched (GET)
+        // 4. Service related to charge will be fetched (GET)
+        // 5. Charge status will be updated (PUT)
+        // 6. Client will be redirected to /card_details/:chargeId (304)
+        cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      })
+
+      it('Should have extra browser information for ePDQ 3DS2', () => {
+        cy.window().then($win => {
+          cy.get('#card-details input[name=jsScreenColorDepth]').should('exist')
+          cy.get('#card-details input[name=jsScreenColorDepth]').should('have.attr', 'value', $win.screen.colorDepth.toString())
+
+          cy.get('#card-details input[name=jsScreenColorHeight]').should('exist')
+          cy.get('#card-details input[name=jsScreenColorHeight]').should('have.attr', 'value', $win.screen.height.toString())
+
+          cy.get('#card-details input[name=jsScreenColorWidth]').should('exist')
+          cy.get('#card-details input[name=jsScreenColorWidth]').should('have.attr', 'value', $win.screen.width.toString())
+
+          const now = new Date()
+          cy.get('#card-details input[name=jsTimezoneOffsetMins]').should('exist')
+          cy.get('#card-details input[name=jsTimezoneOffsetMins]').should('have.attr', 'value', now.getTimezoneOffset().toString())
+
+          cy.get('#card-details input[name=jsNavigatorLanguage]').should('exist')
+          cy.get('#card-details input[name=jsNavigatorLanguage]').should('have.attr', 'value', $win.navigator.language.toString())
+        })
+      })
+    })
+
+    describe('ePDQ gateway account with 3DS1 enabled', () => {
+      const providerOpts = {
+        paymentProvider: 'epdq',
+        requires3ds: true,
+        integrationVersion3ds: 1
+      }
+      const createPaymentChargeStubsEnglish = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', gatewayAccountId, sessionOpts, providerOpts)
+      it('Should setup the payment and load the page', () => {
+        cy.task('setupStubs', createPaymentChargeStubsEnglish)
+        cy.visit(`/secure/${tokenId}`)
+
+        // 1. Charge will be created using this id as a token (GET)
+        // 2. Token will be deleted (DELETE)
+        // 3. Charge will be fetched (GET)
+        // 4. Service related to charge will be fetched (GET)
+        // 5. Charge status will be updated (PUT)
+        // 6. Client will be redirected to /card_details/:chargeId (304)
+        cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      })
+
+      it('Should not have extra browser information for ePDQ 3DS2', () => {
+        cy.get('#card-details input[name=jsScreenColorDepth]').should('not.exist')
+        cy.get('#card-details input[name=jsScreenColorHeight]').should('not.exist')
+        cy.get('#card-details input[name=jsScreenColorWidth]').should('not.exist')
+        cy.get('#card-details input[name=jsTimezoneOffsetMins]').should('not.exist')
+        cy.get('#card-details input[name=jsNavigatorLanguage]').should('not.exist')
+      })
+    })
+
+    describe('ePDQ gateway account with 3DS disabled', () => {
+      const providerOpts = {
+        paymentProvider: 'epdq',
+        requires3ds: false,
+        integrationVersion3ds: 2
+      }
+      const createPaymentChargeStubsEnglish = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', gatewayAccountId, sessionOpts, providerOpts)
+      it('Should setup the payment and load the page', () => {
+        cy.task('setupStubs', createPaymentChargeStubsEnglish)
+        cy.visit(`/secure/${tokenId}`)
+
+        // 1. Charge will be created using this id as a token (GET)
+        // 2. Token will be deleted (DELETE)
+        // 3. Charge will be fetched (GET)
+        // 4. Service related to charge will be fetched (GET)
+        // 5. Charge status will be updated (PUT)
+        // 6. Client will be redirected to /card_details/:chargeId (304)
+        cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      })
+
+      it('Should not have extra browser information for ePDQ 3DS2', () => {
+        cy.get('#card-details input[name=jsScreenColorDepth]').should('not.exist')
+        cy.get('#card-details input[name=jsScreenColorHeight]').should('not.exist')
+        cy.get('#card-details input[name=jsScreenColorWidth]').should('not.exist')
+        cy.get('#card-details input[name=jsTimezoneOffsetMins]').should('not.exist')
+        cy.get('#card-details input[name=jsNavigatorLanguage]').should('not.exist')
+      })
+    })
+
+    describe('Worldpay gateway account with 3DS2 enabled', () => {
+      const providerOpts = {
+        paymentProvider: 'worldpay',
+        requires3ds: false,
+        integrationVersion3ds: 2
+      }
+      const createPaymentChargeStubsEnglish = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', gatewayAccountId, sessionOpts, providerOpts)
+      it('Should setup the payment and load the page', () => {
+        cy.task('setupStubs', createPaymentChargeStubsEnglish)
+        cy.visit(`/secure/${tokenId}`)
+
+        // 1. Charge will be created using this id as a token (GET)
+        // 2. Token will be deleted (DELETE)
+        // 3. Charge will be fetched (GET)
+        // 4. Service related to charge will be fetched (GET)
+        // 5. Charge status will be updated (PUT)
+        // 6. Client will be redirected to /card_details/:chargeId (304)
+        cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      })
+
+      it('Should not have extra browser information for ePDQ 3DS2', () => {
+        cy.get('#card-details input[name=jsScreenColorDepth]').should('not.exist')
+        cy.get('#card-details input[name=jsScreenColorHeight]').should('not.exist')
+        cy.get('#card-details input[name=jsScreenColorWidth]').should('not.exist')
+        cy.get('#card-details input[name=jsTimezoneOffsetMins]').should('not.exist')
+        cy.get('#card-details input[name=jsNavigatorLanguage]').should('not.exist')
+      })
+    })
+  }
+
+  setUpAndCheckCardPaymentPage()
+})


### PR DESCRIPTION
Description:
- This adds extra browser information required for ePDQ 3DS2 which is read from the window object
- We decided to add the hidden input fields for this when the page is loaded as it is easier to test in Cypress
