### PR TITLE
ZD-4632051: Bump pay-js-commons for custom branding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1934,9 +1934,9 @@
       "dev": true
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.2.1.tgz",
-      "integrity": "sha512-bBc4fXAdDXA7GaLEKXo5KFYvyeVcvhM2OEIr5wJ8qMl9SNXivSPhPLy6I5yoGCTL6FYYkNkD0Eswb5J9gxbn+g==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.2.3.tgz",
+      "integrity": "sha512-cBudhlib7jwjJXASMNKiArEY/EIKhDuIayvukWNz7L67ysE94ymYKSWgkv+JrGXzg+r08WYk3VbW7gGitMmzJQ==",
       "requires": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.33",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "^3.2.1",
+    "@govuk-pay/pay-js-commons": "^3.2.3",
     "@sentry/node": "6.9.0",
     "appmetrics": "5.1.1",
     "appmetrics-statsd": "3.0.0",


### PR DESCRIPTION
## WHAT
Bumps pay-js-commons to 3.2.3 to pick up custom branding changes (on an up-to-date branch this time!)




