### PR TITLE
PP-4733: Spike sending metrics to hosted graphite

### DIFF
--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -4,6 +4,13 @@ const logger = require('../../utils/logger')(__filename)
 const baseClient = require('./base_client/base_client')
 const requestLogger = require('../../utils/request_logger')
 
+const metrics = require('metrics')
+const registry = new metrics.Report
+const GraphiteReporter = new metrics.GraphiteReporter(registry, "frontend.connector.calls", process.env.METRICS_HOST, 8094)
+const meter = new metrics.Meter
+registry.addMetric("myapp.Meter", meter)
+GraphiteReporter.start(1000)
+
 // Constants
 const SERVICE_NAME = 'connector'
 
@@ -161,6 +168,10 @@ const _getConnector = (url, description, loggingFields = {}) => {
       description: description,
       service: SERVICE_NAME
     }
+
+    console.log('Calling meter.mark()')
+    meter.mark()
+    
     requestLogger.logRequestStart(context, loggingFields)
     baseClient.get(
       url,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7984,6 +7984,11 @@
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
+    "events": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg=="
+    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -13820,6 +13825,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "metrics": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/metrics/-/metrics-0.1.21.tgz",
+      "integrity": "sha512-Lg/0Kj7fani6FDmlC99glxpPjK3GHzE50Hp6IVIaMhGc9ZxR2MF0Eo4haOl1C0cGWpRkViv45P0hdvRJghkJtQ==",
+      "requires": {
+        "events": "^2.0.0"
+      }
     },
     "micromatch": {
       "version": "3.1.10",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "lodash": "4.17.x",
     "mailcheck": "^1.1.1",
     "memory-cache": "^0.2.0",
+    "metrics": "0.1.21",
     "minimist": "1.2.x",
     "moment-timezone": "^0.5.31",
     "morgan": "1.10.x",


### PR DESCRIPTION
Send metrics to port 8094 as we've configured telegraf to listen to TCP traffic
this port. This PR is meant to be a spike and will be reverted once we prove
metrics appear in hosted graphite.
