### PR TITLE
PP 7118 fix lint errors in move session cookie validation test

### DIFF
--- a/test/middleware/enforce_session_cookie_test.js
+++ b/test/middleware/enforce_session_cookie_test.js
@@ -54,7 +54,7 @@ describe('enforce session cookie test', () => {
       viewName: 'UNAUTHORISED',
       analytics: ANALYTICS_ERROR.analytics
     }))
-    expect(next.notCalled).to.be.true
+    expect(next.notCalled).to.be.true // eslint-disable-line
   })
 
   it('should call next when frontend_state cookie contains chargeId', done => {
@@ -73,7 +73,7 @@ describe('enforce session cookie test', () => {
     testPromise.then(result => {
       try {
         expect(status.calledWith(200))
-        expect(next.called).to.be.true
+        expect(next.called).to.be.true // eslint-disable-line
         done()
       } catch (err) {
         done(err)

--- a/test/middleware/retrieve_charge_test.js
+++ b/test/middleware/retrieve_charge_test.js
@@ -81,7 +81,7 @@ describe('retrieve charge test', () => {
           viewName: 'SYSTEM_ERROR',
           analytics: ANALYTICS_ERROR.analytics
         }))
-        expect(next.notCalled).to.be.true
+        expect(next.notCalled).to.be.true // eslint-disable-line
         done()
       } catch (err) { done(err) }
     }, done)

--- a/test/unit/session_test.js
+++ b/test/unit/session_test.js
@@ -46,21 +46,21 @@ describe('session utils ', () => {
 
     describe('retrieve ', () => {
         it('should return session', function () {
-            expect(session.retrieve(VALID_GET_RESPONSE, chargeId)).to.be.true
+            expect(session.retrieve(VALID_GET_RESPONSE, chargeId)).to.be.true // eslint-disable-line
         })
     })
 
     describe('validateSessionCookie ', () => {
         it('should return true for GET request with valid session cookie', function () {
-            expect(session.validateSessionCookie(VALID_GET_RESPONSE)).to.be.true
+            expect(session.validateSessionCookie(VALID_GET_RESPONSE)).to.be.true // eslint-disable-line
         })
 
         it('should return true for POST request with valid session cookie', function () {
-            expect(session.validateSessionCookie(VALID_POST_RESPONSE)).to.be.true
+            expect(session.validateSessionCookie(VALID_POST_RESPONSE)).to.be.true // eslint-disable-line
         })
 
         it('should return false if the charge param is not present in params or body', function () {
-            expect(session.validateSessionCookie(EMPTY_RESPONSE)).to.be.false
+            expect(session.validateSessionCookie(EMPTY_RESPONSE)).to.be.false // eslint-disable-line
         })
 
         it('should return false if the charge param is in params but not in session', function () {
@@ -68,7 +68,7 @@ describe('session utils ', () => {
         })
 
         it('should return false if the charge param is in THE BODY but not in session', function () {
-            expect(session.validateSessionCookie(NO_SESSION_POST_RESPONSE)).to.be.false
+            expect(session.validateSessionCookie(NO_SESSION_POST_RESPONSE)).to.be.false // eslint-disable-line
         })
     })
 })


### PR DESCRIPTION
Description:
- Concourse CI build of the original PR did not catch the lint errors.


