### PR TITLE
PP-6614 Normalise the last four digits for Apple Pay

### DIFF
--- a/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
+++ b/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
@@ -3,6 +3,7 @@
 const logger = require('../../../utils/logger')(__filename)
 const { getLoggingFields } = require('../../../utils/logging_fields_helper')
 const { output, redact } = require('../../../utils/structured_logging_value_helper')
+const isNumeric = require('../../../utils/number')
 const humps = require('humps')
 
 const logselectedPayloadProperties = req => {
@@ -80,7 +81,14 @@ const nullable = word => {
   return word
 }
 
-const normaliseLastDigitsCardNumber = displayName => displayName.substr(displayName.length - 4)
+const normaliseLastDigitsCardNumber = displayName => {
+  let lastDigitsCardNumber = ''
+  const lastFourChars = displayName.substr(displayName.length - 4)
+  if (displayName.length >= 4 && isNumeric(lastFourChars)) {
+    lastDigitsCardNumber = lastFourChars
+  }
+  return lastDigitsCardNumber
+}
 
 module.exports = req => {
   logselectedPayloadProperties(req)

--- a/app/utils/number.js
+++ b/app/utils/number.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = str => {
+  return !isNaN(str) && !isNaN(parseInt(str))
+}

--- a/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
+++ b/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
@@ -53,6 +53,124 @@ describe('normalise apple pay payload', function () {
       }
     )
   })
+
+  it('should return an empty string for last_digits_card_number when displayName does not have numeric values for last 4 characters', function () {
+    const applePayPayload = {
+      shippingContact: {
+        emailAddress: 'jonheslop@bla.test',
+        familyName: 'payment',
+        givenName: 'mr',
+        phoneticFamilyName: '',
+        phoneticGivenName: ''
+      },
+      token: {
+        paymentData: {
+          version: 'EC_v1',
+          data: 'MLHhOn2BXhNw9wLLDR48DyeUcuSmRJ6KnAIGTMGqsgiMpc+AoJ…LUQ6UovkfSnW0sFH6NGZ0jhoap6LYnThYb9WT6yKfEm/rDhM=',
+          signature: 'MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFAD…ZuQFfsLJ+Nb3+7bpjfBsZAhA1sIT1XmHoGFdoCUT3AAAAAAAA',
+          header: {
+            ephemeralPublicKey: 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5/Qc6z4TY5HQ5n…KC3kJ4DtIWedPQ70N35PBZzJUrFjtvDZFUvs80uo2ynu+lw==',
+            publicKeyHash: 'Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=',
+            transactionId: '372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9'
+          }
+        },
+        paymentMethod: {
+          displayName: 'MasterCard ABDC',
+          network: 'MasterCard',
+          type: 'debit'
+        },
+        transactionIdentifier: '372C3858122B6BC39C6095ECA2F994A8AA012F3B025D0D72ECFD449C2A5877F9'
+      }
+    }
+    const normalisedPayload = normalise({ body: applePayPayload })
+    expect(normalisedPayload).to.have.deep.nested.property('payment_info',
+      {
+        last_digits_card_number: '',
+        brand: 'master-card',
+        card_type: 'DEBIT',
+        cardholder_name: 'mr payment',
+        email: 'jonheslop@bla.test'
+      })
+  })
+
+  it('should return an empty string for last_digits_card_number when displayName is shorter than 4 characters', function () {
+    const applePayPayload = {
+      shippingContact: {
+        emailAddress: 'jonheslop@bla.test',
+        familyName: 'payment',
+        givenName: 'mr',
+        phoneticFamilyName: '',
+        phoneticGivenName: ''
+      },
+      token: {
+        paymentData: {
+          version: 'EC_v1',
+          data: 'MLHhOn2BXhNw9wLLDR48DyeUcuSmRJ6KnAIGTMGqsgiMpc+AoJ…LUQ6UovkfSnW0sFH6NGZ0jhoap6LYnThYb9WT6yKfEm/rDhM=',
+          signature: 'MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFAD…ZuQFfsLJ+Nb3+7bpjfBsZAhA1sIT1XmHoGFdoCUT3AAAAAAAA',
+          header: {
+            ephemeralPublicKey: 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5/Qc6z4TY5HQ5n…KC3kJ4DtIWedPQ70N35PBZzJUrFjtvDZFUvs80uo2ynu+lw==',
+            publicKeyHash: 'Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=',
+            transactionId: '372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9'
+          }
+        },
+        paymentMethod: {
+          displayName: 'JBC',
+          network: 'MasterCard',
+          type: 'debit'
+        },
+        transactionIdentifier: '372C3858122B6BC39C6095ECA2F994A8AA012F3B025D0D72ECFD449C2A5877F9'
+      }
+    }
+    const normalisedPayload = normalise({ body: applePayPayload })
+    expect(normalisedPayload).to.have.deep.nested.property('payment_info',
+      {
+        last_digits_card_number: '',
+        brand: 'master-card',
+        card_type: 'DEBIT',
+        cardholder_name: 'mr payment',
+        email: 'jonheslop@bla.test'
+      })
+  })
+
+  it('should return an empty string for last_digits_card_number when displayName is an empty string', function () {
+    const applePayPayload = {
+      shippingContact: {
+        emailAddress: 'jonheslop@bla.test',
+        familyName: 'payment',
+        givenName: 'mr',
+        phoneticFamilyName: '',
+        phoneticGivenName: ''
+      },
+      token: {
+        paymentData: {
+          version: 'EC_v1',
+          data: 'MLHhOn2BXhNw9wLLDR48DyeUcuSmRJ6KnAIGTMGqsgiMpc+AoJ…LUQ6UovkfSnW0sFH6NGZ0jhoap6LYnThYb9WT6yKfEm/rDhM=',
+          signature: 'MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFAD…ZuQFfsLJ+Nb3+7bpjfBsZAhA1sIT1XmHoGFdoCUT3AAAAAAAA',
+          header: {
+            ephemeralPublicKey: 'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5/Qc6z4TY5HQ5n…KC3kJ4DtIWedPQ70N35PBZzJUrFjtvDZFUvs80uo2ynu+lw==',
+            publicKeyHash: 'Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=',
+            transactionId: '372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9'
+          }
+        },
+        paymentMethod: {
+          displayName: '       ',
+          network: 'MasterCard',
+          type: 'debit'
+        },
+        transactionIdentifier: '372C3858122B6BC39C6095ECA2F994A8AA012F3B025D0D72ECFD449C2A5877F9'
+      }
+    }
+    const normalisedPayload = normalise({ body: applePayPayload })
+    expect(normalisedPayload).to.have.deep.nested.property('payment_info',
+      {
+        last_digits_card_number: '',
+        brand: 'master-card',
+        card_type: 'DEBIT',
+        cardholder_name: 'mr payment',
+        email: 'jonheslop@bla.test'
+      })
+  })
+
   it('should return an error when an unrecognizable card brand is passed in', function () {
     const applePayPayload = {
       shippingContact: {
@@ -74,7 +192,7 @@ describe('normalise apple pay payload', function () {
           }
         },
         paymentMethod: {
-          displayName: 'Unsupportedcard',
+          displayName: 'Unsupportedcard 4567',
           network: 'UnSupportedCard',
           type: 'debit'
         },


### PR DESCRIPTION
- If the displayName is less than four characters then map the last four digits to an empty string.
- If the last four characters of the displayName are not numeric then map the last four digits to an empty string.

Paired with @narinderchana 

