### PR TITLE
ZD#4109437 Update text on payment in progress page

### DIFF
--- a/locales/cy.json
+++ b/locales/cy.json
@@ -70,7 +70,7 @@
 	"errorViews": {
 		"either": "Gallwch:",
 		"continue": "Parhau gyda’ch taliad",
-		"tryAgain": "Mynd yn ôl i geisio’r taliad eto",
+		"tryAgain": "Canslo a mynd yn ôl i trio'r taliad eto",
 		"problem": "Roedd problem gyda’ch taliad",
 		"declined": "Mae eich taliad wedi cael ei wrthod",
 		"contactYourBank": "Nid oes arian wedi cael ei dynnu o’ch cyfrif. Cysylltwch â’ch banc am ragor o fanylion.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -67,7 +67,7 @@
 	"errorViews": {
 		"either": "You can either:",
 		"continue": "Continue with your payment",
-		"tryAgain": "Go back to try the payment again",
+		"tryAgain": "Cancel and go back to try the payment again",
 		"problem": "There was a problem with your payment",
 		"declined": "Your payment has been declined",
 		"contactYourBank": "No money has been taken from your account. Contact your bank for more details.",

--- a/test/cypress/integration/card/token-reuse.spec.js
+++ b/test/cypress/integration/card/token-reuse.spec.js
@@ -59,7 +59,7 @@ describe('Re-use token flow', () => {
 
       cy.get('#card-details-link').should(($a) => expect($a).to.contain('Continue with your payment'))
       cy.get('#card-details-link').should(($a) => expect($a).to.have.attr('href', `/card_details/${chargeId}`))
-      cy.get('#return-url').should(($a) => expect($a).to.contain('Go back to try the payment again'))
+      cy.get('#return-url').should(($a) => expect($a).to.contain('Cancel and go back to try the payment again'))
       cy.get('#return-url').should(($a) => expect($a).to.have.attr('href', `/return/${chargeId}`))
 
       cy.get('#card-details-link').click()
@@ -120,7 +120,7 @@ describe('Re-use token flow', () => {
 
       cy.get('#confirm-link').should(($a) => expect($a).to.contain('Continue with your payment'))
       cy.get('#confirm-link').should(($a) => expect($a).to.have.attr('href', `/card_details/${chargeId}/confirm`))
-      cy.get('#return-url').should(($a) => expect($a).to.contain('Go back to try the payment again'))
+      cy.get('#return-url').should(($a) => expect($a).to.contain('Cancel and go back to try the payment again'))
       cy.get('#return-url').should(($a) => expect($a).to.have.attr('href', `/return/${chargeId}`))
 
       cy.get('#confirm-link').click()


### PR DESCRIPTION
## WHAT
- Update text `Go back to try the payment again` to "Cancel and go back to try the payment again` on payment progress page to make the action clear to the users

