### PR TITLE
PP-7351 Accept-for-HTML header with Google Pay post to frontend

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -10,7 +10,8 @@ const processPayment = paymentData => {
     method: 'POST',
     credentials: 'same-origin',
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'Accept-for-HTML': document.body.getAttribute('data-accept-header') || '*/*'
     },
     body: JSON.stringify(paymentData)
   })


### PR DESCRIPTION
After the user has confirmed they want to make a payment using Google Pay, make it so that the JavaScript POST from the browser to frontend includes a `Accept-For-HTML` header whose value is the same as that of the `data-accept-header` attribute on the `body` element or `*/*` if it’s not there for some reason.

The `data-accept-header` attribute contains the HTTP `Accept` header that the browser sent when it loaded the enter card details page. This is likely to be different to the `Accept` header sent with the JavaScript-initiated POST.

This code isn’t currently very well tested but the change is simple enough and the Cypress tests ensure that adding the header doesn’t cause everything to blow up.