### PR TITLE
ZD#4115502 Fix total amount calculation

### DIFF
--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -202,7 +202,7 @@ var init = function () {
   }
 
   var showCorporateCardSurchargeInformation = function (cardType, corporateCardSurchargeAmount) {
-    var amountNumber = parseInt(paymentSummaryAmountValue)
+    var amountNumber = parseFloat(paymentSummaryAmountValue)
     var corporateCardSurchargeAmountNumber = corporateCardSurchargeAmount / 100
 
     // card message


### PR DESCRIPTION
## WHAT
- Consider pence for total amount calculation when applying corporate surchage on `entering card details page`
- Currently amount (from enter card details page) is treated as integer which is resulting in incorrect total amount on the page. There is no impact on the backend

