### PR TITLE
PP-7477 - Add JSON fields for Google Pay to be SCA compliance

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -86,7 +86,8 @@ const getGooglePaymentsConfiguration = () => {
     type: 'CARD',
     parameters: {
       allowedAuthMethods: allowedCardAuthMethods,
-      allowedCardNetworks: allowedCardNetworks
+      allowedCardNetworks: allowedCardNetworks,
+      assuranceDetailsRequired: true
     },
     tokenizationSpecification
   }
@@ -102,6 +103,7 @@ const getGooglePaymentsConfiguration = () => {
     transactionInfo: {
       totalPriceStatus: 'FINAL',
       totalPrice: window.paymentDetails.amount,
+      countryCode: 'GB',
       currencyCode: 'GBP'
     },
     allowedPaymentMethods: [cardPaymentMethod]


### PR DESCRIPTION
Description:
- Some of the fields which are required for SCA compliance are already present in the PaymentRequest object.
- This PR adds the countryCode and assuranceDetailsRequired to the object. The documentation doesn't make it clear whether assuranceDetailsRequired is required for SCA compliance so I've included it in anyways. Since Worldpay haven't specified what fields to send in addition to the 3DS parameters we already send adding these fields into our current Google Pay integration shouldn't break anything as we aren't sending the newly added fields along
- See [here](https://developers.google.com/pay/api/android/guides/resources/sca) for the fields Google Pay want us to add


