### PR TITLE
PP-7118 Remove 3ds in cookie validation & lint fix

### DIFF
--- a/test/integration/three_d_secure_ft_tests.js
+++ b/test/integration/three_d_secure_ft_tests.js
@@ -234,9 +234,9 @@ describe('chargeTests', function () {
         postChargeRequest(app, false, data, chargeId, false, '/3ds_required_in')
           .expect(200)
           .expect(function (res) {
-            expect(res.header['set-cookie'] === undefined).to.be.true
+            expect(res.header['set-cookie'] === undefined).to.be.true // eslint-disable-line
             const $ = cheerio.load(res.text)
-            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist
+            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist // eslint-disable-line
             expect($('form[name=\'three_ds_required\'] > input[name=\'PaRes\']').attr('value')).to.eql('aPaRes')
             expect($('form[name=\'three_ds_required\'] > input[name=\'MD\']').attr('value')).to.eql('aMD')
             expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(`/card_details/${chargeId}/3ds_handler`)
@@ -256,11 +256,11 @@ describe('chargeTests', function () {
         postChargeRequest(app, false, data, chargeId, false, '/3ds_required_in')
           .expect(200)
           .expect(function (res) {
-            expect(res.header['set-cookie'] === undefined).to.be.true
+            expect(res.header['set-cookie'] === undefined).to.be.true // eslint-disable-line
             const $ = cheerio.load(res.text)
-            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist
-            expect($('form[name=\'three_ds_required\'] > input[name=\'PaRes\']').attr('value')).to.not.exist
-            expect($('form[name=\'three_ds_required\'] > input[name=\'MD\']').attr('value')).to.not.exist
+            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist // eslint-disable-line
+            expect($('form[name=\'three_ds_required\'] > input[name=\'PaRes\']').attr('value')).to.not.exist // eslint-disable-line
+            expect($('form[name=\'three_ds_required\'] > input[name=\'MD\']').attr('value')).to.not.exist // eslint-disable-line
           })
           .end(done)
       })
@@ -281,9 +281,9 @@ describe('chargeTests', function () {
         postChargeRequest(app, false, data, chargeId, false, '/3ds_required_in/epdq')
           .expect(200)
           .expect(function (res) {
-            expect(res.header['set-cookie'] === undefined).to.be.true
+            expect(res.header['set-cookie'] === undefined).to.be.true // eslint-disable-line
             const $ = cheerio.load(res.text)
-            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist
+            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist // eslint-disable-line
             expect($('form[name=\'three_ds_required\'] > input[name=\'providerStatus\']').attr('value')).to.eql('success')
             expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(`/card_details/${chargeId}/3ds_handler`)
           })
@@ -303,9 +303,9 @@ describe('chargeTests', function () {
         getChargeRequest(app, false, chargeId, '/3ds_required_in/epdq?status=declined')
           .expect(200)
           .expect(function (res) {
-            expect(res.header['set-cookie'] === undefined).to.be.true
+            expect(res.header['set-cookie'] === undefined).to.be.true // eslint-disable-line
             const $ = cheerio.load(res.text)
-            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist
+            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist // eslint-disable-line
             expect($('form[name=\'three_ds_required\'] > input[name=\'providerStatus\']').attr('value')).to.eql('declined')
             expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(`/card_details/${chargeId}/3ds_handler`)
           })
@@ -326,9 +326,9 @@ describe('chargeTests', function () {
         postChargeRequest(app, false, data, chargeId, false, '/3ds_required_in/epdq?status=error')
           .expect(200)
           .expect(function (res) {
-            expect(res.header['set-cookie'] === undefined).to.be.true
+            expect(res.header['set-cookie'] === undefined).to.be.true // eslint-disable-line
             const $ = cheerio.load(res.text)
-            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist
+            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist // eslint-disable-line
             expect($('form[name=\'three_ds_required\'] > input[name=\'providerStatus\']').attr('value')).to.eql('error')
             expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(`/card_details/${chargeId}/3ds_handler`)
           })
@@ -350,9 +350,9 @@ describe('chargeTests', function () {
         postChargeRequest(app, false, data, chargeId, false, '/3ds_required_in')
           .expect(200)
           .expect(function (res) {
-            expect(res.header['set-cookie'] === undefined).to.be.true
+            expect(res.header['set-cookie'] === undefined).to.be.true // eslint-disable-line
             const $ = cheerio.load(res.text)
-            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist
+            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist // eslint-disable-line
             expect($('form[name=\'three_ds_required\'] > input[name=\'PaRes\']').attr('value')).to.eql('aPaRes')
             expect($('form[name=\'three_ds_required\'] > input[name=\'MD\']').attr('value')).to.eql('md')
             expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(`/card_details/${chargeId}/3ds_handler`)


### PR DESCRIPTION
Description:

- Fix JS lint issues

- Users arrive at the 3DS required in page via a cross-site request and modern browsers treat cookies as SameSite=lax by default, which means we won’t sometimes won’t get sent the cookie when it’s a POST request. We’ll still require the cookie to continue further on the journey and actually process the 3DS result.

- Session cookie validation will not be required for /card_details/:chargeId/3ds_required_in & /card_details/:chargeId/3ds_required_in/epdq requests only.



