### PR TITLE
PP-6613 - Allow all supported cards as normalised for Google Pay

### DIFF
--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -44,11 +44,19 @@ const normaliseCardName = cardName => {
     case 'AMEX':
       return 'american-express'
     case 'VISA':
+    case 'ELECTRON':
       return 'visa'
+    case 'DISCOVER':
+      return 'discover'
+    case 'JCB':
+      return 'jcb'
+    case 'MAESTRO':
+      return 'maestro'
     default:
-      throw new Error('Unrecognised card brand in google pay payload')
+      throw new Error('Unrecognised card brand in Google Pay payload: ' + cardName)
   }
 }
+
 const nullable = word => {
   if (word.length === 0 || !word.trim()) {
     return null

--- a/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
+++ b/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
@@ -41,6 +41,32 @@ describe('normalise Google Pay payload', () => {
       }
     )
   })
+
+  it('should throw error for invalid the payload', () => {
+    const googlePayPayload = {
+      details: {
+        apiVersionMinor: 0,
+        apiVersion: 2,
+        paymentMethodData: {
+          description: 'UnSupported card •••• 4242',
+          info: {
+            cardNetwork: 'UnSupportedCard',
+            cardDetails: '4242'
+          },
+          tokenizationData: {
+            type: 'PAYMENT_GATEWAY',
+            token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+          },
+          type: 'CARD'
+        }
+      },
+      payerEmail: 'name@email.fyi',
+      payerName: 'Some Name'
+    }
+
+    expect(() => normalise({ body: googlePayPayload })).to.throw('Unrecognised card brand in Google Pay payload: UnSupportedCard')
+  })
+
   it('should return the correct format for the payload with min data', () => {
     const googlePayPayload = {
       details: {


### PR DESCRIPTION
Description:
- Google Pay code which filters the supported card brands allows Discover, JCB, Maestro and Visa Electron for Google Pay. However
when we normalise the card brand we only allow Visa, Mastercard or American Express which causes an error for users who try to pay with
Discover, JCB, Maestro or Visa Electron.
- This PR modifies the normalisation code to allow for these.
- A test has been added to check to see whether an exception is thrown when an unrecognizable card brand has been inputted. We decided against testing all the cards as testing a single card would be sufficient.

