### PR TITLE
PP-7080 Implement new expiry date validation algorithm

### DIFF
--- a/app/utils/charge_validation_fields.js
+++ b/app/utils/charge_validation_fields.js
@@ -73,20 +73,41 @@ module.exports = (Card, chargeOptions = { collect_billing_address: true }) => {
 }
 
 // Validation Functions
-function expiryMonth (expiryMonth, allFields) {
-  let expiryYear = allFields.expiryYear
-  if (!expiryMonth || !expiryYear) return 'message'
 
+function expiryMonth (expiryMonth, allFields) {
   // validations for both expiry month and year are done together in 'expiryMonth'
   // it can't be renamed as it all runs off meta programming further up the stack
-  expiryMonth = expiryMonth - 1 // month is zero indexed
-  if (!(/^\d+$/.test(expiryMonth) && expiryMonth >= 0 && expiryMonth <= 11)) return 'invalidMonth'
-  if (![2, 4].includes(String(allFields.expiryYear).length)) return 'invalidYear'
-  if (`${expiryYear}`.length === 2) expiryYear = '20' + expiryYear
-  const cardDate = new Date(expiryYear, expiryMonth)
-  const currentDate = new Date()
-  if (currentDate.getFullYear() > cardDate.getFullYear()) return 'inThePast'
-  if (currentDate.getFullYear() === cardDate.getFullYear() && currentDate.getMonth() > cardDate.getMonth()) return 'inThePast'
+  const expiryYear = allFields.expiryYear
+
+  if (!expiryMonth || !expiryYear) {
+    return 'message'
+  }
+
+  if (!(/^[1-9]$/.test(expiryMonth)) && !(/^0[1-9]$/).test(expiryMonth) && !(/^1[0-2]$/.test(expiryMonth))) {
+    return 'invalidMonth'
+  }
+
+  const expiryMonthInt = parseInt(expiryMonth, 10)
+
+  if (!(/^[0-9]{2}$/.test(expiryYear)) && !(/^[1-9][0-9]{3}$/).test(expiryYear)) {
+    return 'invalidYear'
+  }
+
+  const expiryYearInt = expiryYear.length === 2 ? 2000 + parseInt(expiryYear, 10) : parseInt(expiryYear, 10)
+
+  if (expiryYearInt > 2099) {
+    return 'invalidYear'
+  }
+
+  const now = new Date()
+
+  if (expiryYearInt < now.getFullYear()) {
+    return 'inThePast'
+  }
+
+  if (expiryYearInt === now.getFullYear() && expiryMonthInt < now.getMonth() + 1) {
+    return 'inThePast'
+  }
 
   return true
 }

--- a/test/utils/charge_validation_fields/expiry_month_validation_test.js
+++ b/test/utils/charge_validation_fields/expiry_month_validation_test.js
@@ -21,18 +21,83 @@ describe('Card expiry date validation', function () {
     }
   })
 
