### PR TITLE
PP-6611 Log selected fields from Apple Pay or Google Pay payload

### DIFF
--- a/app/controllers/web-payments/payment-auth-request-controller.js
+++ b/app/controllers/web-payments/payment-auth-request-controller.js
@@ -10,9 +10,9 @@ const { CORRELATION_HEADER } = require('../../../config/correlation_header')
 const { setSessionVariable } = require('../../utils/cookies')
 
 module.exports = (req, res) => {
-  const { chargeId, params, body } = req
+  const { chargeId, params } = req
   const { provider } = params
-  const payload = provider === 'apple' ? normaliseApplePayPayload(body) : normaliseGooglePayPayload(body)
+  const payload = provider === 'apple' ? normaliseApplePayPayload(req) : normaliseGooglePayPayload(req)
   return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet({ chargeId, provider, payload }, getLoggingFields(req))
     .then(data => {
       setSessionVariable(req, `ch_${(chargeId)}.webPaymentAuthResponse`, {

--- a/app/utils/structured_logging_value_helper.js
+++ b/app/utils/structured_logging_value_helper.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const outputOrRedact = (property, redact) => {
+  if (property === null) {
+    return '(null)'
+  }
+
+  if (typeof property === 'string') {
+    if (property.length === 0) {
+      return '(empty string)'
+    }
+
+    if (!property.trim()) {
+      return '(blank string)'
+    }
+
+    return redact ? '(redacted non-blank string)' : property
+  }
+
+  if (Array.isArray(property)) {
+    return '(array)'
+  }
+
+  return '(' + typeof property + ')'
+}
+
+const output = property => outputOrRedact(property, false)
+
+const redact = property => outputOrRedact(property, true)
+
+module.exports = {
+  output,
+  redact
+}

--- a/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
+++ b/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
@@ -30,7 +30,7 @@ describe('normalise apple pay payload', function () {
         transactionIdentifier: '372C3858122B6BC39C6095ECA2F994A8AA012F3B025D0D72ECFD449C2A5877F9'
       }
     }
-    const normalisedPayload = normalise(applePayPayload)
+    const normalisedPayload = normalise({ body: applePayPayload })
     expect(normalisedPayload).to.eql(
       {
         payment_info: {
@@ -81,7 +81,7 @@ describe('normalise apple pay payload', function () {
         transactionIdentifier: '372C3858122B6BC39C6095ECA2F994A8AA012F3B025D0D72ECFD449C2A5877F9'
       }
     }
-    const normalisedPayload = normalise(applePayPayload)
+    const normalisedPayload = normalise({ body: applePayPayload })
     expect(normalisedPayload).to.eql(
       {
         payment_info: {

--- a/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
+++ b/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
@@ -24,7 +24,7 @@ describe('normalise Google Pay payload', () => {
       payerName: 'Some Name'
     }
 
-    const normalisedPayload = normalise(googlePayPayload)
+    const normalisedPayload = normalise({ body: googlePayPayload })
     expect(normalisedPayload).to.eql(
       {
         payment_info: {
@@ -60,7 +60,7 @@ describe('normalise Google Pay payload', () => {
         }
       }
     }
-    const normalisedPayload = normalise(googlePayPayload)
+    const normalisedPayload = normalise({ body: googlePayPayload })
     expect(normalisedPayload).to.eql(
       {
         payment_info: {

--- a/test/utils/structured_logging_value_helper_test.js
+++ b/test/utils/structured_logging_value_helper_test.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const expect = require('chai').expect
+
+const { output, redact } = require('../../app/utils/structured_logging_value_helper.js')
+
+describe('The output function', () => {
+  it('returns "(null)" for a null value', () => {
+    expect(output(null)).to.equal('(null)')
+  })
+
+  it('returns "(array)" for an array', () => {
+    expect(output([])).to.equal('(array)')
+  })
+
+  it('returns "(object)" for an object', () => {
+    expect(output({})).to.equal('(object)')
+  })
+
+  it('returns "(number)" for an number', () => {
+    expect(output(42)).to.equal('(number)')
+  })
+
+  it('returns "(boolean)" for true', () => {
+    expect(output(true)).to.equal('(boolean)')
+  })
+
+  it('returns "(boolean)" for false', () => {
+    expect(output(false)).to.equal('(boolean)')
+  })
+
+  it('returns "(empty string)" for the empty string', () => {
+    expect(output('')).to.equal('(empty string)')
+  })
+
+  it('returns "(blank string)" for a non-empty blank string', () => {
+    expect(output(' ')).to.equal('(blank string)')
+  })
+
+  it('returns the actual string for a non-blank string', () => {
+    expect(output('cake')).to.equal('cake')
+  })
+})
+
+describe('The redact function', () => {
+  it('returns "(null)" for a null value', () => {
+    expect(redact(null)).to.equal('(null)')
+  })
+
+  it('returns "(array)" for an array', () => {
+    expect(redact([])).to.equal('(array)')
+  })
+
+  it('returns "(object)" for an object', () => {
+    expect(redact({})).to.equal('(object)')
+  })
+
+  it('returns "(number)" for an number', () => {
+    expect(redact(42)).to.equal('(number)')
+  })
+
+  it('returns "(boolean)" for true', () => {
+    expect(redact(true)).to.equal('(boolean)')
+  })
+
+  it('returns "(boolean)" for false', () => {
+    expect(redact(false)).to.equal('(boolean)')
+  })
+
+  it('returns "(empty string)" for the empty string', () => {
+    expect(redact('')).to.equal('(empty string)')
+  })
+
+  it('returns "(blank string)" for a non-empty blank string', () => {
+    expect(redact(' ')).to.equal('(blank string)')
+  })
+
+  it('returns "(redacted non-blank string)" for a non-blank string', () => {
+    expect(redact('cake')).to.equal('(redacted non-blank string)')
+  })
+})


### PR DESCRIPTION
When we receive an Apple Pay or Google Pay payload, log some
selected properties like this (not a representative example):

```json
"message": "Received Apple Pay payload",
"selected_payload_properties": {
  "token": {
    "paymentMethod": {
      "displayName": "Visa 1233",
      "network": "visa",
      "type": "debit"
    }
  },
  "shippingContact": {
    "givenName": "(empty string)",
    "familyName": "(null)",
    "emailAddress": "(redacted non-blank string)"
  }
}
```

It’s not the complete payload, only some properties we manipulate before sending to connector. Properties with null values get removed somewhere in our logging pipeline, which is why values like `"(null)"` and `"(empty string)"` are used. Some property values may contain personally-identifiable information, so we don’t output the actual value there, instead using `"(redacted non-blank string)"`.