### PR TITLE
PP-6857 Disable confirm payment button on submit

### DIFF
--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -49,6 +49,11 @@
       window.payScripts.formValidation.init();
       window.payScripts.epdq3ds2.init();
     } else if (mainWrap.classList.contains('confirm-page')) {
+      var confirmationForm = document.getElementById('confirmation')
+      var confirmButton = document.getElementById('confirm')
+      confirmationForm.addEventListener('submit', function () {
+        confirmButton.setAttribute('disabled', 'disabled')
+      })
       analyticsTrackConfirmClick().init('{{analytics.analyticsId}}', '{{analytics.type}}', '{{analytics.paymentProvider}}', '{{analytics.amount}}', '{{hitPage}}');
     }
     {% if allowGooglePay%}


### PR DESCRIPTION
We currently rely on the GOV.UK design system button behaviour of
`preventDoubleClick` "debouncing" form submission to prevent multiple
confirm submissions.

This debounce only lasts for 1 second so if a submission takes longer
then that (due to slow page load, slow Connector response, etc.) the
user could potentially press submit again. If submitted twice the second
submit is guaranteed to `403` as the first submit removes the users
session.

In order to maintain parity between the confirmation page and the
payments page, disable the form submission button after it has been
pressed. This `POST` request is terminal (it will either redirect or
render an error page) and so there is never a scenario where it needs to
respond to upstream events (i.e be clicked again).

Future PRs/ issues will propose upstream to the design system that there
is use for terminally "debouncing" a button for form submissions that
take a long time.

Cypress tests should assert this to future regressions and will follow
in another commit.

