### PR TITLE
PP-6706 Make example card expiry date always be in the future

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -20,6 +20,7 @@ const Charge = require('../models/charge')
 const Card = require('../models/card')
 const State = require('../../config/state')
 const paths = require('../paths')
+const { getFutureYearAs2Digits } = require('../services/example_card_expiry_date')
 const { countries } = require('../services/countries')
 const { commonTypos } = require('../utils/email_tools')
 const { withAnalyticsError, withAnalytics } = require('../utils/analytics')
@@ -45,16 +46,17 @@ const appendChargeForNewView = async function appendChargeForNewView (charge, re
     prepaidCredit: charge.gatewayAccount.corporatePrepaidCreditCardSurchargeAmount,
     prepaidDebit: charge.gatewayAccount.corporatePrepaidDebitCardSurchargeAmount
   })
-  charge.post_card_action = routeFor('create', chargeId)
   charge.id = chargeId
+  charge.exampleCardExpiryDateYear = getFutureYearAs2Digits()
+  charge.post_card_action = routeFor('create', chargeId)
   charge.post_cancel_action = routeFor('cancel', chargeId)
   charge.allowApplePay = charge.gatewayAccount.allowApplePay
   charge.allowGooglePay = charge.gatewayAccount.allowGooglePay
   charge.googlePayGatewayMerchantID = charge.gatewayAccount.gatewayMerchantId
