### PR TITLE
Bump @govuk-pay/pay-js-commons from 3.0.9 to 3.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2278,9 +2278,9 @@
       "dev": true
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.0.9.tgz",
-      "integrity": "sha512-52EESUxOCBxKqL40mREH4/WTaCWQ3EyO7Y2NqqpLZ6MK5m0vtWmB+QqxtRdKx50Ybj4CyzEtw5YUk9TZKu2ijw==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.0.10.tgz",
+      "integrity": "sha512-w43BjCYvpfDY9+HZVBeK1zRZ4Iimrla/VA3vDItmOdzTMKzIXNP5XAT4HqmR1n2WbidNLWpO/iCl/GiNhlPYUw==",
       "requires": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.33",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "3.0.9",
+    "@govuk-pay/pay-js-commons": "^3.0.10",
     "@sentry/node": "6.2.2",
     "appmetrics": "5.1.1",
     "appmetrics-statsd": "3.0.0",


### PR DESCRIPTION
- Bumps pay-js-commons to latest
