### PR TITLE
PP-6869 Tell search engines not to index card payment pages

### DIFF
--- a/app/assets/iframe/worldpay-3ds-flex-ddc.html
+++ b/app/assets/iframe/worldpay-3ds-flex-ddc.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Device data collection for Worldpay 3DS Flex</title>
+    <meta name="robots" content="noindex, nofollow">
   </head>
   <body>
     <form id="collectionForm" name="devicedata" method="POST" action="">

--- a/app/views/auth_waiting.njk
+++ b/app/views/auth_waiting.njk
@@ -25,6 +25,7 @@
 
   {% include "includes/analytics.njk" %}
   <meta http-equiv="refresh" content="2" />
+  <meta name="robots" content="noindex, nofollow">
 {% endblock %}
 
 {% block content %}

--- a/app/views/capture_waiting.njk
+++ b/app/views/capture_waiting.njk
@@ -25,6 +25,7 @@
 
   {% include "includes/analytics.njk" %}
   <meta http-equiv="refresh" content="2" />
+  <meta name="robots" content="noindex, nofollow">
 {% endblock %}
 
 {% block content %}

--- a/app/views/errors/incorrect_state/capture_waiting.njk
+++ b/app/views/errors/incorrect_state/capture_waiting.njk
@@ -25,6 +25,7 @@
 
   {% include "includes/analytics.njk" %}
   <meta http-equiv="refresh" content="0;URL='/card_details/{{ chargeId }}/capture_waiting'" />
+  <meta name="robots" content="noindex, nofollow">
 {% endblock %}
 
 {% block content %}

--- a/app/views/includes/iframe_head.njk
+++ b/app/views/includes/iframe_head.njk
@@ -3,4 +3,5 @@
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <link href="{{ css_path }}" media="screen" rel="stylesheet" type="text/css" />
+    <meta name="robots" content="noindex, nofollow">
 </head>

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -10,6 +10,7 @@
   {% endif %}
 
   {% include "includes/analytics.njk" %}
+  <meta name="robots" content="noindex, nofollow">
 {% endblock %}
 
 {% if service and service.customBranding and service.customBranding.cssUrl %}


### PR DESCRIPTION
Add `<meta name="robots" content="noindex, nofollow">` to all card payment pages so search engines don’t index them.

This is the approach specified by:
https://www.gov.uk/service-manual/technology/get-a-domain-name#telling-search-engines-not-to-index-pages

This does not affect the GOV.UK product pages available on the same host.