### PR TITLE
BAU Bump product page to 4.7.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16037,8 +16037,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.7.7/pay-product-page-4.7.7.tgz",
-      "integrity": "sha512-Z1m9hdHi3X5NfB+k8OxCCy4GiF8KMnXQvrVGNvcwjmfO5ReTu4m6YxP5yCvEF+rSRCwe9GuzcizSBA29bdldnA==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.7.8/pay-product-page-4.7.8.tgz",
+      "integrity": "sha512-UfOsanBy8tHXUj3EfIvsXrtarFK8szapjybYlmFgWEQooAzS6DuSgoRIJA2AVdZ2acG0FfZXEetf/kwE1Sidhw==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "nodemon": "^2.0.7",
     "nyc": "15.1.x",
     "pact": "4.3.2",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.7.7/pay-product-page-4.7.7.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.7.8/pay-product-page-4.7.8.tgz",
     "proxyquire": "~2.1.3",
     "sass-lint": "^1.13.1",
     "sinon": "9.2.x",


### PR DESCRIPTION
Include the following product page content changes:
- update the public roadmap
- update 3DSecure page and guidance

