### PR TITLE
BAU — Stop Cypress tests breaking on New Year’s Day 🥳

### DIFF
--- a/test/cypress/integration/card/payment.spec.js
+++ b/test/cypress/integration/card/payment.spec.js
@@ -75,8 +75,6 @@ describe('Standard card payment flow', () => {
 
   describe('Secure card payment page', () => {
     it('Should setup the payment and load the page', () => {
-      cy.clock(Date.UTC(2020, 6, 7, 12, 0, 0))
-
       cy.task('setupStubs', createPaymentChargeStubsEnglish)
       cy.visit(`/secure/${tokenId}`)
 
@@ -92,7 +90,7 @@ describe('Standard card payment flow', () => {
       cy.get('#google-pay-payment-method-divider').should('not.exist')
       cy.get('#apple-pay-payment-method-divider').should('not.exist')
 
-      cy.get('#expiry-date-hint').should('contain', '10/22')
+      cy.get('#expiry-date-hint').contains(/\b10\/[0-9]{2}\b/)
     })
 
     it('Should enter and validate a correct card', () => {


### PR DESCRIPTION
The `cy.clock(…)` function only overrides what time the browser thinks it is, not what the time is on the server.

This means that when running the Cypress tests, the example expiry date shown on the enter card details page will always be two years out from the actual current year. Which will mean it will change from 10/22 to 10/23 on New Year’s Day, causing our Cypress test that looks for 10/22 to fail.

Not a great start to the new year.

Fix this by making the test instead just look for 10/_xx_ where _xx_ is any two digits.

We could try to calculate the current date at the time the test runs but this would have unreliable results around midnight on New Year’s Eve, when people are usually occupied by other things. We have unit tests that check the year is two years out, so just checking that there is an example expiry date in the right format should be sufficient for the Cypress test.