-  it('should return true if month and 2-digit year are in future', function () {
+  it('should return true if 2-digit month and 2-digit year are this month', function () {
+    var result = fields.fieldValidations.expiryMonth('09', { expiryYear: '20' })
+    expect(result).to.equal(true)
+  })
+
+  it('should return true if 2-digit month and 4-digit year are this month', function () {
+    var result = fields.fieldValidations.expiryMonth('09', { expiryYear: '2020' })
+    expect(result).to.equal(true)
+  })
+
+  it('should return true if single-digit month and 2-digit year are this month', function () {
+    var result = fields.fieldValidations.expiryMonth('9', { expiryYear: '20' })
+    expect(result).to.equal(true)
+  })
+
+  it('should return true if single-digit month and 4-digit year are this month', function () {
+    var result = fields.fieldValidations.expiryMonth('9', { expiryYear: '2020' })
+    expect(result).to.equal(true)
+  })
+
+  it('should return true if month and 2-digit year are in the future', function () {
     var result = fields.fieldValidations.expiryMonth('10', { expiryYear: '20' })
     expect(result).to.equal(true)
   })
 
-  it('should return true if month and 4-digit year are in future', function () {
+  it('should return true if month and 4-digit year are in the future', function () {
     var result = fields.fieldValidations.expiryMonth('10', { expiryYear: '2020' })
     expect(result).to.equal(true)
   })
 
+  it('should return true if 2-digit month is earlier than now but 2-digit year is in the future', function () {
+    var result = fields.fieldValidations.expiryMonth('08', { expiryYear: '21' })
+    expect(result).to.equal(true)
+  })
+
+  it('should return true if 2-digit month is earlier than now but 4-digit year is in the future', function () {
+    var result = fields.fieldValidations.expiryMonth('08', { expiryYear: '2021' })
+    expect(result).to.equal(true)
+  })
+
+  it('should return true if single-digit month is earlier than now but 2-digit year is in the future', function () {
+    var result = fields.fieldValidations.expiryMonth('8', { expiryYear: '21' })
+    expect(result).to.equal(true)
+  })
+
+  it('should return true if single-digit month is earlier than now but 4-digit year is in the future', function () {
+    var result = fields.fieldValidations.expiryMonth('8', { expiryYear: '2021' })
+    expect(result).to.equal(true)
+  })
+
+  it('should return invalidMonth if month is 3 digits', function () {
+    var result = fields.fieldValidations.expiryMonth('123', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidMonth if month is 3 digits with first digit 0', function () {
+    var result = fields.fieldValidations.expiryMonth('012', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidMonth if month is 0', function () {
+    var result = fields.fieldValidations.expiryMonth('0', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
   it('should return invalidMonth if month is a decimal', function () {
-    var result = fields.fieldValidations.expiryMonth('0.1', { expiryYear: '21' })
+    var result = fields.fieldValidations.expiryMonth('1.3', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidMonth if month is negative with single digit', function () {
+    var result = fields.fieldValidations.expiryMonth('-1', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidMonth if month is negative with 2 digits', function () {
+    var result = fields.fieldValidations.expiryMonth('-12', { expiryYear: '21' })
     expect(result).to.equal('invalidMonth')
   })
 
@@ -41,9 +106,39 @@ describe('Card expiry date validation', function () {
     expect(result).to.equal('invalidMonth')
   })
 
-  it('should return invalidMonth if month has characters as well as digits', function () {
-    var result = fields.fieldValidations.expiryMonth('a12', { expiryYear: '21' })
+  it('should return invalidMonth if month is greater than 12 but doesn’t begin with 1', function () {
+    var result = fields.fieldValidations.expiryMonth('21', { expiryYear: '21' })
     expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidMonth if 2-digit month has letters as well as digits', function () {
+    var result = fields.fieldValidations.expiryMonth('a2', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidMonth if 2-digit month has only letters', function () {
+    var result = fields.fieldValidations.expiryMonth('ab', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidMonth if single-digit month has only letters', function () {
+    var result = fields.fieldValidations.expiryMonth('a', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidMonth if 2-digit month has only punctuation', function () {
+    var result = fields.fieldValidations.expiryMonth('--', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidMonth if single-digit month has only punctuation', function () {
+    var result = fields.fieldValidations.expiryMonth('-', { expiryYear: '21' })
+    expect(result).to.equal('invalidMonth')
+  })
+
+  it('should return invalidYear if year is 1 digit', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '9' })
+    expect(result).to.equal('invalidYear')
   })
 
   it('should return invalidYear if year is 3 digits', function () {
@@ -51,19 +146,114 @@ describe('Card expiry date validation', function () {
     expect(result).to.equal('invalidYear')
   })
 
-  it('should return inThePast if month in the past', function () {
+  it('should return invalidYear if year is 5 digits', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '20201' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if year is 5 digits and begins with 0', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '02021' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if year is 4 digits and begins with 0', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '0202' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if year is a decimal', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '20.2' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if year is negative  with single digit', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '-1' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if year is negative  with 2 digits', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '-30' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if year is negative  with 3 digits', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '-300' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if year is negative  with 4 digits', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '-2099' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if year is after than 2099', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '2199' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if 2-digit has letters as well as digits', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '3a' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if 4-digit has letters as well as digits', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '203a' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidMonth if 2-digit year has only letters', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: 'ab' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidMonth if 4-digit year has only letters', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: 'abcd' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if 2-digit year has only punctuation', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '--' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return invalidYear if 4-digit has only punctuation', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '----' })
+    expect(result).to.equal('invalidYear')
+  })
+
+  it('should return inThePast if single-digit month is in the past this year', function () {
     var result = fields.fieldValidations.expiryMonth('8', { expiryYear: '20' })
     expect(result).to.equal('inThePast')
   })
 
-  it('should return inThePast if 2-digit year in the past', function () {
+  it('should return inThePast if two-digit month is in the past this year', function () {
+    var result = fields.fieldValidations.expiryMonth('08', { expiryYear: '20' })
+    expect(result).to.equal('inThePast')
+  })
+
+  it('should return inThePast if 2-digit year is in the past', function () {
     var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '19' })
     expect(result).to.equal('inThePast')
   })
 
-  it('should return inThePast if 4-digit year in the past', function () {
+  it('should return inThePast if 4-digit year is in the past', function () {
     var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '2019' })
     expect(result).to.equal('inThePast')
+  })
+
+  it('should return inThePast if 2-digit year is in the past and begins with 0', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '09' })
+    expect(result).to.equal('inThePast')
+  })
+
+  it('should return inThePast if 4-digit year is before 2000', function () {
+    var result = fields.fieldValidations.expiryMonth('12', { expiryYear: '1999' })
+    expect(result).to.equal('inThePast')
+  })
+
+  it('should return message if month is not defined', function () {
+    var result = fields.fieldValidations.expiryMonth('', { expiryYear: '21' })
+    expect(result).to.equal('message')
   })
 
   it('should return message if year is not defined', function () {


### PR DESCRIPTION
Implement new expiry date validation algorithm, which takes a month and year (which have already had their whitespace stripped):

1. If _month_ is not exactly 1 or 2 digits, both in the range 0 to 9, return an `invalidMonth` error
2. If _month_ is 1 digit and that digit is 0, return an `invalidMonth` error
3. If _month_ is 2 digits and those two digits are not 10, 11 or 12, return an `invalidMonth` error
4. If _year_ is not exactly 2 or 4 digits, all in the range 0 to 9, return an `invalidYear` error
5. If _year_ is 4 digits and the first digit is 0, return an `invalidYear` error
6. If _year_ is 2 digits, prefix it with 20 (for example, 22 becomes 2022)
7. If _year_ is greater than 2099, return an `invalidYear` error
8. If _year_ is less than the current year, return an `inThePast` error
9. If _year_ matches the current year and _month_ is less than the current month, return an `inThePast` error
10. Otherwise, the expiry date is valid

Apart from being stricter than the old algorithm about catching invalid input, the only functional change is that years after 2099 are now considered invalid. Previously they were allowed but then normalised to 2 digits and then, depending on the payment gateway, changed back to 4 digits assuming the 21st century (so 2119 could become 19 and then 2019). Since we shouldn’t have to worry about actual card expiry dates later than 2099 for a number of years yet this new behaviour is sensible but eventually we (or our successors) are going to have to deal with years after 2099.

Also add substantially more tests to check this all works.