### PR TITLE
PP-6380 Log 3DS paRes received across several lines

### DIFF
--- a/app/controllers/three_d_secure_controller.js
+++ b/app/controllers/three_d_secure_controller.js
@@ -31,8 +31,15 @@ const build3dsPayload = (chargeId, req) => {
   const paRes = _.get(req, 'body.PaRes')
   if (!_.isUndefined(paRes)) {
     auth3dsPayload.pa_response = paRes
-    logger.info(`paRes received for charge [${chargeId}] 3DS authorisation [${paRes}]`,
-      getLoggingFields(req))
+
+    const paResSegments = []
+    for (let i = 0; i < paRes.length; i += 1000) {
+      paResSegments.push(paRes.substring(i, i + 1000))
+    }
+    for (let i = 0; i < paResSegments.length; i++) {
+      logger.info(`paRes received for charge [${chargeId}] 3DS authorisation [${paResSegments[i]}] (${i + 1}/${paResSegments.length})`,
+        getLoggingFields(req))
+    }
   }
 
   const providerStatus = threeDsEPDQResults[_.get(req, 'body.providerStatus', '')]


### PR DESCRIPTION
The `paRes` received from the card issuer when the user has completed 3DS authentication can be very long. We were logging the `paRes` but unfortunately Docker splits lines that are longer than around 2,000 characters across several different lines. This breaks structured logging and makes anything on the second and subsequent lines very difficult to retrieve.

Work around this by splitting the `paRes` into segments of up to 1,000 characters each (number chosen so that it plus the characters on the rest of the line total less than 2,000) and logging a separate line for each segment. This preserves structured logging and keeps enough contextual information that we can reconstruct the full `paRes`.
