### PR TITLE
PP-8373 Remove payment_provider from gateway_account fixture

### DIFF
--- a/app/middleware/retrieve-charge.js
+++ b/app/middleware/retrieve-charge.js
@@ -22,7 +22,7 @@ module.exports = (req, res, next) => {
       req.chargeData = data
       setLoggingField(req, GATEWAY_ACCOUNT_ID, data.gateway_account.gateway_account_id)
       setLoggingField(req, GATEWAY_ACCOUNT_TYPE, data.gateway_account.type)
-      setLoggingField(req, PROVIDER, data.gateway_account.payment_provider)
+      setLoggingField(req, PROVIDER, data.payment_provider)
       next()
     })
     .catch((err) => {

--- a/test/controllers/charge.controller.test.js
+++ b/test/controllers/charge.controller.test.js
@@ -74,8 +74,7 @@ const aChargeWithStatus = function (status) {
     gatewayAccount: {
       serviceName: 'Service Name',
       analyticsId: 'test-1234',
-      type: 'test',
-      paymentProvider: 'sandbox'
+      type: 'test'
     },
     id: '3'
   }
@@ -112,8 +111,7 @@ describe('card details endpoint', function () {
       gatewayAccount: {
         serviceName: 'Service Name',
         analyticsId: 'test-1234',
-        type: 'test',
-        paymentProvider: 'sandbox'
+        type: 'test'
       },
       analytics: {
         analyticsId: 'test-1234',

--- a/test/controllers/secure.controller.test.js
+++ b/test/controllers/secure.controller.test.js
@@ -107,9 +107,9 @@ describe('secure controller', function () {
           gatewayAccount: {
             service_name: 'Service Name',
             analytics_id: 'bla-1234',
-            type: 'live',
-            payment_provider: 'worldpay'
-          }
+            type: 'live'
+          },
+          payment_provider: 'worldpay'
         }
       }
 
@@ -160,9 +160,9 @@ describe('secure controller', function () {
               gatewayAccount: {
                 service_name: 'Service Name',
                 analytics_id: 'bla-1234',
-                type: 'live',
-                payment_provider: 'worldpay'
-              }
+                type: 'live'
+              },
+              payment_provider: 'worldpay'
             }
           }
           await requireSecureController(mockCharge.withSuccess(charge), mockToken.withSuccess(), responseRouter).new(requestWithEmptyCookie, response)
@@ -184,9 +184,9 @@ describe('secure controller', function () {
               gatewayAccount: {
                 service_name: 'Service Name',
                 analytics_id: 'bla-1234',
-                type: 'live',
-                payment_provider: 'worldpay'
-              }
+                type: 'live'
+              },
+              payment_provider: 'worldpay'
             }
           }
           await requireSecureController(mockCharge.withSuccess(charge), mockToken.withSuccess(), responseRouter).new(requestWithoutCookie, response)
@@ -213,9 +213,9 @@ describe('secure controller', function () {
               gatewayAccount: {
                 service_name: 'Service Name',
                 analytics_id: 'bla-1234',
-                type: 'live',
-                payment_provider: 'worldpay'
-              }
+                type: 'live'
+              },
+              payment_provider: 'worldpay'
             }
           }
           await requireSecureController(mockCharge.withSuccess(charge), mockToken.withSuccess(), responseRouter).new(requestWithWrongCookie, response)
@@ -242,9 +242,9 @@ describe('secure controller', function () {
               gatewayAccount: {
                 service_name: 'Service Name',
                 analytics_id: 'bla-1234',
-                type: 'live',
-                payment_provider: 'worldpay'
-              }
+                type: 'live'
+              },
+              payment_provider: 'worldpay'
             }
           }
           await requireSecureController(mockCharge.withSuccess(charge), mockToken.withSuccess(), responseRouter).new(requestWithFrontendStateCookie, response)

--- a/test/controllers/web-payments/handle-auth-response.controller.test.js
+++ b/test/controllers/web-payments/handle-auth-response.controller.test.js
@@ -24,8 +24,7 @@ const req = {
     paymentProvider: 'sandbox',
     gatewayAccount: {
       analyticsId: 'test-1234',
-      type: 'test',
-      paymentProvider: 'sandbox'
+      type: 'test'
     },
     status: 'AUTHORISATION SUCCESS'
   }

