### PR TITLE
PP-7082 Move no cache headers after static assets 

### DIFF
--- a/server.js
+++ b/server.js
@@ -74,11 +74,6 @@ function initialiseGlobalMiddleware (app) {
     next()
   })
 
-  app.use(function (req, res, next) {
-    noCache(res)
-    next()
-  })
-
   app.use(bodyParser.json())
   app.use(bodyParser.urlencoded({ extended: true }))
 
@@ -151,6 +146,13 @@ function initialiseRoutes (app) {
   router.bind(app)
 }
 
+function setNoCacheHeadersForRoutes (app) {
+  app.use((req, res, next) => {
+    noCache(res)
+    next()
+  })
+}
+
 function listen () {
   const app = initialise()
   app.listen(PORT || 3000)
@@ -179,7 +181,9 @@ function initialise () {
   initialiseCookies(app)
   initialiseTemplateEngine(app)
   initialisePublic(app)
+  setNoCacheHeadersForRoutes(app)
   initialiseRoutes(app) // This contains the 404 override and so should be last
+
   logApplePayCertificateTimeToExpiry()
   app.use(Sentry.Handlers.errorHandler())
   app.use(errorHandlers.defaultErrorHandler)


### PR DESCRIPTION
A no cache policy was set on card payments frontend in the past with
some work done on browser history back/forward behaviour.

The existing middleware stack sets this at the beginning which will apply
to both static routes (served through express middleware) and route
controllers responding to requests.

This commit moves the no cache reset below the definition for serving
static assets, this will apply the no cache header only to the actual
route controllers, continuing to respect the intended behaviour of
forcing browsers to request a new copy of route resources.

This allows upstream services (likely proxies) to set cache headers on
requests and cache commonly used assets.

Co-authored-by: Steven Fountain <steven.fountain@digital.cabinet-office.gov.uk>
