### PR TITLE
PP-8581 Fix tab selection jump to country autocomplete

### DIFF
--- a/app/assets/javascripts/browsered/helpers.js
+++ b/app/assets/javascripts/browsered/helpers.js
@@ -13,6 +13,9 @@ const initialiseAddressCountryAutocomplete = () => {
       autoselect: true,
       displayMenu: 'overlay'
     })
+
+    var noOpAutocompleteIdentifier = Math.random().toString(36).substring(2, 15)
+    document.getElementById('address-country').setAttribute('autocomplete', noOpAutocompleteIdentifier)
   }
 
   autocompleteScript.setAttribute('type', 'text/javascript')


### PR DESCRIPTION
In the Chrome browser, if a service is configured to collect billing
address the tab order will "jump" back to the country selection when the
user blurs (moves on from) the final form input (currently users email).

This is because of a collision between the accessible autocomplete
library and Chrome's behaviour with the web standard `autocomplete=off`.
Instead of ignoring this input as described in
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocomple>
Chrome is using "off" as the autoselect key and providing the previous
values that have been entered for any input that sets this value. As the
browser autocomplete is also loaded, the input is not cleanly tabbed
away from which means it is the next in line to be selected once there
is nothing left in the form to jump to.

Chrome ignoring the `off` value is documented in the Chromium bug report
https://bugs.chromium.org/p/chromium/issues/detail?id=914451

Because we rely on a third party library (country autocomplete ->
accessible autocomplete) we don't have direct control over the
autocomplete value this is set
(https://github.com/alphagov/accessible-autocomplete/blob/master/src/autocomplete.js#L499)

Unless we can identify a long term supported fix it would be difficult
to submit a workaround to the upstream library.

This workaround sets the key for Chrome's autocomplete to a random value
that shouldn't be shared by either this page or other pages. This
effectively stops Chrome from trying to provice suggestions and allows
the element tab order to remain consistent.

**Current behaviour**

https://user-images.githubusercontent.com/2844572/108073219-ad804200-705f-11eb-88fa-6390c8410399.mov


**Behaviour following change**


https://user-images.githubusercontent.com/2844572/108073238-b244f600-705f-11eb-8060-344b4bc4fd02.mov



