### PR TITLE
PP-7118 Ignore cookies for 3ds urls

### DIFF
--- a/app/services/charge_param_retriever.js
+++ b/app/services/charge_param_retriever.js
@@ -7,20 +7,25 @@ const cookie = require('../utils/cookies')
 
 exports.retrieve = req => {
   const chargeId = req.params.chargeId ? req.params.chargeId : req.body.chargeId
-  setLoggingField(req, PAYMENT_EXTERNAL_ID, chargeId)
 
+  setLoggingField(req, PAYMENT_EXTERNAL_ID, chargeId)
+  
   if (!chargeId) {
     logger.error('ChargeId was not found in request', getLoggingFields(req))
     return false
   } else if (!cookie.getSessionCookieName() || !cookie.isSessionPresent(req)) {
-    logger.info('Session cookie is not present', {
-      ...getLoggingFields(req),
-      referrer: req.get('Referrer'),
-      url: req.originalUrl,
-      method: req.method
-    })
-    return false
-  } else if (!cookie.getSessionVariable(req, 'ch_' + chargeId)) {
+    if(req.originalUrl && req.method.toLowerCase() === 'post' && req.originalUrl.includes(`/card_details/${chargeId}/3ds_required_in`)) {
+      return chargeId
+    } else {
+      logger.info('Session cookie is not present', {
+        ...getLoggingFields(req),
+        referrer: req.get('Referrer'),
+        url: req.originalUrl,
+        method: req.method
+      })
+      return false
+    }
+  } else if (!cookie.getSessionVariable(req, 'ch_' + chargeId)) { 
     logger.info('ChargeId was not found on the session', {
       ...getLoggingFields,
       referrer: req.get('Referrer'),

--- a/test/cypress/integration/card/frontend-state-cookie-removed.spec.js
+++ b/test/cypress/integration/card/frontend-state-cookie-removed.spec.js
@@ -1,0 +1,67 @@
+const cardPaymentStubs = require('../../utils/card-payment-stubs')
+
+describe('Frontend state cookie removed', () => {
+
+  const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
+  const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
+
+  const validPayment = {
+    cardNumber: '4444333322221111',
+    expiryMonth: '01',
+    expiryYear: '30',
+    name: 'Valid Paying Name',
+    securityCode: '012',
+    addressLine1: '10 Valid Paying Address',
+    city: 'London',
+    postcode: 'E1 8QS',
+    email: 'validpayingemail@example.com'
+  }
+
+  const createPaymentChargeStubsEnglish = cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en')
+  const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
+
+  beforeEach(() => {
+    // this test is for the full process, the session should be maintained
+    // as it would for an actual payment flow
+    Cypress.Cookies.preserveOnce('frontend_state')
+  })
+
+  describe('Should show "Your payment session has expired" if cookie is removed before submitting the payment', () => {
+    it('Should setup the payment and load the page', () => {
+      cy.task('setupStubs', createPaymentChargeStubsEnglish)
+      cy.visit(`/secure/${tokenId}`)
+    })
+
+    it('Should enter and validate a correct card', () => {
+      cy.task('setupStubs', checkCardDetailsStubs)
+
+      cy.server()
+      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.get('#card-no').type(validPayment.cardNumber)
+      cy.get('#card-no').blur()
+      cy.wait('@checkCard')
+      cy.get('#card-no').should('not.have.class', 'govuk-input--error')
+    })
+
+    it('Should enter payment details', () => {
+      cy.get('#expiry-month').type(validPayment.expiryMonth)
+      cy.get('#expiry-year').type(validPayment.expiryYear)
+      cy.get('#cardholder-name').type(validPayment.name)
+      cy.get('#cvc').type(validPayment.securityCode)
+      cy.get('#address-line-1').type(validPayment.addressLine1)
+      cy.get('#address-city').type(validPayment.city)
+      cy.get('#address-postcode').type(validPayment.postcode)
+      cy.get('#email').type(validPayment.email)
+    })
+
+    it('Should show "Your payment session has expired"', () => {
+      cy.clearCookie("frontend_state")
+
+      cy.get('#card-details').submit()
+
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      cy.get('h1').should('contain', 'Your payment session has expired')
+    })
+  })
+})

--- a/test/integration/card_details_errors_ft_tests.js
+++ b/test/integration/card_details_errors_ft_tests.js
@@ -146,6 +146,12 @@ describe('chargeTests', function () {
   })
 
   describe('Enter card details page — errors ', function () {
+    it('should error without frontend state cookie', function (done) {
+      postChargeRequest(app, null, minimumFormCardData('5105 1051 0510 5100'), chargeId, false)
+        .expect(403)
+        .end(done)
+    })
+
     it('should error without csrf', function (done) {
       const cookieValue = cookie.create(chargeId)
       defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)

--- a/test/services/charge_param_retriever_test.js
+++ b/test/services/charge_param_retriever_test.js
@@ -36,6 +36,22 @@ describe('charge param retreiver', function () {
     get: () => null
   }
 
+  var VALID_POST_RESPONSE_FOR_3DS = {
+    params: {},
+    originalUrl: '/card_details/foo/3ds_required_in',
+    body: { chargeId: 'foo' },
+    method: 'POST',
+    get: () => null
+  }
+
+  var VALID_POST_RESPONSE_FOR_EPDQ_3DS = {
+    params: {},
+    originalUrl: '/card_details/foo/3ds_required_in/epdq',
+    body: { chargeId: 'foo' },
+    method: 'POST',
+    get: () => null
+  }
+
   it('should return false if the charge param is not present in params or body', function () {
     assert.strictEqual(chargeParam.retrieve(EMPTY_RESPONSE), false)
   })
@@ -52,7 +68,16 @@ describe('charge param retreiver', function () {
     assert.strictEqual(chargeParam.retrieve(VALID_GET_RESPONSE), 'foo')
   })
 
-  it('should return false if the charge param is in THE BODY and has session', function () {
+  it('should return THE ID if the charge param is in THE BODY and has session', function () {
     assert.strictEqual(chargeParam.retrieve(VALID_POST_RESPONSE), 'foo')
   })
+
+  it('should return THE ID if the charge id is in the 3ds post url', function () {
+    assert.strictEqual(chargeParam.retrieve(VALID_POST_RESPONSE_FOR_3DS), 'foo')
+  })
+
+  it('should return THE ID if the charge id is in the EPDQ 3ds post url', function () {
+    assert.strictEqual(chargeParam.retrieve(VALID_POST_RESPONSE_FOR_EPDQ_3DS), 'foo')
+  })
+
 })


### PR DESCRIPTION
Description:
- We are making this change due to changes to SameSite cookie behaviour changing in some browsers (chrome) which causes the session cookie to be lost inside 3DS iframe if too long a time is spent on on the 3D secure page.
- Use the chargeId from /card_details/:chargeId/3ds_required_in and /card_details/:chargeId/3ds_required_in/epdq post urls.

