### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ govuk_modules
 node_modules/*
 *.log
 reports
-.pre-commit-config.yaml
 .env
 
 # IntelliJ gubbins

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": "package-lock.json",
-    "lines": null
-  },
-  "generated_at": "2020-11-03T18:13:56Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,215 +53,297 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "package-lock.json"
+      ]
+    }
+  ],
   "results": {
-    "app/controllers/web-payments/apple-pay/merchant-validation.controller.js": [
+    ".pre-commit-config.yaml": [
       {
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
         "is_verified": false,
-        "line_number": 13,
-        "type": "Private Key"
+        "line_number": 3
       }
     ],
     "app/middleware/csp.js": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "app/middleware/csp.js",
         "hashed_secret": "175847ef942af200ff3d6485225ffa881eb614e1",
         "is_verified": false,
-        "line_number": 13,
-        "type": "Base64 High Entropy String"
-      }
-    ],
-    "test/charge_hash_out_tests.js": [
-      {
-        "hashed_secret": "afa3c58c3c6e358cb6c7805fc45aa94d2768fa70",
-        "is_verified": false,
-        "line_number": 10,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "cdb7bc4ecc504c11d6815bf6630f08e38f36664c",
-        "is_verified": false,
-        "line_number": 11,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "0f88cae92c8396efd6e68444898a6bd090e7d98a",
-        "is_verified": false,
-        "line_number": 12,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "2f8ea9d911ccd82147e549fb39a8a5c126644eb6",
-        "is_verified": false,
-        "line_number": 13,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "5dd59772d03e517bea5ac0396c3073f02b490841",
-        "is_verified": false,
-        "line_number": 14,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "69f848c3782bb2757b6409df4778706430c28bae",
-        "is_verified": false,
-        "line_number": 15,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "e64b23888fd7189838a71fbb475eb9947758e249",
-        "is_verified": false,
-        "line_number": 16,
-        "type": "Hex High Entropy String"
-      }
-    ],
-    "test/controllers/secure_controller_test.js": [
-      {
-        "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
-        "is_verified": false,
-        "line_number": 261,
-        "type": "Secret Keyword"
+        "line_number": 13
       }
     ],
     "test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js": [
       {
-        "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
-        "is_verified": false,
-        "line_number": 218,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js",
         "hashed_secret": "321f58f0cffa4caf8de5176503e82691f0f4f092",
         "is_verified": false,
-        "line_number": 237,
-        "type": "Base64 High Entropy String"
+        "line_number": 21
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js",
+        "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
+        "is_verified": false,
+        "line_number": 30
       }
     ],
     "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
+        "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
+        "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
+        "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
+        "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
+        "is_verified": false,
+        "line_number": 24
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 191,
-        "type": "Base64 High Entropy String"
+        "line_number": 46
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
+        "hashed_secret": "1ee4b74cf4b89c3cd9792a34a1fdfed2c8d4b71d",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
+        "hashed_secret": "29537aaf22996353c2fe981aaa72e960b2ed2d70",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
+        "hashed_secret": "6464ec4579ee376ccaa76867f536aa1061bc89bf",
+        "is_verified": false,
+        "line_number": 48
       }
     ],
-    "test/cypress/integration/web-payments/apple-pay.spec.js": [
+    "test/cypress/integration/card/payment.cy.test.js": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/card/payment.cy.test.js",
+        "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/card/payment.cy.test.js",
+        "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/card/payment.cy.test.js",
+        "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/card/payment.cy.test.js",
+        "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
+        "is_verified": false,
+        "line_number": 22
+      }
+    ],
+    "test/cypress/integration/web-payments/apple-pay.cy.test.js": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/web-payments/apple-pay.cy.test.js",
         "hashed_secret": "321f58f0cffa4caf8de5176503e82691f0f4f092",
         "is_verified": false,
-        "line_number": 23,
-        "type": "Base64 High Entropy String"
+        "line_number": 33
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "test/cypress/integration/web-payments/apple-pay.cy.test.js",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 32,
-        "type": "Hex High Entropy String"
+        "line_number": 42
       }
     ],
-    "test/fixtures/wallet_payment_fixtures.js": [
+    "test/cypress/integration/web-payments/google-pay.cy.test.js": [
       {
-        "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/web-payments/google-pay.cy.test.js",
+        "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
         "is_verified": false,
-        "line_number": 18,
-        "type": "Base64 High Entropy String"
+        "line_number": 30
       },
       {
-        "hashed_secret": "c272ed583c5dfbb2013e22812d200068997d5969",
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/web-payments/google-pay.cy.test.js",
+        "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
         "is_verified": false,
-        "line_number": 53,
-        "type": "Base64 High Entropy String"
+        "line_number": 30
       },
       {
-        "hashed_secret": "9c98d4fa9b3055dede39101f223aa53c2b830d95",
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/web-payments/google-pay.cy.test.js",
+        "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
         "is_verified": false,
-        "line_number": 55,
-        "type": "Base64 High Entropy String"
+        "line_number": 30
       },
       {
-        "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/web-payments/google-pay.cy.test.js",
+        "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
         "is_verified": false,
-        "line_number": 57,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
-        "is_verified": false,
-        "line_number": 58,
-        "type": "Base64 High Entropy String"
+        "line_number": 30
       }
     ],
-    "test/fixtures/worldpay_3ds_flex_fixtures.js": [
+    "test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js": [
       {
-        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js",
+        "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
         "is_verified": false,
-        "line_number": 5,
-        "type": "JSON Web Token"
+        "line_number": 48
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js",
+        "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js",
+        "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js",
+        "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
+        "is_verified": false,
+        "line_number": 48
       }
     ],
-    "test/middleware/decrypt_card_data_test.js": [
+    "test/middleware/decrypt-card-data.test.js": [
       {
+        "type": "Secret Keyword",
+        "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "063166341af85659c0b5226ef0987932d7380c27",
         "is_verified": false,
-        "line_number": 46,
-        "type": "Secret Keyword"
+        "line_number": 27
       },
       {
+        "type": "Private Key",
+        "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 127,
-        "type": "Private Key"
+        "line_number": 126
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "2600a4bbca0e75c7fd331333413040209e97bccf",
         "is_verified": false,
-        "line_number": 168,
-        "type": "Base64 High Entropy String"
+        "line_number": 167
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "528ecf3b9ac1e9846921e29b32d2c04354b6bfe7",
         "is_verified": false,
-        "line_number": 172,
-        "type": "Base64 High Entropy String"
+        "line_number": 171
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "5c03e44c937badf76e28e556d38a5768cf7bc7e7",
         "is_verified": false,
-        "line_number": 176,
-        "type": "Base64 High Entropy String"
+        "line_number": 175
       }
     ],
-    "test/unit/cookies_test.js": [
+    "test/unit/cookies.test.js": [
       {
+        "type": "Secret Keyword",
+        "filename": "test/unit/cookies.test.js",
         "hashed_secret": "ef5c25da3f68da43b33a9bc96de633756beb2d88",
         "is_verified": false,
-        "line_number": 92,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/utils/charge_validation_fields/postcode_validation_test.js": [
-      {
-        "hashed_secret": "1a7cf4db116c5bdf8a39a3d0ef2830fc1dc057e8",
-        "is_verified": false,
-        "line_number": 52,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "e6c3c68adfa0266e7df91a262835ef0d47097988",
-        "is_verified": false,
-        "line_number": 64,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "fa21be8bbadd5bf6aeac6751e98f719282f99bcc",
-        "is_verified": false,
-        "line_number": 69,
-        "type": "Hex High Entropy String"
+        "line_number": 35
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-13T15:14:42Z"
 }


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`
- Update the `.gitignore` file to allow tracking of a `.pre-commit.yaml`


