### PR TITLE
Revert "PP-7618: Temporarily only enable Apple Pay for our live account"

### DIFF
--- a/app/controllers/charge_controller.js
+++ b/app/controllers/charge_controller.js
@@ -51,7 +51,7 @@ const appendChargeForNewView = async function appendChargeForNewView (charge, re
   charge.exampleCardExpiryDateYear = getFutureYearAs2Digits()
   charge.post_card_action = routeFor('create', chargeId)
   charge.post_cancel_action = routeFor('cancel', chargeId)
-  charge.allowApplePay = charge.gatewayAccount.gatewayAccountId === 27
+  charge.allowApplePay = charge.gatewayAccount.allowApplePay
   charge.allowGooglePay = charge.gatewayAccount.allowGooglePay
   charge.googlePayGatewayMerchantID = charge.gatewayAccount.gatewayMerchantId
   charge.acceptHeader = req.headers['accept']

--- a/test/cypress/integration/web-payments/apple-pay.spec.js
+++ b/test/cypress/integration/web-payments/apple-pay.spec.js
@@ -1,6 +1,6 @@
 const { getMockApplePayClass, MockApplePayError } = require('../../utils/apple-pay-js-api-stubs')
 
-describe.skip('Apple Pay payment flow', () => {
+describe('Apple Pay payment flow', () => {
   const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
   const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
   const returnURL = '?success'


### PR DESCRIPTION
Reverts alphagov/pay-frontend#1996

[Test payment in production](https://toolbox.payments.service.gov.uk/transactions/aord7u702kpa1bdmh9bucvuepc) was successful.