### PR TITLE
BAU Bump JS Commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2094,9 +2094,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.1.0.tgz",
-      "integrity": "sha512-SNwNRRjJOAeE6tMiwoErj5nfQPiEkwJfw1A5tEDLgBGDT85CUqHdmYRdtcL5znDcvrFzX2tzOTiqpUeHAIkPhA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.0.7.tgz",
+      "integrity": "sha512-WW/V7YJQqoWCu+QI5GluFClWLqhyxGlZIkzggmUGNlON6Amm9Arn29ldhNgsiK887KhRVQinXkUyKVdbiRdqTQ==",
       "requires": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.33",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "3.1.0",
+    "@govuk-pay/pay-js-commons": "3.0.7",
     "@sentry/node": "6.2.0",
     "appmetrics": "5.1.1",
     "appmetrics-statsd": "3.0.0",


### PR DESCRIPTION
This will pick up custom branding changes for MHRA and NIBSC reference
zen desk ticket https://govuk.zendesk.com/agent/tickets/4487202.

Note that release `3.1.0` was created in error about 10 days ago and was
subsequently corrected to `3.0.5` which I have confirmed with the
developer. It appears frontend wasn't updated with the corrected
version. This is not downgrading the version of `pay-js-commons`.


