### PR TITLE
PP-66611 Handle Apple Pay not having shipping contact better

### DIFF
--- a/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
+++ b/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
@@ -73,13 +73,6 @@ const normaliseCardName = cardName => {
   }
 }
 
-const nullable = word => {
-  if (word.length === 0 || !word.trim()) {
-    return null
-  }
-  return word
-}
-
 const normaliseLastDigitsCardNumber = displayName => {
   let lastDigitsCardNumber = ''
   if (displayName.length >= 4) {
@@ -91,6 +84,28 @@ const normaliseLastDigitsCardNumber = displayName => {
   return lastDigitsCardNumber
 }
 
+const normaliseCardholderName = payload => {
+  if (payload.shippingContact) {
+    if (payload.shippingContact.givenName && payload.shippingContact.familyName) {
+      return payload.shippingContact.givenName + ' ' + payload.shippingContact.familyName
+    }
+    if (payload.shippingContact.familyName) {
+      return payload.shippingContact.familyName
+    }
+    if (payload.shippingContact.givenName) {
+      return payload.shippingContact.givenName
+    }
+  }
+  return null
+}
+
+const normaliseEmail = payload => {
+  if (payload.shippingContact && payload.shippingContact.emailAddress) {
+    return payload.shippingContact.emailAddress
+  }
+  return null
+}
+
 module.exports = req => {
   logselectedPayloadProperties(req)
 
@@ -100,8 +115,8 @@ module.exports = req => {
     last_digits_card_number: normaliseLastDigitsCardNumber(payload.token.paymentMethod.displayName),
     brand: normaliseCardName(payload.token.paymentMethod.network),
     card_type: payload.token.paymentMethod.type.toUpperCase(),
-    cardholder_name: nullable(payload.shippingContact.givenName + ' ' + payload.shippingContact.familyName),
-    email: nullable(payload.shippingContact.emailAddress)
+    cardholder_name: normaliseCardholderName(payload),
+    email: normaliseEmail(payload)
   }
 
   delete payload.token.paymentMethod

--- a/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
+++ b/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
@@ -199,13 +199,6 @@ describe('normalise apple pay payload', function () {
   })
   it('should return the correct format for the payload with min data', function () {
     const applePayPayload = {
-      shippingContact: {
-        emailAddress: '',
-        familyName: '',
-        givenName: '',
-        phoneticFamilyName: '',
-        phoneticGivenName: ''
-      },
       token: {
         paymentData: {
           version: 'EC_v1',


### PR DESCRIPTION
It is our understanding that if we receive an Apple Pay payload with an email address, we get a `shippingContact` object with an `emailAddress` property populated and other properties, such as `givenName` and `familyName`, set to empty strings (because we don’t actually request a shipping name when initiating Apple Pay). When there is no email address (because email address collection is switched off for the service), we believe we get no `shippingContact` object at all (though we would if we requested a shipping name).

Harden our code to remove the assumption that there’s always a `shippingContact` object.