### PR TITLE
PP-8194 Use Charge paymentProvider instead of gateway account payment provider

### DIFF
--- a/app/controllers/charge.controller.js
+++ b/app/controllers/charge.controller.js
@@ -72,7 +72,7 @@ const appendChargeForNewView = async function appendChargeForNewView (charge, re
   charge.worldpay3dsFlexDdcJwt = await worlpay3dsFlexService.getDdcJwt(charge, correlationId, getLoggingFields(req))
   charge.worldpay3dsFlexDdcUrl = charge.gatewayAccount.type !== 'live' ? WORLDPAY_3DS_FLEX_DDC_TEST_URL : WORLDPAY_3DS_FLEX_DDC_LIVE_URL
 
-  charge.collectAdditionalBrowserDataForEpdq3ds = charge.gatewayAccount.paymentProvider === 'epdq' &&
+  charge.collectAdditionalBrowserDataForEpdq3ds = charge.paymentProvider === 'epdq' &&
     charge.gatewayAccount.requires3ds && charge.gatewayAccount.integrationVersion3ds === 2
 }
 

--- a/app/middleware/state-enforcer.js
+++ b/app/middleware/state-enforcer.js
@@ -16,7 +16,7 @@ module.exports = (req, res, next) => {
   const correctStates = stateService.resolveStates(req.actionName)
   const currentState = req.chargeData.status
 
-  const paymentProvider = req.chargeData.gateway_account.payment_provider
+  const paymentProvider = req.chargeData.payment_provider
   if (paymentProvider === 'stripe' && currentState === State.AUTH_3DS_READY) {
     correctStates.push(State.AUTH_3DS_READY)
   }
@@ -43,7 +43,7 @@ function getGoogleAnalytics (req) {
       path: paths.generateRoute('card.new', { chargeId: req.chargeId }),
       analyticsId: gatewayAccount.analytics_id,
       type: gatewayAccount.type,
-      paymentProvider: gatewayAccount.payment_provider
+      paymentProvider: req.chargeData.payment_provider
     }
   }
   return withAnalyticsError().analytics

