### PR TITLE
BAU add default label for dependabot updates 2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,10 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "daily"
+    default_labels:
+      - "govuk-pay"
   - package_manager: "docker"
     directory: "/"
     update_schedule: "weekly"
+    default_labels:
+      - "govuk-pay"


### PR DESCRIPTION
## WHAT
- add govuk-pay default label to repo so it shows up in the unified dependabot updates view
