### PR TITLE
Pp 7864 payment page update layout

### DIFF
--- a/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
+++ b/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
@@ -5,7 +5,7 @@ const toggleWaiting = () => {
   document.getElementById('spinner').classList.toggle('hidden')
   document.getElementById('error-summary').classList.add('hidden')
 
-  var paymentDetailsHeader = document.querySelector('.govuk-heading-l.web-payment-button-heading')
+  var paymentDetailsHeader = document.querySelector('.web-payment-button-section')
   if (typeof paymentDetailsHeader !== 'undefined' && paymentDetailsHeader !== null) {
     paymentDetailsHeader.style.display = 'none'
   }

--- a/app/assets/sass/modules/_summary-panel.scss
+++ b/app/assets/sass/modules/_summary-panel.scss
@@ -1,18 +1,7 @@
 .payment-summary {
-  margin-top: govuk-spacing(6);
   border-top: 2px solid $govuk-brand-colour;
   padding: govuk-spacing(3);
   background-color: govuk-colour('light-grey');
-
-  @include govuk-media-query($from: tablet) {
-    margin-top: 0;
-  }
-
-  &-wrap {
-    position: -webkit-sticky;
-    position: sticky;
-    top: govuk-spacing(6);
-  }
 
   .amount {
     display: block;

--- a/app/assets/sass/modules/_web-payments.scss
+++ b/app/assets/sass/modules/_web-payments.scss
@@ -14,7 +14,7 @@
   } 
 }
 
-.web-payment-button-heading{
+.web-payment-button-section{
   display: none;
   
   .apple-pay-available &,
@@ -23,7 +23,7 @@
   } 
 }
 
-.non-web-payment-button-heading{
+.non-web-payment-button-section{
   display: block;
 
   .apple-pay-available &,

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -16,6 +16,28 @@
   'data-accept-header': acceptHeader
 } %}
 
+{% macro paymentSummary() %}
+  <div class="payment-summary-wrap">
+    <div class="payment-summary">
+        <h2 class="govuk-heading-m">{{ __p("paymentSummary.title") }}</h2>
+        <p id="payment-description" class="govuk-body">
+        {{ description }}
+        </p>
+        <p class="govuk-body hidden" id="payment-summary-breakdown">
+        {{ __p("paymentSummary.amount") }}
+        <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount"></span><br/>
+        {{ __p("paymentSummary.corporateCardFee") }}
+        <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee"></span>
+        </p>
+        <p class="govuk-body govuk-!-margin-bottom-0">
+        {{ __p("paymentSummary.totalAmount") }}
+        <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold" data-amount="{{ amount }}">£{{ amount }}</span>
+        </p>
+    </div>
+  </div>
+{% endmacro %}
+
+
 {% block bodyStart %}
   {% if allowApplePay or allowGooglePay %}
     <script nonce="{{ nonce }}">
@@ -67,7 +89,10 @@
               </div>
             </div>
             {% if allowApplePay or allowGooglePay %}
-              <h1 class="govuk-heading-l web-payment-button-heading">{{ __p("cardDetails.enterPaymentDetails") }}</h1>
+              <div class="web-payment-button-section govuk-!-margin-bottom-7">
+                <h1 class="govuk-heading-l">{{ __p("cardDetails.enterPaymentDetails") }}</h1>
+                {{ paymentSummary() }}
+              </div>
             {% endif %}
             {% if allowApplePay %}
               <div class="apple-pay-container">
@@ -121,9 +146,12 @@
 
             <div id="card-details-wrap">
               {% if allowApplePay or allowGooglePay %}
-                <h2 class="govuk-heading-m web-payment-button-heading">{{ __p("cardDetails.enterCardDetails") }}</h2>
+                <h2 class="govuk-heading-m web-payment-button-section">{{ __p("cardDetails.enterCardDetails") }}</h2>
               {% endif %}
-              <h1 class="govuk-heading-l non-web-payment-button-heading">{{ __p("cardDetails.enterCardDetails") }}</h1>
+              <div class="non-web-payment-button-section govuk-!-margin-bottom-5">
+                <h1 class="govuk-heading-l ">{{ __p("cardDetails.enterCardDetails") }}</h1>
+                {{paymentSummary()}}
+              </div>
 
               <form id="card-details" name="cardDetails" method="POST" action="{{ post_card_action }}" novalidate>
                 <input id="charge-id" name="chargeId" type="hidden" value="{{ id }}"/>
@@ -158,16 +186,17 @@
                     {% set cardNumberAutoCompleteType = 'cc-number' %}
                   {% endif %}
 
-                  <input id="card-no"
-                      type="{{cardNumberInputType}}"
-                      inputmode="numeric"
-                      pattern="[0-9]*"
-                      name="cardNo"
-                      maxlength="26"
-                      class="govuk-input govuk-!-width-three-quarters"
-                      autocomplete="{{cardNumberAutoCompleteType}}"
-                      value="{{cardNo}}"
-                    />
+                  <p class="govuk-body-s accepted-cards-hint withdrawal-text govuk-!-margin-bottom-0">
+                    {% if withdrawalText === 'debit_credit' %}
+                      {{ __p("cardDetails.withdrawalText").debit_credit }}
+                    {% endif %}
+                    {% if withdrawalText === 'debit' %}
+                      {{ __p("cardDetails.withdrawalText").debit }}
+                    {% endif %}
+                    {% if withdrawalText === 'credit' %}
+                      {{ __p("cardDetails.withdrawalText").credit }}
+                    {% endif %}
+                  </p>
 
                   <ul class="accepted-cards field-empty">
                     {% if allowedCards %}
@@ -183,18 +212,19 @@
                       {% endfor %}
                     {% endif %}
                   </ul>
-                  <p class="govuk-body-s accepted-cards-hint withdrawal-text">
-                    {% if withdrawalText === 'debit_credit' %}
-                      {{ __p("cardDetails.withdrawalText").debit_credit }}
-                    {% endif %}
-                    {% if withdrawalText === 'debit' %}
-                      {{ __p("cardDetails.withdrawalText").debit }}
-                    {% endif %}
-                    {% if withdrawalText === 'credit' %}
-                      {{ __p("cardDetails.withdrawalText").credit }}
-                    {% endif %}
-                  </p>
+
                   <div class="govuk-inset-text hidden" id="corporate-card-surcharge-message"></div>
+
+                  <input id="card-no"
+                      type="{{cardNumberInputType}}"
+                      inputmode="numeric"
+                      pattern="[0-9]*"
+                      name="cardNo"
+                      maxlength="26"
+                      class="govuk-input govuk-!-width-three-quarters"
+                      autocomplete="{{cardNumberAutoCompleteType}}"
+                      value="{{cardNo}}"
+                    />
                 </div>
 
                 <div class="govuk-form-group govuk-clearfix govuk-!-margin-bottom-7 {% if highlightErrorFields.expiryMonth %} error{% endif %} expiry-date" data-validation="expiryMonth">
@@ -325,9 +355,9 @@
                       <fieldset class="govuk-fieldset" aria-describedby="address-hint">
                         <legend>
                           {% if allowApplePay or allowGooglePay %}
-                            <h3 class="govuk-heading-m govuk-!-margin-bottom-1 web-payment-button-heading">{{ __p("cardDetails.billingAddress") }}</h3>
+                            <h3 class="govuk-heading-m govuk-!-margin-bottom-1 web-payment-button-section">{{ __p("cardDetails.billingAddress") }}</h3>
                           {% endif %}
-                          <h2 class="govuk-heading-m govuk-!-margin-bottom-1 non-web-payment-button-heading">{{ __p("cardDetails.billingAddress") }}</h2>
+                          <h2 class="govuk-heading-m govuk-!-margin-bottom-1 non-web-payment-button-section">{{ __p("cardDetails.billingAddress") }}</h2>
                         </legend>
 
                         <div id="address-hint" class="govuk-hint govuk-!-margin-bottom-6">{{ __p("cardDetails.billingAddressHint") }}</div>
@@ -444,9 +474,9 @@
                       <div>
                         <legend for="email" class="govuk-!-margin-bottom-6">
                           {% if allowApplePay or allowGooglePay %}
-                            <h3 class="govuk-heading-m govuk-!-margin-bottom-1 web-payment-button-heading">{{ __p("cardDetails.contactDetails") }}</h3>
+                            <h3 class="govuk-heading-m govuk-!-margin-bottom-1 web-payment-button-section">{{ __p("cardDetails.contactDetails") }}</h3>
                           {% endif %}
-                          <h2 class="govuk-heading-m govuk-!-margin-bottom-1 non-web-payment-button-heading">{{ __p("cardDetails.contactDetails") }}</h2>
+                          <h2 class="govuk-heading-m govuk-!-margin-bottom-1 non-web-payment-button-section">{{ __p("cardDetails.contactDetails") }}</h2>
                         </legend>
                         <div id="email-hint" class="govuk-hint govuk-!-margin-bottom-2">{{ __p("cardDetails.emailHint") }}</div>
 
@@ -540,24 +570,6 @@
             <iframe id="worldpay3dsFlexDdcIframe" src="/public/worldpay/worldpay-3ds-flex-ddc.html" class="govuk-!-display-none"></iframe>
           {% endif %}
       </main>
-      <aside class="govuk-grid-column-one-third payment-summary-wrap">
-        <div class="payment-summary">
-          <h2 class="govuk-heading-m">{{ __p("paymentSummary.title") }}</h2>
-          <p id="payment-description" class="govuk-body">
-            {{ description }}
-          </p>
-          <p class="govuk-body hidden" id="payment-summary-breakdown">
-            {{ __p("paymentSummary.amount") }}
-            <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount"></span><br/>
-            {{ __p("paymentSummary.corporateCardFee") }}
-            <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee"></span>
-          </p>
-          <p class="govuk-body govuk-!-margin-bottom-0">
-            {{ __p("paymentSummary.totalAmount") }}
-            <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold" data-amount="{{ amount }}">£{{ amount }}</span>
-          </p>
-        </div>
-      </aside>
     </div>
   </div>
 {% endblock %}

--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -13,6 +13,27 @@
         <div class="confirm-page__content">
           <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">{{ __p("confirmDetails.title") }}</h1>
 
+          <div class="payment-summary-wrap govuk-!-margin-bottom-2">
+            <div class="payment-summary">
+              <h2 class="govuk-heading-m">{{ __p("paymentSummary.title") }}</h2>
+              <p id="payment-description" class="govuk-body">
+                {{ charge.description }}
+              </p>
+              {% if charge.corporateCardSurcharge %}
+                <p class="govuk-body" id="payment-summary-breakdown">
+                  {{ __p("paymentSummary.amount") }}
+                  <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount">£{{ charge.amount }}</span><br/>
+                  {{ __p("paymentSummary.corporateCardFee") }}
+                  <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee">£{{ charge.corporateCardSurcharge }}</span>
+                </p>
+              {% endif %}
+              <p class="govuk-body govuk-!-margin-bottom-0">
+                {{ __p("paymentSummary.totalAmount") }}
+                <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold">£{{ charge.totalAmount if charge.totalAmount else charge.amount }}</span>
+              </p>
+            </div>
+          </div>
+
           {% set cardDetailsArray = [
             [
               {
@@ -119,26 +140,6 @@
           </form>
         </div>
       </main>
-      <aside class="govuk-grid-column-one-third payment-summary-wrap">
-          <div class="payment-summary">
-            <h2 class="govuk-heading-m">{{ __p("paymentSummary.title") }}</h2>
-            <p id="payment-description" class="govuk-body">
-              {{ charge.description }}
-            </p>
-            {% if charge.corporateCardSurcharge %}
-              <p class="govuk-body" id="payment-summary-breakdown">
-                {{ __p("paymentSummary.amount") }}
-                <span class="govuk-!-font-weight-bold" id="payment-summary-breakdown-amount">£{{ charge.amount }}</span><br/>
-                {{ __p("paymentSummary.corporateCardFee") }}
-                <span class="govuk-!-font-weight-bold" id="payment-summary-corporate-card-fee">£{{ charge.corporateCardSurcharge }}</span>
-              </p>
-            {% endif %}
-            <p class="govuk-body govuk-!-margin-bottom-0">
-              {{ __p("paymentSummary.totalAmount") }}
-              <span id="amount" class="amount govuk-!-font-size-36 govuk-!-font-weight-bold">£{{ charge.totalAmount if charge.totalAmount else charge.amount }}</span>
-            </p>
-          </div>
-        </aside>
     </div>
   </div>
 {% endblock %}

--- a/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js
+++ b/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js
@@ -211,7 +211,7 @@ describe('Worldpay 3ds flex card payment flow', () => {
       cy.get('#card-details').submit()
 
       cy.get('.google-pay-container').should('have.attr', 'style', 'display: none;')
-      cy.get('.govuk-heading-l.web-payment-button-heading').should('have.attr', 'style', 'display: none;')
+      cy.get('.web-payment-button-section').should('have.attr', 'style', 'display: none;')
     })
   })
 })


### PR DESCRIPTION
- Update the `Charge` & `Confirm` page layouts based on findings from user research.
- Move the `Payment summary` to the middle and top of the page.
- Charge page:
  - Move the `accepted card types` and card icons above the `card number` input. 
- Make sure the layout works correctly when Apple & Google pay is visible.
  - Rename the classes
    - `web-payment-button-button` -> `web-payment-button-section`
    - `non-web-payment-button-button` -> `non-web-payment-button-section`
    - Show the `payment-summary` in the correct sections depending if the `apple` or `google` pay buttons are visible.

# Charge page

## Old layout:
![image](https://user-images.githubusercontent.com/59831992/122080271-13a28900-cdf6-11eb-9ba3-a3c58f198098.png)

## New layout:
![image](https://user-images.githubusercontent.com/59831992/122080829-801d8800-cdf6-11eb-8184-5018986ca0dd.png)


# Confirm page

## Old layout
![image](https://user-images.githubusercontent.com/59831992/122081987-806a5300-cdf7-11eb-9f02-519209adbf87.png)

## New layout
![image](https://user-images.githubusercontent.com/59831992/122082247-bf98a400-cdf7-11eb-969b-8c15b1b322d5.png)

