### PR TITLE
PP-6613 - Allow all supported cards as normalised for Apple Pay

### DIFF
--- a/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
+++ b/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
@@ -59,7 +59,15 @@ const normaliseCardName = cardName => {
     case 'amex':
       return 'american-express'
     case 'visa':
+    case 'electron':
       return 'visa'
+    case 'discover':
+      return 'discover'
+    case 'jcb':
+      return 'jcb'
+    case 'maestro':
+      return 'maestro'
+
     default:
       throw new Error('Unrecognised card brand in Apple Pay payload: ' + cardName)
   }

--- a/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
+++ b/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
@@ -53,6 +53,36 @@ describe('normalise apple pay payload', function () {
       }
     )
   })
+  it('should return an error when an unrecognizable card brand is passed in', function () {
+    const applePayPayload = {
+      shippingContact: {
+        emailAddress: 'jonheslop@bla.test',
+        familyName: 'payment',
+        givenName: 'mr',
+        phoneticFamilyName: '',
+        phoneticGivenName: ''
+      },
+      token: {
+        paymentData: {
+          version: 'EC_v1',
+          data: 'MLHhOn2BXhNw9wLLDR48DyeUcuSmRJ6KnAIGTMGqsgiMpc+AoJ…LUQ6UovkfSnW0sFH6NGZ0jhoap6LYnThYb9WT6yKfEm/rDhM=',
+          signature: 'MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFAD…ZuQFfsLJ+Nb3+7bpjfBsZAhA1sIT1XmHoGFdoCUT3AAAAAAAA',
+          header: {
+            ephemeralPublicKey: 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5/Qc6z4TY5HQ5n…KC3kJ4DtIWedPQ70N35PBZzJUrFjtvDZFUvs80uo2ynu+lw==',
+            publicKeyHash: 'Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=',
+            transactionId: '372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9'
+          }
+        },
+        paymentMethod: {
+          displayName: 'Unsupportedcard',
+          network: 'UnSupportedCard',
+          type: 'debit'
+        },
+        transactionIdentifier: '372C3858122B6BC39C6095ECA2F994A8AA012F3B025D0D72ECFD449C2A5877F9'
+      }
+    }
+    expect(() => normalise({ body: applePayPayload })).to.throw('Unrecognised card brand in Apple Pay payload: UnSupportedCard')
+  })
   it('should return the correct format for the payload with min data', function () {
     const applePayPayload = {
       shippingContact: {


### PR DESCRIPTION
Description:
- Apple Pay code which filters the supported card brands allows Discover, JCB, Maestro and Visa Electron for Apple Pay. However
when we normalise the card brand we only allow Visa, Mastercard or American Express which causes an error for users who try to pay with
Discover, JCB, Maestro or Visa Electron.
- This PR modifies the normalisation code to allow for these.
- A test has been added to check to see whether an exception is thrown when an unrecognizable card brand has been inputted. We decided against testing all the cards as testing a single card would be sufficient.

Paired with @narinderchana
