### PR TITLE
PP-6676 Set node version for concourse build packs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": "^12.18.1"
+    "node": "^12.16.3"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
The highest version of 12.X node that pass build pack supports is 12.16.3 so
set the node engine version to use this or higher. This setting is only
used by PaaS buildpack at present since Jenkins Ci will reference .nvmrc
and the app is deployed to current infra in a container with node
version set via the docker image base.


**WHAT**
Current paas error
```
**ERROR** Unable to install node: no match found for ^12.18.1 in [10.19.0 10.20.1 12.16.2 12.16.3 13.12.0 13.14.0]
```