### PR TITLE
PP-6995: Log downstream errors

### DIFF
--- a/app/services/clients/adminusers_client.js
+++ b/app/services/clients/adminusers_client.js
@@ -39,6 +39,13 @@ function _getAdminUsers(url, description, findOptions, loggingFields = {}, calli
         return new Service(response.body)
       } else {
         if (response.statusCode > 499 && response.statusCode < 600) {
+          logger.error(`Error communicating with ${url}`, {
+            ...loggingFields,
+            service: 'adminusers',
+            method: 'GET',
+            status_code: response.statusCode,
+            url: url
+          })
           incrementFailureCounter(callingFunctionName, response.statusCode)
         }
         return response.body

--- a/app/services/clients/connector_client.js
+++ b/app/services/clients/connector_client.js
@@ -70,6 +70,13 @@ function _putConnector(url, payload, description, loggingFields = {}, callingFun
     .then(response => {
       logger.info('PUT to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       if (response.statusCode > 499 && response.statusCode < 600) {
+        logger.error(`Error communicating with ${url}`, {
+          ...loggingFields,
+          service: 'connector',
+          method: 'PUT',
+          status_code: response.statusCode,
+          url: url
+        })
         incrementFailureCounter(callingFunctionName, response.statusCode)
       }
       return response
@@ -103,6 +110,13 @@ function _postConnector(url, payload, description, loggingFields = {}, callingFu
   ).then(response => {
     logger.info('POST to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
     if (response.statusCode > 499 && response.statusCode < 600) {
+      logger.error(`Error communicating with ${url}`, {
+        ...loggingFields,
+        service: 'connector',
+        method: 'POST',
+        status_code: response.statusCode,
+        url: url
+      })
       incrementFailureCounter(callingFunctionName, response.statusCode)
     }
     return response
@@ -136,6 +150,13 @@ function _patchConnector(url, payload, description, loggingFields = {}, callingF
   ).then(response => {
     logger.info('PATCH to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
     if (response.statusCode > 499 && response.statusCode < 600) {
+      logger.error(`Error communicating with ${url}`, {
+        ...loggingFields,
+        service: 'connector',
+        method: 'PATCH',
+        status_code: response.statusCode,
+        url: url
+      })
       incrementFailureCounter(callingFunctionName, response.statusCode)
     }
     return response
@@ -167,11 +188,12 @@ function _getConnector(url, description, loggingFields = {}, callingFunctionName
     .then(response => {
       logger.info('GET to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       if (response.statusCode !== 200) {
-        logger.warn('Calling connector to GET something returned a non http 200 response', {
+        logger.error(`Error communicating with ${url}`, {
           ...loggingFields,
           service: 'connector',
           method: 'GET',
-          status_code: response.statusCode
+          status_code: response.statusCode,
+          url: url
         })
         if (response.statusCode > 499 && response.statusCode < 600) {
           incrementFailureCounter(callingFunctionName, response.statusCode)


### PR DESCRIPTION
The acceptance criteria on the story says 
```
Log a structured log line at error level with the message Error communicating with https://the-url-goes-here and a url key containing the URL and, if appropriate, a remote_http_status key containing the HTTP status code.
```
However some errors have already been logged with other messages. The important thing is that errors are being logged so I'm not too concerned about logging `Error communicating with https://the-url-goes-here`. 
`status_code` is already used in places so using this instead of `remote_http_status`.
