### PR TITLE
PP-6869 Remove robots.txt file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,14 +36,6 @@ module.exports = function (grunt) {
   }
 
   const copy = {
-    robots: {
-      files: [{
-        expand: true,
-        cwd: 'app/assets/',
-        src: ['robots.txt'],
-        dest: 'public/'
-      }]
-    },
     assets: {
       files: [{
         expand: true,

--- a/app/assets/robots.txt
+++ b/app/assets/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow: /card_details/
-Disallow: /worldpay/
-Disallow: /public/worldpay/


### PR DESCRIPTION
https://www.gov.uk/service-manual/technology/get-a-domain-name#telling-search-engines-not-to-index-pages says to use `<meta name="robots" content="noindex, nofollow">` to tell search engines not to index our pages. Additionally, it says not to use `robots.txt` to prevent crawling because this stops the `noindex` directive from being seen by search engines.

We added `<meta name="robots" content="noindex, nofollow">` in commit b1c97f1bb60461b06ee053eae4cc59310a2a4f67. This commit completes the work by removing the `robots.txt` file.