--- a/app/services/normalise-charge.js
+++ b/app/services/normalise-charge.js
@@ -16,6 +16,7 @@ module.exports = (function () {
       amount: penceToPounds(charge.amount),
       service_return_url: charge.return_url,
       description: charge.description,
+      paymentProvider: charge.payment_provider,
       links: charge.links,
       status: charge.status,
       email: charge.email,

--- a/app/services/worldpay-3ds-flex.service.js
+++ b/app/services/worldpay-3ds-flex.service.js
@@ -3,7 +3,7 @@
 const connectorClient = require('./clients/connector.client')
 
 const getDdcJwt = async function getDdcJwt (charge, correlationId, loggingFields = {}) {
-  if (charge.gatewayAccount.paymentProvider === 'worldpay' &&
+  if (charge.paymentProvider === 'worldpay' &&
     charge.gatewayAccount.requires3ds &&
     charge.gatewayAccount.integrationVersion3ds === 2) {
     const response = await connectorClient({ correlationId }).getWorldpay3dsFlexJwt({ chargeId: charge.id }, loggingFields)

--- a/app/utils/analytics.js
+++ b/app/utils/analytics.js
@@ -23,7 +23,7 @@ exports.withAnalytics = (charge, param, path) => {
       path: path || paths.generateRoute('card.new', { chargeId: charge.id }),
       analyticsId: charge.gatewayAccount.analyticsId,
       type: charge.gatewayAccount.type,
-      paymentProvider: charge.gatewayAccount.paymentProvider,
+      paymentProvider: charge.paymentProvider,
       amount: charge.amount,
       testingVariant: 'original'
     }

--- a/test/controllers/charge.controller.test.js
+++ b/test/controllers/charge.controller.test.js
@@ -70,6 +70,7 @@ const aChargeWithStatus = function (status) {
     externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
     status: status,
     amount: '4.99',
+    paymentProvider: 'sandbox',
     gatewayAccount: {
       serviceName: 'Service Name',
       analyticsId: 'test-1234',

--- a/test/controllers/web-payments/handle-auth-response.controller.test.js
+++ b/test/controllers/web-payments/handle-auth-response.controller.test.js
@@ -21,6 +21,7 @@ const req = {
   chargeData: {
     id: 3,
     amount: '4.99',
+    paymentProvider: 'sandbox',
     gatewayAccount: {
       analyticsId: 'test-1234',
       type: 'test',

--- a/test/fixtures/payment.fixtures.js
+++ b/test/fixtures/payment.fixtures.js
@@ -182,6 +182,7 @@ const buildChargeDetails = function buildChargeDetails (opts) {
       finished: false
     },
     description: opts.description || 'Example fixture payment',
+    payment_provider: opts.paymentProvider || 'sandbox',
     language: opts.language || 'en',
     status: opts.status || 'CREATED',
     charge_id: chargeId,

--- a/test/integration/charge-status.ft.test.js
+++ b/test/integration/charge-status.ft.test.js
@@ -63,6 +63,7 @@ describe('chargeTests', function () {
             description: 'Payment Description',
             status: status,
             return_url: 'http://www.example.com/service',
+            payment_provider: 'sandbox',
             gateway_account: {
               gateway_account_id: gatewayAccountId,
               analytics_id: 'test-1234',

--- a/test/middleware/state-enforcer.test.js
+++ b/test/middleware/state-enforcer.test.js
@@ -29,7 +29,7 @@ describe('state enforcer', function () {
   it('should call next when everything is in the correct state', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: { status: 'ENTERING CARD DETAILS', gateway_account: { payment_provider: 'Test Provider' } }
+      chargeData: { status: 'ENTERING CARD DETAILS', payment_provider: 'Test Provider' }
     }, {}, next)
     expect(next.calledOnce).to.be.true // eslint-disable-line
   })
@@ -37,7 +37,7 @@ describe('state enforcer', function () {
   it('should call next when Stripe charge is in AUTH_3DS_READY', function () {
     stateEnforcer({
       actionName: 'card.auth3dsHandler',
-      chargeData: { status: 'AUTHORISATION 3DS READY', gateway_account: { payment_provider: 'stripe' } }
+      chargeData: { status: 'AUTHORISATION 3DS READY', payment_provider: 'stripe'}
     }, {}, next)
     expect(next.calledOnce).to.be.true // eslint-disable-line
   })
@@ -45,7 +45,7 @@ describe('state enforcer', function () {
   it('should NOT call next when an invalid state is called and render an error', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: { status: 'INVALID STATE', gateway_account: { payment_provider: 'Test Provider' } }
+      chargeData: { status: 'INVALID STATE', payment_provider: 'Test Provider' }
     }, response, next)
     expect(next.notCalled).to.be.true // eslint-disable-line
     assert(status.calledWith(500))
@@ -60,7 +60,7 @@ describe('state enforcer', function () {
   it('should NOT call next when the object is in the wrong state is called and render the appropriate error view', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: { status: 'AUTHORISATION_SUCCESS', return_url: 'foo', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider' } },
+      chargeData: { status: 'AUTHORISATION_SUCCESS', return_url: 'foo', payment_provider: 'Test Provider', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type' } },
       chargeId: 1
     }, response, next)
     expect(next.notCalled).to.be.true // eslint-disable-line
@@ -83,7 +83,7 @@ describe('state enforcer', function () {
   it('should render the auth_waiting view the correct analytics when auth is rejected', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: { status: 'AUTHORISATION_READY', return_url: 'foo', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider' } },
+      chargeData: { status: 'AUTHORISATION_READY', return_url: 'foo', payment_provider: 'Test Provider', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type' } },
       chargeId: 1
     }, response, next)
     expect(next.notCalled).to.be.true // eslint-disable-line
@@ -115,7 +115,7 @@ describe('state enforcer', function () {
   it('should render the confirm view when coming back from the service with the correct analytics', function () {
     stateEnforcer({
       actionName: 'card.confirm',
-      chargeData: { status: 'CAPTURED', return_url: 'foo', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider' } },
+      chargeData: { status: 'CAPTURED', return_url: 'foo', payment_provider: 'Test Provider', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type' } },
       chargeId: 1
     }, response, next)
     expect(next.notCalled).to.be.true // eslint-disable-line
@@ -139,7 +139,7 @@ describe('state enforcer', function () {
   it('should render the auth_failure view the correct analytics when auth is rejected', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: { status: 'AUTHORISATION_REJECTED', return_url: 'foo', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider' } },
+      chargeData: { status: 'AUTHORISATION_REJECTED', return_url: 'foo', payment_provider: 'Test Provider', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type' } },
       chargeId: 1
     }, response, next)
     expect(next.notCalled).to.be.true // eslint-disable-line
@@ -162,7 +162,7 @@ describe('state enforcer', function () {
   it('should render the auth_failure view the correct analytics when auth is cancelled', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: { status: 'AUTHORISATION_CANCELLED', return_url: 'foo', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider' } },
+      chargeData: { status: 'AUTHORISATION_CANCELLED', return_url: 'foo', payment_provider: 'Test Provider', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type' } },
       chargeId: 1
     }, response, next)
     expect(next.notCalled).to.be.true // eslint-disable-line
@@ -184,7 +184,7 @@ describe('state enforcer', function () {
   it('should render the capture_failure view the correct analytics when capture fails', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: { status: 'CAPTURE_FAILURE', return_url: 'foo', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider' } },
+      chargeData: { status: 'CAPTURE_FAILURE', return_url: 'foo', payment_provider: 'Test Provider', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type' } },
       chargeId: 1
     }, response, next)
     expect(next.notCalled).to.be.true // eslint-disable-line
@@ -206,7 +206,7 @@ describe('state enforcer', function () {
   it('should render the capture_failure view the correct analytics when capture errors', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: { status: 'CAPTURE_ERROR', return_url: 'foo', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider' } },
+      chargeData: { status: 'CAPTURE_ERROR', return_url: 'foo', payment_provider: 'Test Provider', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type' } },
       chargeId: 1
     }, response, next)
     expect(next.notCalled).to.be.true // eslint-disable-line
@@ -229,10 +229,10 @@ describe('state enforcer', function () {
   it('should render the capture_waiting view the correct analytics when capture is ready', function () {
     stateEnforcer({
       actionName: 'card.new',
-      chargeData: { status: 'CAPTURE_READY', return_url: 'foo', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type', payment_provider: 'Test Provider' } },
+      chargeData: { status: 'CAPTURE_READY', return_url: 'foo', payment_provider: 'Test Provider', gateway_account: { analytics_id: 'Test AnalyticsID', type: 'Test Type' } },
       chargeId: 1
     }, response, next)
-    expect(next.notCalled).to.be.true // eslint-disable-line 
+    expect(next.notCalled).to.be.true // eslint-disable-line
     assert(status.calledWith(200))
     assert(render.calledWith('errors/incorrect-state/capture-waiting',
       {

--- a/test/services/worldpay-3ds-flex.service.test.js
+++ b/test/services/worldpay-3ds-flex.service.test.js
@@ -39,6 +39,7 @@ describe('Worldpay 3DS Flex service', () => {
       it('should call connector to get a JWT', async () => {
         const charge = {
           id: 'a-charge-id',
+          paymentProvider: 'worldpay',
           gatewayAccount: {
             paymentProvider: 'worldpay',
             requires3ds: true,
@@ -58,6 +59,7 @@ describe('Worldpay 3DS Flex service', () => {
       it('should not call connector to get a JWT', async () => {
         const charge = {
           id: 'a-charge-id',
+          paymentProvider: 'epdq',
           gatewayAccount: {
             paymentProvider: 'worldpay',
             requires3ds: true,
@@ -75,6 +77,7 @@ describe('Worldpay 3DS Flex service', () => {
       it('should not call connector to get a JWT', async () => {
         const charge = {
           id: 'a-charge-id',
+          paymentProvider: 'epdq',
           gatewayAccount: {
             paymentProvider: 'worldpay',
             requires3ds: false,
@@ -92,6 +95,7 @@ describe('Worldpay 3DS Flex service', () => {
       it('should not call connector to get a JWT', async () => {
         const charge = {
           id: 'a-charge-id',
+          paymentProvider: 'epdq',
           gatewayAccount: {
             paymentProvider: 'epdq',
             requires3ds: true,
@@ -124,6 +128,7 @@ describe('Worldpay 3DS Flex service', () => {
       it('should throw an error', async () => {
         const charge = {
           id: 'a-charge-id',
+          paymentProvider: 'worldpay',
           gatewayAccount: {
             paymentProvider: 'worldpay',
             requires3ds: true,

--- a/test/utils/normalise.test.js
+++ b/test/utils/normalise.test.js
@@ -6,6 +6,7 @@ var unNormalisedCharge = {
   amount: 1234,
   return_url: 'foo',
   description: 'bar',
+  payment_provider: 'worldpay',
   links: [{
     rel: 'rar',
     href: 'http://foo'
@@ -38,6 +39,7 @@ var normalisedCharge = {
   amount: '12.34',
   service_return_url: 'foo',
   description: 'bar',
+  paymentProvider: 'worldpay',
   links: [{
     rel: 'rar',
     href: 'http://foo'


### PR DESCRIPTION
## WHAT

- We currently use gateway account payment_provider during payment journey where needed. Gateway account is going to support multiple payment providers (when PSP switching is supported), so use payment_provider available on charge
