### PR TITLE
PP-8095 Add security.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,6 @@ Run in two separate terminals:
 
 [MIT License](LICENSE)
 
-## Responsible Disclosure
+## Vulnerability Disclosure
 
-GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. We will give appropriate credit to those reporting confirmed issues. Please e-mail gds-team-pay-security@digital.cabinet-office.gov.uk with details of any issue you find, we aim to reply quickly.
+GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. Please refer to our [vulnerability disclosure policy](https://www.gov.uk/help/report-vulnerability) and our [security.txt](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt) file for details.

--- a/app/routes.js
+++ b/app/routes.js
@@ -91,6 +91,11 @@ exports.bind = function (app) {
   app.get(paths.static.humans.path, statik.humans)
   app.all(paths.static.naxsi_error.path, statik.naxsi_error)
 
+  // security.txt — https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html
+  const securitytxt = 'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'
+  app.get('/.well-known/security.txt', (req, res) => res.redirect(securitytxt))
+  app.get('/security.txt', (req, res) => res.redirect(securitytxt))
+
   // route to gov.uk 404 page
   // this has to be the last route registered otherwise it will redirect other routes
   app.all('*', (req, res) => res.redirect('https://www.gov.uk/404'))


### PR DESCRIPTION
Make `/.well-known/security.txt` and `/security.txt` redirect to https://vdp.cabinetoffice.gov.uk/.well-known/security.txt.

Update `README.md` to reference the Cabinet Office CDIO Cyber Security vulnerability disclosure policy and security.txt file rather than the GOV.UK Pay security vulnerability email address.