### PR TITLE
PP-7351 Google Pay: Accept, User-Agent, IP address go to connector

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-09-04T18:00:57Z",
+  "generated_at": "2020-11-03T18:13:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -144,7 +144,7 @@
       {
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 173,
+        "line_number": 191,
         "type": "Base64 High Entropy String"
       }
     ],
@@ -166,31 +166,31 @@
       {
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 18,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "c272ed583c5dfbb2013e22812d200068997d5969",
         "is_verified": false,
-        "line_number": 50,
+        "line_number": 53,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "9c98d4fa9b3055dede39101f223aa53c2b830d95",
         "is_verified": false,
-        "line_number": 52,
+        "line_number": 55,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_verified": false,
-        "line_number": 54,
+        "line_number": 57,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_verified": false,
-        "line_number": 55,
+        "line_number": 58,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -3,6 +3,7 @@
 const logger = require('../../../utils/logger')(__filename)
 const { getLoggingFields } = require('../../../utils/logging_fields_helper')
 const { output, redact } = require('../../../utils/structured_logging_value_helper')
+const userIpAddress = require('../../../utils/user_ip_address')
 const humps = require('humps')
 
 const logselectedPayloadProperties = req => {
@@ -81,7 +82,10 @@ module.exports = req => {
     last_digits_card_number: normaliseLastDigitsCardNumber(payload.details.paymentMethodData.info.cardDetails),
     brand: normaliseCardName(payload.details.paymentMethodData.info.cardNetwork),
     cardholder_name: nullable(payload.payerName || ''),
-    email: nullable(payload.payerEmail || '')
+    email: nullable(payload.payerEmail || ''),
+    accept_header: req.headers['accept-for-html'],
+    user_agent_header: req.headers['user-agent'],
+    ip_address: userIpAddress(req)
   }
 
   const paymentData = humps.decamelizeKeys(JSON.parse(payload.details.paymentMethodData.tokenizationData.token))

--- a/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
+++ b/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
@@ -1,6 +1,12 @@
 const expect = require('chai').expect
 const normalise = require('../../../../app/controllers/web-payments/google-pay/normalise-google-pay-payload')
 
+const headers = {
+  'accept-for-html': 'text/html;q=1.0, */*;q=0.9',
+  'user-agent': 'Mozilla/5.0',
+  'x-forwarded-for': '203.0.113.1'
+}
+
 describe('normalise Google Pay payload', () => {
   it('should return the correct format for the payload', () => {
     const googlePayPayload = {
@@ -24,14 +30,17 @@ describe('normalise Google Pay payload', () => {
       payerName: 'Some Name'
     }
 
-    const normalisedPayload = normalise({ body: googlePayPayload })
+    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload })
     expect(normalisedPayload).to.eql(
       {
         payment_info: {
           last_digits_card_number: '4242',
           brand: 'master-card',
           cardholder_name: 'Some Name',
-          email: 'name@email.fyi'
+          email: 'name@email.fyi',
+          accept_header: 'text/html;q=1.0, */*;q=0.9',
+          user_agent_header: 'Mozilla/5.0',
+          ip_address: '203.0.113.1'
         },
         encrypted_payment_data: {
           signature: 'MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ=',
@@ -64,7 +73,7 @@ describe('normalise Google Pay payload', () => {
       payerName: 'Some Name'
     }
 
-    expect(() => normalise({ body: googlePayPayload })).to.throw('Unrecognised card brand in Google Pay payload: UnSupportedCard')
+    expect(() => normalise({ headers: headers, body: googlePayPayload })).to.throw('Unrecognised card brand in Google Pay payload: UnSupportedCard')
   })
 
   it('should return the correct format for the payload with min data', () => {
@@ -86,14 +95,17 @@ describe('normalise Google Pay payload', () => {
         }
       }
     }
-    const normalisedPayload = normalise({ body: googlePayPayload })
+    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload })
     expect(normalisedPayload).to.eql(
       {
         payment_info: {
           last_digits_card_number: '4242',
           brand: 'master-card',
           cardholder_name: null,
-          email: null
+          email: null,
+          accept_header: 'text/html;q=1.0, */*;q=0.9',
+          user_agent_header: 'Mozilla/5.0',
+          ip_address: '203.0.113.1'
         },
         encrypted_payment_data: {
           signature: 'MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ=',
@@ -123,14 +135,17 @@ describe('normalise Google Pay payload', () => {
         }
       }
     }
-    const normalisedPayload = normalise({ body: googlePayPayload })
+    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload })
     expect(normalisedPayload).to.eql(
       {
         payment_info: {
           last_digits_card_number: '',
           brand: 'master-card',
           cardholder_name: null,
-          email: null
+          email: null,
+          accept_header: 'text/html;q=1.0, */*;q=0.9',
+          user_agent_header: 'Mozilla/5.0',
+          ip_address: '203.0.113.1'
         },
         encrypted_payment_data: {
           signature: 'MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ=',
@@ -160,14 +175,17 @@ describe('normalise Google Pay payload', () => {
         }
       }
     }
-    const normalisedPayload = normalise({ body: googlePayPayload })
+    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload })
     expect(normalisedPayload).to.eql(
       {
         payment_info: {
           last_digits_card_number: '',
           brand: 'master-card',
           cardholder_name: null,
-          email: null
+          email: null,
+          accept_header: 'text/html;q=1.0, */*;q=0.9',
+          user_agent_header: 'Mozilla/5.0',
+          ip_address: '203.0.113.1'
         },
         encrypted_payment_data: {
           signature: 'MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ=',

--- a/test/fixtures/wallet_payment_fixtures.js
+++ b/test/fixtures/wallet_payment_fixtures.js
@@ -9,7 +9,10 @@ const fixtures = {
         last_digits_card_number: ops.lastDigitsCardNumber !== undefined ? ops.lastDigitsCardNumber : successfulLastDigitsCardNumber,
         brand: 'master-card',
         cardholder_name: 'Some Name',
-        email: 'name@email.fyi'
+        email: 'name@email.fyi',
+        accept_header: 'text/html;q=1.0, */*;q=0.9',
+        user_agent_header: 'Mozilla/5.0',
+        ip_address: '203.0.113.1'
       },
       encrypted_payment_data: {
         signature: 'MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ=',


### PR DESCRIPTION
When sending the request to connector to authorise a Google Pay payment, send the `Accept-For-HTML` header (which is the `Accept` header that was sent when the enter card details page was loaded), the `User-Agent` and the IP address because connector needs to send them to Worldpay for 3D Secure.