--- a/test/fixtures/payment.fixtures.js
+++ b/test/fixtures/payment.fixtures.js
@@ -18,7 +18,6 @@ const buildGatewayAccount = function buildGatewayAccount (opts = {}) {
     email_collection_mode: opts.emailCollectionMode || 'MANDATORY',
     block_prepaid_cards: opts.blockPrepaidCards || false,
     live: false,
-    payment_provider: opts.paymentProvider || 'sandbox',
     requires3ds: opts.requires3ds || false,
     service_name: 'My service',
     type: opts.gatewayAccountType || 'test',

--- a/test/integration/charge-status.ft.test.js
+++ b/test/integration/charge-status.ft.test.js
@@ -32,7 +32,6 @@ const defaultCorrelationHeader = {
 }
 const gatewayAccount = {
   gatewayAccountId: '12345',
-  paymentProvider: 'sandbox',
   analyticsId: 'test-1234',
   type: 'test'
 }
@@ -68,7 +67,6 @@ describe('chargeTests', function () {
               gateway_account_id: gatewayAccountId,
               analytics_id: 'test-1234',
               type: 'test',
-              payment_provider: 'sandbox',
               service_name: 'Pranks incorporated',
               card_types: [{
                 type: 'CREDIT',
@@ -101,7 +99,7 @@ describe('chargeTests', function () {
             expect($('#card-details #csrf').attr('value')).to.not.be.empty // eslint-disable-line
             expect($('#amount').text()).to.eql('£23.45')
             expect($('#payment-description').text()).to.contain('Payment Description')
-            expect($('#govuk-script-analytics')[0].children[0].data).to.contains(`init('${gatewayAccount.analyticsId}', '${gatewayAccount.type}', '${gatewayAccount.paymentProvider}', '23.45', '')`)
+            expect($('#govuk-script-analytics')[0].children[0].data).to.contains(`init('${gatewayAccount.analyticsId}', '${gatewayAccount.type}', 'sandbox', '23.45', '')`)
             expect($('#card-details').attr('action')).to.eql(frontendCardDetailsPostPath)
           })
           .end(done)

--- a/test/integration/confirm.ft.test.js
+++ b/test/integration/confirm.ft.test.js
@@ -32,7 +32,6 @@ const app = proxyquire('../../server.js',
 
 const gatewayAccount = {
   gatewayAccountId: '12345',
-  paymentProvider: 'sandbox',
   analyticsId: 'test-1234',
   type: 'test'
 }

--- a/test/test-helpers/test-helpers.js
+++ b/test/test-helpers/test-helpers.js
@@ -117,6 +117,7 @@ function rawSuccessfulGetChargeWithPaymentProvider (status, returnUrl, chargeId,
     status: status,
     return_url: returnUrl,
     email: 'bob@example.com',
+    payment_provider: paymentProvider,
     links: [{
       href: connectorChargeUrl(chargeId),
       rel: 'self',
@@ -134,7 +135,6 @@ function rawSuccessfulGetChargeWithPaymentProvider (status, returnUrl, chargeId,
       gateway_account_id: gatewayAccountId || defaultGatewayAccountId,
       analytics_id: 'test-1234',
       type: 'test',
-      payment_provider: paymentProvider,
       service_name: 'Pranks incorporated',
       card_types: [
         {

--- a/test/utils/normalise.test.js
+++ b/test/utils/normalise.test.js
@@ -23,7 +23,6 @@ var unNormalisedCharge = {
   gateway_account: {
     analytics_id: 'bla-1234',
     type: 'live',
-    payment_provider: 'worldpay',
     service_name: 'Pranks incorporated',
     card_types: [{
       type: 'CREDIT',
@@ -56,7 +55,6 @@ var normalisedCharge = {
   gatewayAccount: {
     analyticsId: 'bla-1234',
     type: 'live',
-    paymentProvider: 'worldpay',
     serviceName: 'Pranks incorporated',
     cardTypes: [{
       brand: 'VISA',


### PR DESCRIPTION
## WHAT
- Remove `payment_provider` from gateway account payload in tests. Frontend is using payment_provider on charge everywhere.
- Also set payment_provider available on charge for logging when retrieving charge from connector
