### PR TITLE
BAU — Update the roadmap for Q2 2020-21

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "nodemon": "^2.0.4",
     "nyc": "15.1.x",
     "pact": "4.3.2",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.4.1/pay-product-page-4.4.1.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.4.2/pay-product-page-4.4.2.tgz",
     "proxyquire": "~2.1.3",
     "sass-lint": "^1.13.1",
     "sinon": "9.0.x",


### PR DESCRIPTION
Update to version 4.4.2 of the product page, which includes the Q2 2020–2021 roadmap