### PR TITLE
PP-7075 Add logging for DDC request for Worldpay 3DS flex

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -72,7 +72,7 @@ const appendChargeForNewView = async function appendChargeForNewView (charge, re
   charge.worldpay3dsFlexDdcUrl = charge.gatewayAccount.type !== 'live' ? WORLDPAY_3DS_FLEX_DDC_TEST_URL : WORLDPAY_3DS_FLEX_DDC_LIVE_URL
 
   charge.collectAdditionalBrowserDataForEpdq3ds = charge.gatewayAccount.paymentProvider === 'epdq' &&
-      charge.gatewayAccount.requires3ds && charge.gatewayAccount.integrationVersion3ds === 2
+    charge.gatewayAccount.requires3ds && charge.gatewayAccount.integrationVersion3ds === 2
 }
 
 const routeFor = (resource, chargeId) => paths.generateRoute(`card.${resource}`, { chargeId: chargeId })
@@ -137,6 +137,16 @@ module.exports = {
 
     normalise.addressLines(req.body)
     normalise.whitespace(req.body)
+
+
+    const { worldpay3dsFlexDdcStatus } = req.body
+    if (worldpay3dsFlexDdcStatus) {
+      logger.info(`Payment details submitted for a Worldpay 3DS Flex charge. DDC status is: ${worldpay3dsFlexDdcStatus}`,
+        {
+          ...getLoggingFields(req),
+          worldpay_3ds_flex_ddc_status: worldpay3dsFlexDdcStatus
+        })
+    }
 
     if (charge.status === State.AUTH_READY) return redirect(res).toAuthWaiting(req.chargeId)
     // else

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -127,6 +127,9 @@
                 {% if (originalEmail) %}
                   <input name="originalemail" type="hidden" value="{{ originalEmail }}"/>
                 {% endif %}
+                {% if worldpay3dsFlexDdcJwt %}
+                  <input name="worldpay3dsFlexDdcStatus" id="worldpay3dsFlexDdcStatus" type="hidden" value="Not initiated"/>
+                {% endif %}
 
                 <div class="govuk-form-group{% if highlightErrorFields.cardNo %} govuk-form-group--error{% endif %} card-no-group" data-validation="cardNo">
                   <label id="card-no-lbl" for="card-no" class="govuk-label govuk-label--s govuk-!-width-three-quarters">

--- a/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.spec.js
+++ b/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.spec.js
@@ -95,32 +95,36 @@ describe('Worldpay 3ds flex card payment flow', () => {
   }
 
   setUpAndCheckCardPaymentPage()
-  describe('Secure confirmation page', () => {
-    it('Submitting confirmation with valid details and a JWT should cause worldpay iFrame result to post a message with the session ID', () => {
+  describe('Valid DDC response', () => {
+    it('Form is submitted with the session ID from the DDC response', () => {
       cy.task('setupStubs', [...confirmPaymentDetailsStubs, worldpay3dsFlexDdcStub])
 
       cy.get('#card-details').submit().should($form => {
         const formVal = $form.first()[0].elements.worldpay3dsFlexDdcResult.value
         expect(formVal).to.eq(worldpaySessionId)
+        const ddcStatusVal = $form.first()[0].elements.worldpay3dsFlexDdcStatus.value
+        expect(ddcStatusVal).to.eq('valid DDC result')
       })
     })
   })
 
   setUpAndCheckCardPaymentPage()
-  describe('Secure confirmation page', () => {
-    it('If Worldpay were to respond with status=false, submitting confirmation should not include the hidden input containing the session ID', () => {
+  describe('Worldpay responds with status=false', () => {
+    it('submitting confirmation should not include the hidden input containing the session ID', () => {
       cy.task('setupStubs', [...confirmPaymentDetailsStubs, worldpay3dsFlexDdcStubFailure])
 
       cy.get('#card-details').submit().should($form => {
         const formVal = $form.first()[0].elements.worldpay3dsFlexDdcResult
         expect(formVal).to.eq(undefined)
+        const ddcStatusVal = $form.first()[0].elements.worldpay3dsFlexDdcStatus.value
+        expect(ddcStatusVal).to.eq('DDC result did not have Status of true')
       })
     })
   })
 
   setUpAndCheckCardPaymentPage()
-  describe('Secure confirmation page', () => {
-    it('Submitting confirmation when Worldpay times out after  iframe post should still submit the form but without the worldpaySessionId', () => {
+  describe('DDC times out', () => {
+    it('iframe post should still submit the form but without the worldpaySessionId', () => {
       confirmPaymentDetailsStubs.pop()
       cy.task('setupStubs', confirmPaymentDetailsStubs)
 


### PR DESCRIPTION
Add a hidden form field to the payment details form containing a status for the Device Data Collection (DDC) for Worldpay 3DS flex.

Update this status at various points in performing the DDC request. On the server side, log the value of this hidden status field so we can use this to determine at what point the DDC went wrong if we do not get a result to use.

Regenerate .secrets.baseline to ignore package.lock.json