### PR TITLE
PP-6957 Fix MOTO Mask Frontend bug - to use the MOTO flag from the charge.

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -54,9 +54,6 @@ const appendChargeForNewView = async function appendChargeForNewView (charge, re
   charge.allowApplePay = charge.gatewayAccount.allowApplePay
   charge.allowGooglePay = charge.gatewayAccount.allowGooglePay
   charge.googlePayGatewayMerchantID = charge.gatewayAccount.gatewayMerchantId
-  charge.allowMoto = charge.gatewayAccount.allowMoto
-  charge.motoMaskCardNumberInput = charge.gatewayAccount.motoMaskCardNumberInput
-  charge.motoMaskCardSecurityCodeInput = charge.gatewayAccount.motoMaskCardSecurityCodeInput
 
   const googlePayMerchantId = getMerchantId(charge.gatewayAccount.gatewayAccountId)
   if (googlePayMerchantId !== GOOGLE_PAY_MERCHANT_ID && googlePayMerchantId === GOOGLE_PAY_MERCHANT_ID_2) {

--- a/app/services/normalise_charge.js
+++ b/app/services/normalise_charge.js
@@ -19,6 +19,7 @@ module.exports = (function () {
       links: charge.links,
       status: charge.status,
       email: charge.email,
+      moto: charge.moto,
       gatewayAccount: _normaliseGatewayAccountDetails(charge.gateway_account)
     }
     if (charge.auth_3ds_data) {

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -146,7 +146,7 @@
                     {% endif %}
                   </label>
                   
-                  {% if allowMoto and motoMaskCardNumberInput %} 
+                  {% if moto and gatewayAccount.motoMaskCardNumberInput %} 
                     {% set cardNumberInputType = 'password' %}  
                     {% set cardNumberAutoCompleteType = 'off' %}
                   {% else %}
@@ -296,7 +296,7 @@
                     {% endif %}
                   </label>
 
-                  {% if allowMoto and motoMaskCardSecurityCodeInput %} 
+                  {% if moto and gatewayAccount.motoMaskCardSecurityCodeInput %} 
                     {% set securityCodeInputType = 'password' %}  
                     {% set securityCodeAutoCompleteType = 'off' %}
                   {% else %}

--- a/test/cypress/integration/card/moto-mask-payment.spec.js
+++ b/test/cypress/integration/card/moto-mask-payment.spec.js
@@ -18,39 +18,61 @@ describe('Standard card payment flow', () => {
   }
 
   const createPaymentChargeStubsNoMoto = cardPaymentStubs.buildCreatePaymentChargeStubs(
-    tokenId, chargeId, 'en', gatewayAccountId, {}, {}, {
-      allowMoto: false
+    tokenId, chargeId, 'en', gatewayAccountId, {}, {}, {}, {
+      moto: false
     })
 
   const createPaymentChargeStubsNoMotoMaskCardNumberAndSecurityCode = cardPaymentStubs.buildCreatePaymentChargeStubs(
     tokenId, chargeId, 'en', gatewayAccountId, {}, {}, {
-      allowMoto: false,
       motoMaskCardNumberInput: true,
       motoMaskCardSecurityCodeInput: true
+    },
+    {
+      moto: false
+    })
+
+  const createPaymentChargeStubsNoMotoGatewayMotoMaskCardNumberAndSecurityCode = cardPaymentStubs.buildCreatePaymentChargeStubs(
+    tokenId, chargeId, 'en', gatewayAccountId, {}, {}, {
+      allowMoto: true,
+      motoMaskCardNumberInput: true,
+      motoMaskCardSecurityCodeInput: true
+    },
+    {
+      moto: false
     })
 
   const createPaymentChargeStubsMotoMaskCardNumberOnly = cardPaymentStubs.buildCreatePaymentChargeStubs(
     tokenId, chargeId, 'en', gatewayAccountId, {}, {}, {
-      allowMoto: true,
       motoMaskCardNumberInput: true
+    },
+    {
+      moto: true
     })
 
   const createPaymentChargeStubsMotoMaskSecurityCodeOnly = cardPaymentStubs.buildCreatePaymentChargeStubs(
     tokenId, chargeId, 'en', gatewayAccountId, {}, {}, {
       allowMoto: true,
       motoMaskCardSecurityCodeInput: true
+    },
+    {
+      moto: true
     })
 
   const createPaymentChargeStubsMotoMaskCardNumberAndSecurityCode = cardPaymentStubs.buildCreatePaymentChargeStubs(
     tokenId, chargeId, 'en', gatewayAccountId, {}, {}, {
-      allowMoto: true,
       motoMaskCardNumberInput: true,
       motoMaskCardSecurityCodeInput: true
+    },
+    {
+      moto: true
     })
 
   const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
 
-  const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment)
+  const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment, {},
+    {
+      moto: true
+    })
 
   beforeEach(() => {
     // this test is for the full process, the session should be maintained
@@ -86,6 +108,24 @@ describe('Standard card payment flow', () => {
     })
 
     it('Card number & security code input elements should NOT mask digits as it is not a MOTO service', () => {
+      cy.get('#card-no').invoke('attr', 'type').should('eq', 'text')
+      cy.get('#card-no').invoke('attr', 'autocomplete').should('eq', 'cc-number')
+
+      cy.get('#cvc').invoke('attr', 'type').should('eq', 'text')
+      cy.get('#cvc').invoke('attr', 'autocomplete').should('eq', 'cc-csc')
+    })
+  })
+
+  describe('Secure card payment page - MOTO NOT enabled but gateway account is MOTO enabled and masking set for both card number and security code', () => {
+    it('Should setup the payment and load the page', () => {
+      cy.task('setupStubs', createPaymentChargeStubsNoMotoGatewayMotoMaskCardNumberAndSecurityCode)
+      cy.visit(`/secure/${tokenId}`)
+
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      cy.window().its('chargeId').should('eq', `${chargeId}`)
+    })
+
+    it('Card number & security code input elements should NOT mask digits as MOTO is false for this charge', () => {
       cy.get('#card-no').invoke('attr', 'type').should('eq', 'text')
       cy.get('#card-no').invoke('attr', 'autocomplete').should('eq', 'cc-number')
 
@@ -209,9 +249,6 @@ describe('Standard card payment flow', () => {
       cy.get('#expiry-year').type(validPayment.expiryYear)
       cy.get('#cardholder-name').type(validPayment.name)
       cy.get('#cvc').type(validPayment.securityCode)
-      cy.get('#address-line-1').type(validPayment.addressLine1)
-      cy.get('#address-city').type(validPayment.city)
-      cy.get('#address-postcode').type(validPayment.postcode)
       cy.get('#email').type(validPayment.email)
     })
   })

--- a/test/cypress/utils/card-payment-stubs.js
+++ b/test/cypress/utils/card-payment-stubs.js
@@ -78,6 +78,7 @@ const buildCreatePaymentChargeStubs = function buildCreatePaymentChargeStubs (to
     {
       name: 'connectorCreateChargeFromToken',
       opts: {
+        ...additionalChargeOpts,
         tokenId,
         gatewayAccountId,
         status: 'CREATED',

--- a/test/utils/normalise_test.js
+++ b/test/utils/normalise_test.js
@@ -30,7 +30,8 @@ var unNormalisedCharge = {
       brand: 'VISA',
       label: 'Visa'
     }]
-  }
+  },
+  moto: false
 }
 
 var normalisedCharge = {
@@ -61,7 +62,8 @@ var normalisedCharge = {
       debit: false,
       credit: true
     }]
-  }
+  },
+  moto: false
 }
 
 var unNormalisedAddress = {


### PR DESCRIPTION
- Update `normalise_charge.js`, to pass the MOTO flag from the charge.
- Update Nunjucks template
  - Use the MOTO value from the charge rather then the gateway account.
  - General clean up of code
- Uppdate Cypress tests and payment stubs.