### PR TITLE
PP-8279 Remove consecutive number check from email validation

### DIFF
--- a/app/utils/charge-validation-fields.js
+++ b/app/utils/charge-validation-fields.js
@@ -127,7 +127,6 @@ function email (email, allFields, chargeOptions = {}) {
   if (((email || '') === '' && (chargeOptions && chargeOptions.email_collection_mode === 'OPTIONAL')) ||
       chargeOptions.email_collection_mode === 'OFF') return { emptyOrCustomValidationAllowed: true }
   if (email && email.length > EMAIL_MAX_LENGTH) return 'invalidLength'
-  if (emailValidation(email)) return 'containsTooManyDigits'
   if (!rfc822Validator(email)) return 'message'
   const domain = emailTools.validEmail(email).domain
   return domain && domain.indexOf('.') === -1 ? 'message' : true
@@ -147,11 +146,6 @@ function containsSuspectedPAN (input) {
   if (!['string', 'number'].includes(typeof input)) return false
   const matchedDigits = String(input).match(/(\d)/g)
   return (matchedDigits !== null) && (matchedDigits.length > 11)
-}
-
-function emailValidation (input) {
-  const matchedDigits = String(input).match(/[0-9 ]{11,}/)
-  return matchedDigits !== null
 }
 
 function containsSuspectedCVV (input) {

--- a/test/integration/charge-validation.ft.test.js
+++ b/test/integration/charge-validation.ft.test.js
@@ -77,8 +77,7 @@ describe('checks for PAN-like numbers', () => {
           cardholder: 'Enter the name as it appears on the card',
           addressLine1: 'Enter a valid billing address',
           city: 'Enter a valid town/city',
-          postcode: 'Enter a valid postcode',
-          email: 'Enter a valid email'
+          postcode: 'Enter a valid postcode'
         }
         expect($('#cardholder-name-error').text()).to.contains(errorMessages.cardholder)
         expect($('#error-cardholder-name').text()).to.contains(errorMessages.cardholder)
@@ -89,8 +88,6 @@ describe('checks for PAN-like numbers', () => {
         expect($('#error-address-city').text()).to.contains(errorMessages.city)
         expect($('#address-postcode-error').text()).to.contains(errorMessages.postcode)
         expect($('#error-address-postcode').text()).to.contains(errorMessages.postcode)
-        expect($('#email-error').text()).to.contains(errorMessages.email)
-        expect($('#error-email').text()).to.contains(errorMessages.email)
 
         done()
       })

--- a/test/utils/charge-validation-fields/email-field.test.js
+++ b/test/utils/charge-validation-fields/email-field.test.js
@@ -19,11 +19,4 @@ describe('card validation: email', function () {
       expect(result).to.equal(true)
     })
   })
-
-  describe('should not validate if it contains 12 or more digits', () => {
-    it('and the digits are consecutive', () => {
-      result = fields.fieldValidations.email('1234567890123@example.com')
-      expect(result).to.equal('containsTooManyDigits')
-    })
-  })
 })


### PR DESCRIPTION
Consecutive numbers are rejected during email validation, this was
initially to prevent card numbers accidentally populating this field.
This has caused some confusion around what a valid email should be -- as
card numbers on their own fail RFC822/ domain checks remove this
explicit check.

