### PR TITLE
ZD Bump pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1547,9 +1547,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.40.0.tgz",
-      "integrity": "sha512-JZhO+HrTVgv0UWwmsvtc/lXXdHWuxkcN0f+QN6VbPXnzqTkz4LRbUj6H9T7rytzxaAQ2HopP7Uu9sDWaQNFOCQ==",
+      "version": "2.42.0",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.42.0.tgz",
+      "integrity": "sha512-X6fL6HN1z1xtXx4lKsNaPwhLWp2z3OPwyA4VtX0DUTzVVebWOgP4bO6+cqEZwENl6Gb964flAi1JRrVXTGTlfQ==",
       "requires": {
         "lodash": "4.17.20",
         "moment-timezone": "0.5.31",
@@ -21351,7 +21351,7 @@
         },
         "got": {
           "version": "9.6.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/got/-/got-9.6.0.tgz",
           "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "2.40.0",
+    "@govuk-pay/pay-js-commons": "2.42.0",
     "@sentry/node": "5.24.2",
     "appmetrics": "5.1.1",
     "appmetrics-statsd": "3.0.0",


### PR DESCRIPTION
- Bump the version of pay-js-commons from 2.40.0 to 2.42.0



