### PR TITLE
PP-7116 - Remove text when DDC is sent to Worldpay

### DIFF
--- a/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
+++ b/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
@@ -5,28 +5,19 @@ const toggleWaiting = () => {
   document.getElementById('spinner').classList.toggle('hidden')
   document.getElementById('error-summary').classList.add('hidden')
 
-  var paymentMethodSubmitElement = document.getElementById('apple-pay-payment-method-submit')
-  if (typeof paymentMethodSubmitElement !== 'undefined' && paymentMethodSubmitElement !== null) {
-    paymentMethodSubmitElement.classList.add('hidden')
+  var paymentDetailsHeader = document.querySelector('.govuk-heading-l.web-payment-button-heading')
+  if (typeof paymentDetailsHeader !== 'undefined' && paymentDetailsHeader !== null) {
+    paymentDetailsHeader.style.display = "none"
   }
 
-  paymentMethodSubmitElement = document.getElementById('google-pay-payment-method-submit')
-  if (typeof paymentMethodSubmitElement !== 'undefined' && paymentMethodSubmitElement !== null) {
-    paymentMethodSubmitElement.classList.add('hidden')
+  var applePayContainer = document.querySelector('.apple-pay-container')
+  if (typeof applePayContainer !== 'undefined' && applePayContainer !== null) {
+    applePayContainer.style.display = "none"
   }
 
-  var paymentMethodDivider = document.getElementById('apple-pay-payment-method-divider')
-  if (typeof paymentMethodDivider !== 'undefined' && paymentMethodDivider !== null) {
-    paymentMethodDivider.classList.add('hidden')
-    paymentMethodDivider.classList.remove('pay-divider')
-    document.getElementById('apple-pay-payment-method-divider-word').classList.add('hidden')
-  }
-
-  paymentMethodDivider = document.getElementById('google-pay-payment-method-divider')
-  if (typeof paymentMethodDivider !== 'undefined' && paymentMethodDivider !== null) {
-    paymentMethodDivider.classList.add('hidden')
-    paymentMethodDivider.classList.remove('pay-divider')
-    document.getElementById('google-pay-payment-method-divider-word').classList.add('hidden')
+  var googlePayContainer = document.querySelector('.google-pay-container')
+  if (typeof googlePayContainer !== 'undefined' && googlePayContainer !== null) {
+    googlePayContainer.style.display = "none"
   }
 }
 

--- a/test/cypress/integration/web-payments/google-pay.spec.js
+++ b/test/cypress/integration/web-payments/google-pay.spec.js
@@ -22,7 +22,7 @@ describe('Google Pay payment flow', () => {
         type: 'CARD'
       }
     },
-    payerEmail: 'name@email.fyi',
+    payerEmail: 'name@email.test',
     payerName: 'Some Name',
     complete: () => true
   }

--- a/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.spec.js
+++ b/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.spec.js
@@ -1,4 +1,7 @@
+const { expect } = require('chai')
+const _ = require('lodash')
 const cardPaymentStubs = require('../../utils/card-payment-stubs')
+const { getMockPaymentRequest } = require('../../utils/payment-request-api-stub')
 
 describe('Worldpay 3ds flex card payment flow', () => {
   const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
@@ -10,6 +13,11 @@ describe('Worldpay 3ds flex card payment flow', () => {
     paymentProvider: 'worldpay',
     requires3ds: true,
     integrationVersion3ds: 2
+  }
+  const gatewayAccountOpts = {}
+  const additionalChargeOpts = {
+    allowGooglePay: true,
+    gatewayMerchantId: 'SMTHG12345UP'
   }
 
   const validPayment = {
@@ -24,10 +32,36 @@ describe('Worldpay 3ds flex card payment flow', () => {
     email: 'validpayingemail@example.com'
   }
 
+  const validGooglePayment = {
+    details: {
+      apiVersionMinor: 0,
+      apiVersion: 2,
+      paymentMethodData: {
+        description: 'Mastercard •••• 1111',
+        info: {
+          cardNetwork: 'MASTERCARD',
+          cardDetails: '1111'
+        },
+        tokenizationData: {
+          type: 'PAYMENT_GATEWAY',
+          token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+        },
+        type: 'CARD'
+      }
+    },
+    payerEmail: 'name@email.test',
+    payerName: 'Some Name',
+    complete: () => true
+  }
+
+  
   const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment)
   const createPaymentChargeStubsEnglish = cardPaymentStubs.buildCreatePaymentChargeStubs(
     tokenId, chargeId, 'en', gatewayAccountId, sessionOpts, providerOpts)
   const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
+  
+  const createGooglePayPaymentChargeStubsEnglish = cardPaymentStubs.buildCreatePaymentChargeStubs(
+    tokenId, chargeId, 'en', gatewayAccountId, sessionOpts, providerOpts, gatewayAccountOpts, additionalChargeOpts )
 
   const worldpay3dsFlexDdcStub = {
     name: 'worldpay3dsFlexDdcIframePost',
@@ -94,6 +128,52 @@ describe('Worldpay 3ds flex card payment flow', () => {
     })
   }
 
+  const setUpAndCheckCardPaymentPageWithGooglePay = () => {
+    describe('Secure card payment page', () => {
+      it('Setup Google Pay', () => {
+        cy.task('setupStubs', createGooglePayPaymentChargeStubsEnglish)
+        cy.visit(`/card_details/${chargeId}`, {
+          onBeforeLoad: win => {
+            // Stub Payment Request API
+            if (win.PaymentRequest) {
+              // If we’re running in headed mode
+              cy.stub(win, 'PaymentRequest', getMockPaymentRequest(validGooglePayment))
+            } else {
+              // else headless
+              win.PaymentRequest = getMockPaymentRequest(validGooglePayment)
+            }
+          }
+        })
+      })
+
+      it('Should enter and validate a correct card', () => {
+        cy.task('setupStubs', checkCardDetailsStubs)
+
+        cy.server()
+        cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+        cy.get('#card-no').type(validPayment.cardNumber)
+        cy.get('#card-no').blur()
+
+        // 7. Charge status will be fetched (GET)
+        // 8. CardID POST to verify that entered card is correct - this is configured to return valid
+        cy.wait('@checkCard')
+        cy.get('#card-no').should('not.have.class', 'govuk-input--error')
+      })
+      
+      it('Should enter payment details', () => {
+        cy.get('#expiry-month').type(validPayment.expiryMonth)
+        cy.get('#expiry-year').type(validPayment.expiryYear)
+        cy.get('#cardholder-name').type(validPayment.name)
+        cy.get('#cvc').type(validPayment.securityCode)
+        cy.get('#address-line-1').type(validPayment.addressLine1)
+        cy.get('#address-city').type(validPayment.city)
+        cy.get('#address-postcode').type(validPayment.postcode)
+        cy.get('#email').type(validPayment.email)
+      })
+    })
+  }
+
   setUpAndCheckCardPaymentPage()
   describe('Valid DDC response', () => {
     it('Form is submitted with the session ID from the DDC response', () => {
@@ -125,13 +205,26 @@ describe('Worldpay 3ds flex card payment flow', () => {
   setUpAndCheckCardPaymentPage()
   describe('DDC times out', () => {
     it('iframe post should still submit the form but without the worldpaySessionId', () => {
-      confirmPaymentDetailsStubs.pop()
+      const confirmPaymentDetailsStubsPop = _.cloneDeep(confirmPaymentDetailsStubs)
+      confirmPaymentDetailsStubsPop.pop()
+
       cy.task('setupStubs', confirmPaymentDetailsStubs)
 
       cy.get('#card-details').submit().should($form => {
         const formVal = $form.first()[0].elements.worldpay3dsFlexDdcResult
         expect(formVal).to.eq(undefined)
       })
+    })
+  })
+
+  setUpAndCheckCardPaymentPageWithGooglePay()
+  describe('Web payment text is not displayed on DDC spinner screen', () => {
+    it('iframe post should still submit the form but without the worldpaySessionId', () => {
+      cy.task('setupStubs', confirmPaymentDetailsStubs)
+      cy.get('#card-details').submit()
+
+      cy.get('.google-pay-container').should('have.attr', 'style', 'display: none;')
+      cy.get('.govuk-heading-l.web-payment-button-heading').should('have.attr', 'style', 'display: none;')
     })
   })
 })


### PR DESCRIPTION
Description:
- Currently when the service has Google/Apple Pay enabled and is using Worldpay 3DS Flex a paying user will see 'Pay with Google/Apple Pay' and 'Enter payment details' with a spinner. This is a bug because when the DDC is sent to Worldpay we hide most but not all of the elements on the card details page. This PR fixes this bug by hiding the elements which contain the above text.
- Since a user cannot click on 'Submit' and 'Pay with Apple/Google Pay' at the same time we can hide the entire container for Google/Apple Pay
- The confirmPaymentDetailsStubs was modified when being passed into 'DDC times out' test so this has been deep cloned so that subsequent tests won't be affected
- A further PR needs to be made conceptualising how we hide elements
- Cypress test indicates that now the 'Enter with Payment Details' and 'Pay with Google Pay' text has been removed:
<img width="807" alt="Screenshot 2020-09-28 at 11 21 56 am" src="https://user-images.githubusercontent.com/43585976/94448605-00d22080-01a3-11eb-83ea-165e365b4045.png">



