### PR TITLE
BAU: Bump product page to v4.7.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16037,8 +16037,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.7.6/pay-product-page-4.7.6.tgz",
-      "integrity": "sha512-+k44bQIEvMoSPiHgckyXu4a8pCrD3zWkKQ4YJH+xzkKJS5E7sJFV+/SkNSP3EE06mc8P3Ekg1sHpKgtj1+NMTg==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.7.7/pay-product-page-4.7.7.tgz",
+      "integrity": "sha512-Z1m9hdHi3X5NfB+k8OxCCy4GiF8KMnXQvrVGNvcwjmfO5ReTu4m6YxP5yCvEF+rSRCwe9GuzcizSBA29bdldnA==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "nodemon": "^2.0.6",
     "nyc": "15.1.x",
     "pact": "4.3.2",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.7.6/pay-product-page-4.7.6.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.7.7/pay-product-page-4.7.7.tgz",
     "proxyquire": "~2.1.3",
     "sass-lint": "^1.13.1",
     "sinon": "9.2.x",


### PR DESCRIPTION
## WHAT
Pulls in the changes from https://github.com/alphagov/pay-product-page/pull/297

