### PR TITLE
Revert "Bump envfile from 5.1.0 to 6.14.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2688,6 +2688,15 @@
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
+    "ambi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ambi/-/ambi-7.1.0.tgz",
+      "integrity": "sha512-OvWiv3gEy2ZNpHdDwoyJe7isWP2v9vZqFWEb2dzotHd8HMPTa5mIk6MLFjvVusbI7mhTBw++4xWipNhJAehW7Q==",
+      "dev": true,
+      "requires": {
+        "typechecker": "^6.4.0"
+      }
+    },
     "amdefine": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.0.4.tgz",
@@ -6468,6 +6477,15 @@
         "stream-shift": "^1.0.0"
       }
     },
+    "eachr": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-4.5.0.tgz",
+      "integrity": "sha512-9I664RWp6p8jvcHZIwo7bWaiSaUmA1wNSLKwNZEiaYjqiTARq3cGjyRiIunsopZv4QMmX3T5Hs17QoPAzdYxfg==",
+      "dev": true,
+      "requires": {
+        "typechecker": "^6.2.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -6617,10 +6635,15 @@
       "dev": true
     },
     "envfile": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/envfile/-/envfile-6.14.0.tgz",
-      "integrity": "sha512-JxpcaOgJQB/x0XFmNiqFu0BLK22PlI3F0d95of5SOqcLvBlGC0ug7MHYDWnmZqmx9svIue8v0cVcqAygPTyXHQ==",
-      "dev": true
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/envfile/-/envfile-5.1.0.tgz",
+      "integrity": "sha512-6YsSCeyOMxCQp8YJPzK+xAn1V6jmNG7iejJNCAkcLN7AXtMFW9g5bz828o1k5RFA2M5hLlaX5E8VUlXSIyFKjQ==",
+      "dev": true,
+      "requires": {
+        "ambi": "^7.1.0",
+        "eachr": "^4.5.0",
+        "typechecker": "^6.4.0"
+      }
     },
     "error": {
       "version": "7.2.1",
@@ -21307,6 +21330,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typechecker": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-6.4.0.tgz",
+      "integrity": "sha512-EbOu+9szY13mhl0EsvLXnR+pTCa3gTHQQPLdce72ujcC9fRHXlVFBNXtHeRhgzLxLlKUh4zA9C0tezLDgshf+A==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "chokidar-cli": "latest",
     "cypress": "3.1.5",
     "dotenv": "^8.2.0",
-    "envfile": "^6.14.0",
+    "envfile": "^5.1.0",
     "eslint": "^6.8.0",
     "govuk-country-and-territory-autocomplete": "^1.0.1",
     "grunt": "1.3.0",


### PR DESCRIPTION
This caused a frontend build failure.
Reverts alphagov/pay-frontend#1757