### PR TITLE
PP-6611 Fix Apple Pay when email collection is off

### DIFF
--- a/test/cypress/utils/apple-pay-js-api-stubs.js
+++ b/test/cypress/utils/apple-pay-js-api-stubs.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // Mock class for Apple Pay
-const getMockApplePayClass = (validPaymentRequestResponse, email) => {
+const getMockApplePayClass = (validPaymentRequestResponse, email = null) => {
   class MockApplePaySession {
     completePayment () {
       return true

--- a/test/fixtures/wallet_payment_fixtures.js
+++ b/test/fixtures/wallet_payment_fixtures.js
@@ -58,6 +58,9 @@ const fixtures = {
         }
       }
     }
+    if (ops.email) {
+      data.payment_info.email = ops.email
+    }
     return {
       getPactified: () => {
         return pactBase.pactify(data)


### PR DESCRIPTION
Fix Apple Pay when email collection is off by making it not try to validate an email address that isn’t there, which causes an error, which causes the Apple Pay authorisation process to hang for an uncomfortably long time before failing with an error.