### PR TITLE
Pp 7864 payment page add transparent pixel for Google pay button

### DIFF
--- a/app/assets/sass/modules/_web-payments.scss
+++ b/app/assets/sass/modules/_web-payments.scss
@@ -11,16 +11,16 @@
 
   .google-pay-available & {
     display: block;
-  } 
+  }
 }
 
 .web-payment-button-section{
   display: none;
-  
+
   .apple-pay-available &,
   .google-pay-available & {
-    display: block; 
-  } 
+    display: block;
+  }
 }
 
 .non-web-payment-button-section{
@@ -28,8 +28,8 @@
 
   .apple-pay-available &,
   .google-pay-available & {
-    display: none; 
-  } 
+    display: none;
+  }
 }
 
 .web-payment-button {
@@ -43,7 +43,7 @@
 
   //https://developer.apple.com/documentation/apple_pay_on_the_web/displaying_apple_pay_buttons
   &--apple-pay{
-    @supports (-webkit-appearance: -apple-pay-button) { 
+    @supports (-webkit-appearance: -apple-pay-button) {
       min-width: 200px;
       width: 100%;
       min-height: 32px;
@@ -53,13 +53,13 @@
       -webkit-appearance: -apple-pay-button;
       -apple-pay-button-style: black;
     }
-  
+
     @supports not (-webkit-appearance: -apple-pay-button) {
       display: inline-block;
       background-size: 100% 60%;
       background-repeat: no-repeat;
       background-position: 50% 50%;
-      border-radius: 5px;
+      border-radius: 4px;
       padding: 0px;
       box-sizing: border-box;
       min-width: 200px;
@@ -73,11 +73,6 @@
 
   //https://developers.google.com/pay/api/web/overview
   &--google-pay{
-    background-origin: content-box;
-    background-position: center center;
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-image: url("/images/google-pay-logo.svg");
     background-color: #000;
     box-shadow: none;
     min-width: 200px;
@@ -88,6 +83,18 @@
     height: 40px;
     min-height: 40px;
     border: 0;
+
+    &:focus {
+      .google-pay-image{
+          filter: invert(100%);
+      }
+    }
+
+    &:hover {
+      .google-pay-image{
+          filter: invert(0);
+      }
+    }
   }
 
   @include govuk-media-query($until: desktop) {

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -123,7 +123,7 @@
                 <h2 class="govuk-heading-m">{{ __p("cardDetails.webPayments.payWithGooglePay") }}</h2>
 
                 {% set GooglePayButtonHTML %}
-                  <span class="govuk-visually-hidden">Google Pay</span>
+                  <img class="google-pay-image" src="/images/google-pay-logo.svg" alt="Google Pay">
                 {% endset %}
 
                 <form class="govuk-!-width-three-quarters web-payments-container">


### PR DESCRIPTION
- Google pay
  - Make it use an inline image of the `Google pay` logo instead of a background image
  - This is better for acessibility for users with High contrast needs.
  - Fix the focus state
    - The button becomes yellow when in focus state.  This would make the `Google Pay`
      image difficult to see.
    - Now the image inverts colours when in `focus` state using CSS.
    - Hover state - make sure the image goes back to normal
- General styling cleanup
  - Make the border radius consistent between the Apple and Google pay buttons