- 
+
   const googlePayMerchantId = getMerchantId(charge.gatewayAccount.gatewayAccountId)
   if (googlePayMerchantId === GOOGLE_PAY_MERCHANT_ID_2) {
-    logger.info('Using GOOGLE_PAY_MERCHANT_ID_2', {...getLoggingFields(req)})
+    logger.info('Using GOOGLE_PAY_MERCHANT_ID_2', { ...getLoggingFields(req) })
   }
 
   charge.googlePayRequestMethodData = getGooglePayMethodData({

--- a/app/services/example_card_expiry_date.js
+++ b/app/services/example_card_expiry_date.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const moment = require('moment-timezone')
+
+const getFutureYearAs2Digits = () => moment(new Date()).tz('Europe/London').add(2, 'years').format('YY')
+
+module.exports = {
+  getFutureYearAs2Digits
+}

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -194,7 +194,7 @@
                       </label>
                     </legend>
                     <span class="govuk-hint govuk-!-margin-bottom-2" id="expiry-date-hint">
-                      {{ __p("cardDetails.expiryHint") }}</span>
+                      {{ __p("cardDetails.expiryHint", exampleCardExpiryDateYear) }}</span>
                     {% if highlightErrorFields.expiryMonth %}
                       <p class="govuk-error-message" id="error-expiry-date">
                         {{ highlightErrorFields.expiryMonth }}

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -15,7 +15,7 @@
         "enterPaymentDetails": "Rhowch fanylion taliad",
 		"enterCardDetails": "Rhowch fanylion y cerdyn",
 		"expiry": "Dyddiad dod i ben",
-		"expiryHint": "Er enghraifft 10/20",
+		"expiryHint": "Er enghraifft 10/%s",
 		"expiryMonth": "Mis",
 		"expiryYear": "Blwyddyn",
 		"cvc": "Cod diogelwch y cerdyn",

--- a/locales/en.json
+++ b/locales/en.json
@@ -12,7 +12,7 @@
 		"enterPaymentDetails": "Enter payment details",
 		"enterCardDetails": "Enter card details",
 		"expiry": "Expiry date",
-		"expiryHint": "For example, 10/20",
+		"expiryHint": "For example, 10/%s",
 		"expiryMonth": "Month",
 		"expiryYear": "Year",
 		"cvc": "Card security code",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "mailcheck": "^1.1.1",
     "memory-cache": "^0.2.0",
     "minimist": "1.2.x",
+    "moment-timezone": "^0.5.31",
     "morgan": "1.10.x",
     "nunjucks": "^3.2.1",
     "polyfill-array-includes": "^2.0.0",

--- a/test/controllers/charge_controller_test.js
+++ b/test/controllers/charge_controller_test.js
@@ -70,16 +70,16 @@ const mockSession = (function () {
 
 const aChargeWithStatus = function (status) {
   return {
-    'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
-    'status': status,
-    'amount': '4.99',
-    'gatewayAccount': {
-      'serviceName': 'Service Name',
-      'analyticsId': 'test-1234',
-      'type': 'test',
-      'paymentProvider': 'sandbox'
+    externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
+    status: status,
+    amount: '4.99',
+    gatewayAccount: {
+      serviceName: 'Service Name',
+      analyticsId: 'test-1234',
+      type: 'test',
+      paymentProvider: 'sandbox'
     },
-    'id': '3'
+    id: '3'
   }
 }
 
@@ -89,6 +89,9 @@ const requireChargeController = function (mockedCharge, mockedNormalise, mockedC
     '../models/charge.js': mockedCharge,
     '../services/normalise_charge.js': mockedNormalise,
     '../utils/session.js': mockSession,
+    '../services/example_card_expiry_date.js': {
+      getFutureYearAs2Digits: () => '20'
+    },
     '../services/worldpay_3ds_flex_service': {
       getDdcJwt: () => Promise.resolve('a-jwt')
     }
@@ -106,20 +109,20 @@ describe('card details endpoint', function () {
 
   const aResponseWithStatus = function (status) {
     return {
-      'externalId': 'dh6kpbb4k82oiibbe4b9haujjk',
-      'status': status,
-      'gatewayAccount': {
-        'serviceName': 'Service Name',
-        'analyticsId': 'test-1234',
-        'type': 'test',
-        'paymentProvider': 'sandbox'
+      externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
+      status: status,
+      gatewayAccount: {
+        serviceName: 'Service Name',
+        analyticsId: 'test-1234',
+        type: 'test',
+        paymentProvider: 'sandbox'
       },
-      'analytics': {
-        'analyticsId': 'test-1234',
-        'type': 'test',
-        'paymentProvider': 'sandbox'
+      analytics: {
+        analyticsId: 'test-1234',
+        type: 'test',
+        paymentProvider: 'sandbox'
       },
-      'worldpay3dsFlexDdcJwt': 'a-jwt'
+      worldpay3dsFlexDdcJwt: 'a-jwt'
     }
   }
   before(function () {
@@ -171,13 +174,13 @@ describe('card details endpoint', function () {
 
     await requireChargeController(charge, mockedNormalise, mockedConnectorClient).new(request, response)
     const systemErrorObj = {
-      'message': 'Page cannot be found',
-      'viewName': 'NOT_FOUND',
-      'analytics': {
-        'analyticsId': 'Service unavailable',
-        'type': 'Service unavailable',
-        'paymentProvider': 'Service unavailable',
-        'amount': '0.00'
+      message: 'Page cannot be found',
+      viewName: 'NOT_FOUND',
+      analytics: {
+        analyticsId: 'Service unavailable',
+        type: 'Service unavailable',
+        paymentProvider: 'Service unavailable',
+        amount: '0.00'
       }
     }
     expect(response.render.calledWith('error', systemErrorObj)).to.be.true // eslint-disable-line
@@ -191,15 +194,15 @@ describe('card details endpoint', function () {
 
     requireChargeController(charge, mockedNormalise, mockedConnectorClient).capture(request, response)
     const systemErrorObj = {
-      'viewName': 'SYSTEM_ERROR',
-      'returnUrl': '/return/3',
-      'analytics': {
-        'analyticsId': 'test-1234',
-        'type': 'test',
-        'paymentProvider': 'sandbox',
-        'path': '/card_details/3/error',
-        'amount': '4.99',
-        'testingVariant': 'original'
+      viewName: 'SYSTEM_ERROR',
+      returnUrl: '/return/3',
+      analytics: {
+        analyticsId: 'test-1234',
+        type: 'test',
+        paymentProvider: 'sandbox',
+        path: '/card_details/3/error',
+        amount: '4.99',
+        testingVariant: 'original'
       }
     }
     expect(response.render.calledWith('errors/system_error', systemErrorObj)).to.be.true // eslint-disable-line
@@ -213,14 +216,14 @@ describe('card details endpoint', function () {
 
     requireChargeController(charge, mockedNormalise, mockedConnectorClient).capture(request, response)
     const systemErrorObj = {
-      'viewName': 'CAPTURE_FAILURE',
-      'analytics': {
-        'analyticsId': 'test-1234',
-        'type': 'test',
-        'paymentProvider': 'sandbox',
-        'path': '/card_details/3/capture_failure',
-        'amount': '4.99',
-        'testingVariant': 'original'
+      viewName: 'CAPTURE_FAILURE',
+      analytics: {
+        analyticsId: 'test-1234',
+        type: 'test',
+        paymentProvider: 'sandbox',
+        path: '/card_details/3/capture_failure',
+        amount: '4.99',
+        testingVariant: 'original'
       }
     }
     expect(response.render.calledWith('errors/incorrect_state/capture_failure', systemErrorObj)).to.be.true // eslint-disable-line
@@ -229,7 +232,7 @@ describe('card details endpoint', function () {
 
 describe('check card endpoint', function () {
   const mockedCard = function (allowedCards, correlationId) {
-    let card = {
+    const card = {
       brand: 'VISA',
       type: 'CREDIT',
       corporate: true,
@@ -252,32 +255,32 @@ describe('check card endpoint', function () {
     const mockedNormalise = mockNormalise.withCharge(mockedNormalisedCharge)
 
     request = {
-      'headers': {
+      headers: {
         'x-request-id': '1537873066.725'
       },
-      'chargeData': {
-        'language': 'en',
-        'gateway_account': {
-          'card_types': [
+      chargeData: {
+        language: 'en',
+        gateway_account: {
+          card_types: [
             {
-              'id': 'c2683cfc-07b3-47c4-b7ff-5552d3b2f1e6',
-              'brand': 'visa',
-              'label': 'Visa',
-              'type': 'DEBIT',
-              'requires3ds': false
+              id: 'c2683cfc-07b3-47c4-b7ff-5552d3b2f1e6',
+              brand: 'visa',
+              label: 'Visa',
+              type: 'DEBIT',
+              requires3ds: false
             },
             {
-              'id': 'b41ce0fe-c381-43aa-a5d5-77af61cd9baf',
-              'brand': 'visa',
-              'label': 'Visa',
-              'type': 'CREDIT',
-              'requires3ds': false
+              id: 'b41ce0fe-c381-43aa-a5d5-77af61cd9baf',
+              brand: 'visa',
+              label: 'Visa',
+              type: 'CREDIT',
+              requires3ds: false
             }
           ]
         }
       },
       body: {
-        'cardNo': '4242424242424242'
+        cardNo: '4242424242424242'
       }
     }
     response = {

--- a/test/cypress/integration/card/payment.spec.js
+++ b/test/cypress/integration/card/payment.spec.js
@@ -75,6 +75,8 @@ describe('Standard card payment flow', () => {
 
   describe('Secure card payment page', () => {
     it('Should setup the payment and load the page', () => {
+      cy.clock(Date.UTC(2020, 6, 7, 12, 0, 0))
+
       cy.task('setupStubs', createPaymentChargeStubsEnglish)
       cy.visit(`/secure/${tokenId}`)
 
@@ -89,6 +91,8 @@ describe('Standard card payment flow', () => {
 
       cy.get('#google-pay-payment-method-divider').should('not.exist')
       cy.get('#apple-pay-payment-method-divider').should('not.exist')
+
+      cy.get('#expiry-date-hint').should('contain', '10/22')
     })
 
     it('Should enter and validate a correct card', () => {

--- a/test/services/example_card_expiry_date_test.js
+++ b/test/services/example_card_expiry_date_test.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const path = require('path')
+const sinon = require('sinon')
+const moment = require('moment-timezone')
+const { expect } = require('chai')
+const { getFutureYearAs2Digits } = require(path.join(__dirname, '/../../app/services/example_card_expiry_date.js'))
+
+const mockNewDateToAlwaysReturn = (moment) => sinon.useFakeTimers({ now: moment.toDate(), toFake: ['Date'] })
+
+describe('Example card expiry date year', () => {
+  var clock
+
+  afterEach(() => {
+    if (clock) {
+      clock.restore()
+    }
+  })
+
+  it('should return ‘22’ when the current year in the United Kingdom is 2020', () => {
+    const nowIn2020 = moment.tz('2020-07-01 12:00', 'Europe/London')
+    clock = mockNewDateToAlwaysReturn(nowIn2020)
+
+    const result = getFutureYearAs2Digits()
+
+    expect(result).to.equal('22')
+  })
+
+  it('should return ‘23’ when the current year in the United Kingdom is 2021', () => {
+    const nowIn2021 = moment.tz('2021-07-01 12:00', 'Europe/London')
+    clock = mockNewDateToAlwaysReturn(nowIn2021)
+
+    const result = getFutureYearAs2Digits()
+
+    expect(result).to.equal('23')
+  })
+
+  it('should return ‘24’ when the current year in the United Kingdom is 2022', () => {
+    const nowIn2022 = moment.tz('2022-07-01 12:00', 'Europe/London')
+    clock = mockNewDateToAlwaysReturn(nowIn2022)
+
+    const result = getFutureYearAs2Digits()
+
+    expect(result).to.equal('24')
+  })
+})


### PR DESCRIPTION
Make the example card expiry date on the enter card details page always use a year two years ahead of the current year in the UK.

When it’s 2020 in the UK, the example card expiry date will be 10/22. When it’s 2021 in the UK, the example card expiry date will be 10/23. When it’s 2022 in the UK, the example card expiry date will be 10/24. And so on. (The month always remains 10.)

![Expiry date](https://user-images.githubusercontent.com/24316348/86040901-b7a3f080-ba3c-11ea-8b27-af40d946fc98.png)

This means that the example card expiry date will be between 1 year 10 months and 2 years 10 months in the future, which is appropriate given that most cards expire between 3 and 5 years after they are issued.

The example year will change just once each year at the midnight between New Year’s Eve and New Year’s Day in the UK.