### PR TITLE
ZD-4632051: Bump pay-js-commons for custom branding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1648,21 +1648,26 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.0.4.tgz",
-      "integrity": "sha512-cUEUPl7JdxBAjgOMpngkPzlTH13N/OD8TmpWFkH01DtLWa9MkoLSUtU43jqN5hyLt7oPadBfoo8ELB8Yq2lK3A==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.2.3.tgz",
+      "integrity": "sha512-cBudhlib7jwjJXASMNKiArEY/EIKhDuIayvukWNz7L67ysE94ymYKSWgkv+JrGXzg+r08WYk3VbW7gGitMmzJQ==",
       "requires": {
-        "lodash": "4.17.20",
-        "moment-timezone": "0.5.31",
+        "lodash": "4.17.21",
+        "moment-timezone": "0.5.33",
         "rfc822-validate": "1.0.0",
-        "slugify": "1.4.5",
+        "slugify": "1.5.3",
         "winston": "3.3.3"
       },
       "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "moment-timezone": {
-          "version": "0.5.31",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-          "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+          "version": "0.5.33",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+          "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
           "requires": {
             "moment": ">= 2.9.0"
           }
@@ -18046,9 +18051,9 @@
       "dev": true
     },
     "slugify": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.5.tgz",
-      "integrity": "sha512-WpECLAgYaxHoEAJ8Q1Lo8HOs1ngn7LN7QjXgOLbmmfkcWvosyk4ZTXkTzKyhngK640USTZUlgoQJfED1kz5fnQ=="
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.5.3.tgz",
+      "integrity": "sha512-/HkjRdwPY3yHJReXu38NiusZw2+LLE2SrhkWJtmlPDB1fqFSvioYj62NkPcrKiNCgRLeGcGK7QBvr1iQwybeXw=="
     },
     "smart-buffer": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "3.0.4",
+    "@govuk-pay/pay-js-commons": "3.2.3",
     "@sentry/node": "5.29.2",
     "appmetrics": "5.1.1",
     "appmetrics-statsd": "3.0.0",


### PR DESCRIPTION
## WHAT
Bumps pay-js-commons to 3.2.3 to pick up custom branding changes.

Ran npm install to update the package-lock which has also bumped `slugify`.