### PR TITLE
BAU add more default label for dependabot updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,8 +5,10 @@ update_configs:
     update_schedule: "daily"
     default_labels:
       - "govuk-pay"
+      - "dependencies"
   - package_manager: "docker"
     directory: "/"
     update_schedule: "weekly"
     default_labels:
       - "govuk-pay"
+      - "dependencies"


### PR DESCRIPTION
## WHAT
- add dependencies default label to repo so it shows up in the unified dependabot updates view

