### PR TITLE
PP-7195 Fix build and run Dockerfile alpine upgrade

### DIFF
--- a/docker/build_and_test.Dockerfile
+++ b/docker/build_and_test.Dockerfile
@@ -2,7 +2,7 @@ FROM node:12.18.4-alpine3.12@sha256:59fa78a2149e3470ba7346fb17938e2c48e170960060
 
 ### Needed to run appmetrics and pact-mock-service
 COPY sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-RUN ["apk", "--no-cache", "add", "ca-certificates", "python", "build-base", "bash", "ruby"]
+RUN ["apk", "--no-cache", "add", "ca-certificates", "python2", "build-base", "bash", "ruby"]
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && apk add --no-cache glibc-2.28-r0.apk && rm -f glibc-2.28-r0.apk
 ###
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": "^12.18.4"
+    "node": "^12.18.3"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
This Dockerfile should be removed as soon as possible as it introduces
additional flake in the build/ update release process.

- Updated alpine `python` dependency doesn't resolve, specify that we
will be using the `python2` package
- Set the engines version to a paas compatible minimum until we can
patch that separately