### PR TITLE
PP-7080 Tidy up expiry date validation tests

### DIFF
--- a/test/utils/charge_validation_fields/expiry_month_validation_test.js
+++ b/test/utils/charge_validation_fields/expiry_month_validation_test.js
@@ -1,58 +1,73 @@
-var expect = require('chai').expect
-var cardTypes = require('../../test_helpers/test_helpers.js').cardTypes()
-var Card = require('../../../app/models/card.js')(cardTypes)
-var fields = require('../../../app/utils/charge_validation_fields.js')(Card)
+'use strict'
 
-describe('card validation: expiry month', function () {
-  it('should true if correct', function () {
-    var future = new Date()
-    future.setDate(future.getDate() + 30)
-    var fullYear = future.getFullYear().toString()
+const cardTypes = require('../../test_helpers/test_helpers.js').cardTypes()
+const Card = require('../../../app/models/card.js')(cardTypes)
+const fields = require('../../../app/utils/charge_validation_fields.js')(Card)
+const { expect } = require('chai')
+const sinon = require('sinon')
+const mockNewDateToAlwaysReturn = (date) => sinon.useFakeTimers({ now: date, toFake: ['Date'] })
 
-    var result = fields.fieldValidations.expiryMonth(12, { expiryYear: fullYear.substr(2, 2) })
-    var longYear = fields.fieldValidations.expiryMonth(12, { expiryYear: fullYear })
+describe('Card expiry date validation', function () {
+  var clock
 
+  before(() => {
+    const september = 9 - 1 // Months are zero-indexed
+    clock = mockNewDateToAlwaysReturn(new Date(2020, september, 21))
+  });
+
+  after(() => {
+    if (clock) {
+      clock.restore()
+    }
+  })
+
+  it('should return true if month and 2-digit year are in future', function () {
+    var result = fields.fieldValidations.expiryMonth('10', { expiryYear: '20' })
     expect(result).to.equal(true)
-    expect(longYear).to.equal(true)
   })
 
-  it('should fails if month is too large or small', function () {
-    var small = fields.fieldValidations.expiryMonth(0.1, { expiryYear: 16 })
-    var large = fields.fieldValidations.expiryMonth(13, { expiryYear: 16 })
-    var chars = fields.fieldValidations.expiryMonth('a12', { expiryYear: 16 })
-
-    expect(small).to.equal('invalidMonth')
-    expect(large).to.equal('invalidMonth')
-    expect(chars).to.equal('invalidMonth')
+  it('should return true if month and 4-digit year are in future', function () {
+    var result = fields.fieldValidations.expiryMonth('10', { expiryYear: '2020' })
+    expect(result).to.equal(true)
   })
 
-  it('should fails if year is not 2 or 4 digits', function () {
-    var future = new Date()
-    future.setDate(future.getDate() + 30)
-    var fullYear = future.getFullYear().toString()
-
-    var two = fields.fieldValidations.expiryMonth(12, { expiryYear: fullYear.substr(2, 2) })
-    var three = fields.fieldValidations.expiryMonth(12, { expiryYear: '016' })
-    var four = fields.fieldValidations.expiryMonth(12, { expiryYear: fullYear })
-
-    expect(two).to.equal(true)
-    expect(three).to.equal('invalidYear')
-    expect(four).to.equal(true)
+  it('should return invalidMonth if month is a decimal', function () {
+    var result = fields.fieldValidations.expiryMonth('0.1', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
   })
 
-  it('should fail is date is in past', function () {
-    var month = fields.fieldValidations.expiryMonth(1, { expiryYear: 16 })
-    var year = fields.fieldValidations.expiryMonth(1, { expiryYear: 15 })
-    var longYear = fields.fieldValidations.expiryMonth(1, { expiryYear: '2015' })
-
-    expect(month).to.equal('inThePast')
-    expect(year).to.equal('inThePast')
-    expect(longYear).to.equal('inThePast')
+  it('should return invalidMonth if month is greater than 12', function () {
+    var result = fields.fieldValidations.expiryMonth('13', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
   })
 
-  it('should fail year is not defined', function () {
-    var noYear = fields.fieldValidations.expiryMonth('12', {})
+  it('should return invalidMonth if month has characters as well as digits', function () {
+    var result = fields.fieldValidations.expiryMonth('a12', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
 
-    expect(noYear).to.equal('message')
+  it('should return invalidYear if year is 3 digits', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '021' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return inThePast if month in the past', function () {
+    var result = fields.fieldValidations.expiryMonth('8', { expiryYear: '20' })
+    expect(result).to.equal('inThePast')
+  })
+
+  it('should return inThePast if 2-digit year in the past', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '19' })
+    expect(result).to.equal('inThePast')
+  })
+
+  it('should return inThePast if 4-digit year in the past', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '2019' })
+    expect(result).to.equal('inThePast')
+  })
+
+  it('should return message if year is not defined', function () {
+    var result = fields.fieldValidations.expiryMonth('12', {})
+    expect(result).to.equal('message')
   })
 })


### PR DESCRIPTION
Tidy up expiry date validation tests:

- Stub the current date to make the tests not rely on the actual current date, using 21 September 2020 (date picked to be far enough from the end of the month that different time zones are not going to cause issues)

- Don’t test multiple things in each test

No changes to anything apart from the tests. The test cases themselves are the equivalent to the old ones but some of the details differ to reflect the fact we’re stubbing the current date.