### PR TITLE
PP-6328 Fix selecting Google Pay merchant ID by gateway account ID

### DIFF
--- a/app/utils/google_pay_merchant_id_selector.js
+++ b/app/utils/google_pay_merchant_id_selector.js
@@ -6,12 +6,12 @@ const {
 
 const getMerchantId = (gatewayAccountId) => {
   var gatewayAccountIdsForGooglePayMerchantId2 = []
-  
+
   if (GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2) {
     gatewayAccountIdsForGooglePayMerchantId2 = GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2.trim().split(' ')
   }
-  
-  if (GOOGLE_PAY_MERCHANT_ID_2 && gatewayAccountIdsForGooglePayMerchantId2.includes(gatewayAccountId)) {
+
+  if (GOOGLE_PAY_MERCHANT_ID_2 && gatewayAccountIdsForGooglePayMerchantId2.includes(gatewayAccountId.toString())) {
     return GOOGLE_PAY_MERCHANT_ID_2
   } else {
     return GOOGLE_PAY_MERCHANT_ID

--- a/test/utils/google_pay_merchant_id_test.js
+++ b/test/utils/google_pay_merchant_id_test.js
@@ -4,9 +4,10 @@ const proxyquire = require('proxyquire').noPreserveCache()
 
 const googlePayMerchantId = 'google_pay_merchant_id'
 const googlePayMerchantId2 = 'google_pay_merchant_id_2'
-const gatewayAccountForGooglePayMerchantId2 = 'ga4merchantId2'
+const gatewayAccountIdsForGooglePayMerchantId2 = '4 8 15 16 23 42'
+const gatewayAccountIdThatIsInGatewayAccountIdsForGooglePayMerchantId2 = 23
 
-describe('google pay merchant id test', function () {
+describe('Google Pay merchant ID selector test', function () {
   beforeEach(() => {
     process.env.GOOGLE_PAY_MERCHANT_ID = googlePayMerchantId
   })
@@ -20,18 +21,18 @@ describe('google pay merchant id test', function () {
     it('when GOOGLE_PAY_MERCHANT_ID_2 env var is set but GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 is not set', () => {
       process.env.GOOGLE_PAY_MERCHANT_ID_2 = googlePayMerchantId2
       const { getMerchantId } = newGooglePayMerchantIdCalculator()
-      expect(getMerchantId(gatewayAccountForGooglePayMerchantId2)).to.equal(googlePayMerchantId)
+      expect(getMerchantId(gatewayAccountIdThatIsInGatewayAccountIdsForGooglePayMerchantId2)).to.equal(googlePayMerchantId)
     })
 
     it('when GOOGLE_PAY_MERCHANT_ID_2 env var is empty', () => {
-      process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 = gatewayAccountForGooglePayMerchantId2
+      process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 = gatewayAccountIdsForGooglePayMerchantId2
       const { getMerchantId } = newGooglePayMerchantIdCalculator()
-      expect(getMerchantId(gatewayAccountForGooglePayMerchantId2)).to.equal(googlePayMerchantId)
+      expect(getMerchantId(gatewayAccountIdThatIsInGatewayAccountIdsForGooglePayMerchantId2)).to.equal(googlePayMerchantId)
     })
 
     it('when GOOGLE_PAY_MERCHANT_ID_2 env var is set but gateway account is irrelevant', () => {
       process.env.GOOGLE_PAY_MERCHANT_ID_2 = googlePayMerchantId2
-      process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 = gatewayAccountForGooglePayMerchantId2
+      process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 = gatewayAccountIdsForGooglePayMerchantId2
       const { getMerchantId } = newGooglePayMerchantIdCalculator()
       expect(getMerchantId('irrelevant')).to.equal(googlePayMerchantId)
     })
@@ -40,13 +41,13 @@ describe('google pay merchant id test', function () {
   describe('should return GOOGLE_PAY_MERCHANT_ID_2', () => {
     it('when GOOGLE_PAY_MERCHANT_ID_2 env var is set and gateway account is relevant', () => {
       process.env.GOOGLE_PAY_MERCHANT_ID_2 = googlePayMerchantId2
-      process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 = gatewayAccountForGooglePayMerchantId2
+      process.env.GATEWAY_ACCOUNT_IDS_FOR_GOOGLE_PAY_MERCHANT_ID_2 = gatewayAccountIdsForGooglePayMerchantId2
       const { getMerchantId } = newGooglePayMerchantIdCalculator()
-      expect(getMerchantId(gatewayAccountForGooglePayMerchantId2)).to.equal(googlePayMerchantId2)
+      expect(getMerchantId(gatewayAccountIdThatIsInGatewayAccountIdsForGooglePayMerchantId2)).to.equal(googlePayMerchantId2)
     })
   })
 })
 
-function newGooglePayMerchantIdCalculator() {
+function newGooglePayMerchantIdCalculator () {
   return proxyquire('../../app/utils/google_pay_merchant_id_selector.js', {})
 }


### PR DESCRIPTION
The environment variable that says which gateway account IDs should use `GOOGLE_PAY_MERCHANT_ID_2` rather than `GOOGLE_PAY_MERCHANT_ID` is a string containing space-separated IDs, which gets tokenised into an array of strings. The gateway account ID we look for in the array is a number, so it needs to be converted to a string first or we’ll never find a match.