### PR TITLE
PP-6328 Don’t log “Using GOOGLE_PAY_MERCHANT_ID_2” so often

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -9,6 +9,7 @@ const {
   WORLDPAY_3DS_FLEX_DDC_TEST_URL,
   WORLDPAY_3DS_FLEX_DDC_LIVE_URL,
   DECRYPT_AND_OMIT_CARD_DATA,
+  GOOGLE_PAY_MERCHANT_ID,
   GOOGLE_PAY_MERCHANT_ID_2
 } = process.env
 const logger = require('../utils/logger')(__filename)
@@ -55,7 +56,7 @@ const appendChargeForNewView = async function appendChargeForNewView (charge, re
   charge.googlePayGatewayMerchantID = charge.gatewayAccount.gatewayMerchantId
 
   const googlePayMerchantId = getMerchantId(charge.gatewayAccount.gatewayAccountId)
-  if (googlePayMerchantId === GOOGLE_PAY_MERCHANT_ID_2) {
+  if (googlePayMerchantId !== GOOGLE_PAY_MERCHANT_ID && googlePayMerchantId === GOOGLE_PAY_MERCHANT_ID_2) {
     logger.info('Using GOOGLE_PAY_MERCHANT_ID_2', { ...getLoggingFields(req) })
   }
 


### PR DESCRIPTION
Only log `Using GOOGLE_PAY_MERCHANT_ID_2` if the Google Pay merchant ID matches `GOOGLE_PAY_MERCHANT_ID_2` and is not the same as `GOOGLE_PAY_MERCHANT_ID`.

Otherwise, if `GOOGLE_PAY_MERCHANT_ID` and `GOOGLE_PAY_MERCHANT_ID_2` are the same, we’ll log this message for every single payment (even when Google Pay isn’t available), which is just noise.