### PR TITLE
PP-7082 Frontend Design System asset caching

### DIFF
--- a/server.js
+++ b/server.js
@@ -137,7 +137,13 @@ function initialisePublic (app) {
   app.use('/javascripts', express.static(path.join(__dirname, '/public/assets/javascripts'), publicCaching))
   app.use('/images', express.static(path.join(__dirname, '/public/images'), publicCaching))
   app.use('/stylesheets', express.static(path.join(__dirname, '/public/assets/stylesheets'), publicCaching))
-  app.use('/', express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/')))
+
+  if (process.env.NGINX_CACHING_ENABLED === 'true') {
+    app.use('/', express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/'), publicCaching))
+  } else {
+    app.use('/', express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/')))
+  }
+
   app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-pay/pay-js-commons/')))
 }
 


### PR DESCRIPTION
- Add feature flag - NGINX_CACHING_ENABLED
- If flag = true then
  - Add add cache headers to the Design System assets
- Want to see if adding this means we can cache assets from the Design system using NGINX.
- Will be testing this only on the Test env.
