### PR TITLE
PP-6613 - Disallow Maestro for Google Pay normalisation code

### DIFF
--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -50,8 +50,6 @@ const normaliseCardName = cardName => {
       return 'discover'
     case 'JCB':
       return 'jcb'
-    case 'MAESTRO':
-      return 'maestro'
     default:
       throw new Error('Unrecognised card brand in Google Pay payload: ' + cardName)
   }


### PR DESCRIPTION
Description:
- We don't allow Maestro when setting up Google Pay so we can remove it from the normalisation code to ensure consistency

