### PR TITLE
PP-7192: Disable PAN_ONLY Google transactions

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -73,7 +73,7 @@ const prepareAppleRequestObject = () => {
 
 const getGooglePaymentsConfiguration = () => {
   const allowedCardNetworks = supportedNetworksFormattedByProvider(allowedCardTypes, 'google')
-  const allowedCardAuthMethods = ['PAN_ONLY', 'CRYPTOGRAM_3DS']
+  const allowedCardAuthMethods = ['CRYPTOGRAM_3DS']
   const tokenizationSpecification = {
     type: 'PAYMENT_GATEWAY',
     parameters: {

--- a/app/utils/google-pay-check-request.js
+++ b/app/utils/google-pay-check-request.js
@@ -20,7 +20,7 @@ function getGooglePayMethodData (params) {
         {
           type: 'CARD',
           parameters: {
-            allowedAuthMethods: ['PAN_ONLY', 'CRYPTOGRAM_3DS'],
+            allowedAuthMethods: ['CRYPTOGRAM_3DS'],
             allowedCardNetworks: params.allowedCardTypes
           },
           tokenizationSpecification: {


### PR DESCRIPTION
We want to see what the payment page looks like when PAN_ONLY transactions are
disabled.

PAN_ONLY transactions are Google Pay transactions made on Chrome (usually on a
desktop).
CRYPTOGRAM_3DS transactions are Google Pay transactions made via the Google Pay
app. These transactions are "tokenized".

This PR is not meant to be deployed to prod and will be reverted promptly.


