### PR TITLE
PP-8256 Fix email validation for older browsers

### DIFF
--- a/app/utils/email-validation.js
+++ b/app/utils/email-validation.js
@@ -26,7 +26,7 @@ function validateEmail (email) {
   }
 
   // don't allow consecutive periods in either part
-  if (email.includes('..')) {
+  if (email.indexOf('..') !== -1) {
     return { valid: false }
   }
 


### PR DESCRIPTION
ZAP tests are failing, it appears due to PhantomJS not supporting String.prototype.includes.

This is also apparently not supported on IE 11.


