### PR TITLE
PP-7965 Fix Cypress test flakiness

### DIFF
--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -18,7 +18,7 @@ module.exports = (on, config) => {
      * the same call.
      */
     setupStubs (stubs) {
-      return request({
+      return requestPromise({
         method: 'POST',
         url: stubServerURL,
         json: true,


### PR DESCRIPTION
We weren't returning a promise from the `setupStubs` task, causing test flakiness.

