### PR TITLE
PP-7329: Redirect to 3ds required page...

### DIFF
--- a/app/controllers/web-payments/payment-auth-request-controller.js
+++ b/app/controllers/web-payments/payment-auth-request-controller.js
@@ -8,19 +8,30 @@ const normaliseApplePayPayload = require('./apple-pay/normalise-apple-pay-payloa
 const normaliseGooglePayPayload = require('./google-pay/normalise-google-pay-payload')
 const { CORRELATION_HEADER } = require('../../../config/correlation_header')
 const { setSessionVariable } = require('../../utils/cookies')
+const State = require('../../../config/state')
+const paths = require('../../paths')
 
 module.exports = (req, res) => {
   const { chargeId, params } = req
   const { provider } = params
   const payload = provider === 'apple' ? normaliseApplePayPayload(req) : normaliseGooglePayPayload(req)
-  return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet({ chargeId, provider, payload }, getLoggingFields(req))
+  return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] })
+    .chargeAuthWithWallet({ chargeId, provider, payload }, getLoggingFields(req))
     .then(data => {
       setSessionVariable(req, `ch_${(chargeId)}.webPaymentAuthResponse`, {
         statusCode: data.statusCode
       })
-      logger.info(`Successful auth for ${provider} Pay payment. ChargeID: ${chargeId}`, getLoggingFields(req))
       res.status(200)
-      res.send({ url: `/handle-payment-response/${chargeId}` })
+
+      if (data.body.status === State.AUTH_3DS_REQUIRED) {
+        logger.info('Requesting 3DS1 for Google payment.', getLoggingFields(req))
+        var auth3dsPath = paths.generateRoute('card.auth3dsRequired', { chargeId: chargeId })
+        res.send({ url: auth3dsPath })
+      } else {
+        logger.info(`Successful auth for ${provider} Pay payment. ChargeID: ${chargeId}`, getLoggingFields(req))
+        res.send({ url: `/handle-payment-response/${chargeId}` })
+      }
+
     })
     .catch(err => {
       logger.error(`Error while trying to authorise ${provider} Pay payment`, {


### PR DESCRIPTION
...for a google payment if status code is 200 and charge status is
AUTHORISATION 3DS REQUIRED.

I don't think a cypress test is required as the only change made in the app/controllers/web-payments/payment-auth-request-controller.js is to set the `url` to the `auth3dsPath`. The `url` is used in the [browsered google script](https://github.com/alphagov/pay-frontend/blob/master/app/assets/javascripts/browsered/web-payments/google-pay.js#L9-L24) and the browser will redirect to this url.