### PR TITLE
PP-8445 Use default billing address country on service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+PORT=3000
 CONNECTOR_HOST=http://localhost:9300
 ADMINUSERS_URL=http://localhost:9700
 CARDID_HOST=http://localhost:9900

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules/*
 *.log
 reports
 .env
+*.heapsnapshot
 
 # IntelliJ gubbins
 .idea

--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -22,6 +22,7 @@ class Service {
     this.gatewayAccountIds = serviceData.gateway_account_ids
     this.redirectToServiceImmediatelyOnTerminalState = serviceData.redirect_to_service_immediately_on_terminal_state
     this.collectBillingAddress = serviceData.collect_billing_address
+    this.defaultBillingAddressCountry = serviceData.default_billing_address_country
 
     this.customBranding =
       serviceData.custom_branding ? {

--- a/app/services/countries.js
+++ b/app/services/countries.js
@@ -11,7 +11,7 @@ exports.translateCountryISOtoName = countryISO => {
   if (country !== undefined) {
     return country[0]
   } else {
-    return countries.find(country => country[1].split(':')[1] === DEFAULT_COUNTRY_CODE)[0]
+    return false
   }
 }
 

--- a/app/services/normalise-charge.js
+++ b/app/services/normalise-charge.js
@@ -78,8 +78,8 @@ module.exports = (function () {
 
   const _normaliseConfirmationDetails = function (cardDetails) {
     cardDetails.cardNumber = '●●●●●●●●●●●●' + cardDetails.last_digits_card_number
-    delete cardDetails.last_digits_card_number
     const normalisedDetails = humps.camelizeKeys(cardDetails)
+    delete normalisedDetails.lastDigitsCardNumber
     if (cardDetails.billing_address) {
       normalisedDetails.billingAddress = _normaliseAddress(cardDetails.billing_address)
     }
@@ -123,17 +123,6 @@ module.exports = (function () {
       md: auth3dsData.md,
       worldpayChallengeJwt: auth3dsData.worldpayChallengeJwt
     }
-  }
-
-  // an empty string is equal to false in soft equality used by filter
-  const addressForView = function (body) {
-    return [body.addressLine1,
-      body.addressLine2,
-      body.addressCity,
-      body.addressPostcode,
-      countries.translateCountryISOtoName(body.addressCountry)].filter(function (str) {
-      return str
-    }).join(', ')
   }
 
   const creditCard = function (creditCardNo) {
@@ -193,7 +182,6 @@ module.exports = (function () {
     addressForApi,
     addressLines,
     whitespace,
-    addressForView,
     creditCard,
     expiryDate,
     apiPayload

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -377,13 +377,14 @@
                             {% endif %}
                           </label>
                           <select name="addressCountry" class="govuk-select" id="address-country" autocomplete="billing country-name">
-                            {% if not countryCode | length %}
-                              {% set countryCode = 'GB' %}
+                            {% if not countryCode | length and service and service.defaultBillingAddressCountry %}
+                              {% set countryCode = service.defaultBillingAddressCountry %}
+                            {% endif %}
+                            {% if not countryCode %}
+                              <option disabled value="" selected>Pick a country or territory</option>
                             {% endif %}
                             {% for country in countries %}
-                              <option
-                                value="{{ country[1].split(':')[1] }}"
-                                {% if country[1].split(':')[1] ===  countryCode %} selected="selected"{% endif %}>{{ country[0] }}</option>
+                              <option value="{{ country[1].split(':')[1] }}"{% if country[1].split(':')[1] ===  countryCode %} selected="selected"{% endif %}>{{ country[0] }}</option>
                             {% endfor %}
                           </select>
                         </div>

--- a/test/cypress/integration/card/billing-address-collection.cy.test.js
+++ b/test/cypress/integration/card/billing-address-collection.cy.test.js
@@ -16,23 +16,57 @@ const validPayment = {
 
 describe('Billing address collection', () => {
   describe('Billing address collection enabled for service', () => {
-    // get a random gateway account per test as service is cached against gateway account
-    const gatewayAccountId = lodash.random(999999999)
-    const serviceOpts = { collect_billing_address: true }
-    const chargeOpts = { moto: false }
-    const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(
-      tokenId, chargeId, 'en', gatewayAccountId, serviceOpts, {}, {}, chargeOpts)
+    describe('Default billing address country set', () => {
+      // get a random gateway account per test as service is cached against gateway account
+      const gatewayAccountId = lodash.random(999999999)
+      const serviceOpts = {
+        collect_billing_address: true,
+        default_billing_address_country: 'IE'
+      }
+      const chargeOpts = { moto: false }
+      const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(
+        tokenId, chargeId, 'en', gatewayAccountId, serviceOpts, {}, {}, chargeOpts)
 
-    it('Should show the billing address section', () => {
-      cy.task('setupStubs', createPaymentChargeStubs)
-      cy.visit(`/secure/${tokenId}`)
+      it('Should show the billing address section', () => {
+        cy.task('setupStubs', createPaymentChargeStubs)
+        cy.visit(`/secure/${tokenId}`)
 
-      cy.get('h2').contains('Billing address').should('exist')
-      cy.get('#address-country-select').should('exist')
-      cy.get('#address-line-1').should('exist')
-      cy.get('#address-line-2').should('exist')
-      cy.get('#address-city').should('exist')
-      cy.get('#address-postcode').should('exist')
+        cy.get('h2').contains('Billing address').should('exist')
+        cy.get('#address-country-select').should('exist')
+        cy.get('#address-line-1').should('exist')
+        cy.get('#address-line-2').should('exist')
+        cy.get('#address-city').should('exist')
+        cy.get('#address-postcode').should('exist')
+      })
+
+      it('Should populate default billing address from service', () => {
+        // The select is hidden when JavaScript is enabled, and the govuk-country-and-territory-autocomplete is displayed instead
+        // Doesn't seem possible to get the text displayed in the input using selectors, so just look at the select
+        cy.get('#address-country-select').should('have.value', 'IE')
+        cy.get('#address-country-select').find('option:selected').should('have.text', 'Ireland')
+      })
+    })
+
+    describe('Default billing address country not set', () => {
+      // get a random gateway account per test as service is cached against gateway account
+      const gatewayAccountId = lodash.random(999999999)
+      const serviceOpts = {
+        collect_billing_address: true,
+        default_billing_address_country: null
+      }
+      const chargeOpts = { moto: false }
+      const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(
+        tokenId, chargeId, 'en', gatewayAccountId, serviceOpts, {}, {}, chargeOpts)
+
+      it('Should have blank billing address country', () => {
+        cy.task('setupStubs', createPaymentChargeStubs)
+        cy.visit(`/secure/${tokenId}`)
+
+        // The select is hidden when JavaScript is enabled, and the govuk-country-and-territory-autocomplete is displayed instead
+        // Doesn't seem possible to get the text displayed in the input using selectors, so just look at the select
+        cy.get('#address-country-select').should('have.value', null)
+        cy.get('#address-country-select').find('option:selected').should('have.text', 'Pick a country or territory')
+      })
     })
   })
 

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -45,6 +45,10 @@ module.exports = {
       }
     }
 
+    if (data.default_billing_address_country !== null) {
+      data.default_billing_address_country = opts.default_billing_address_country === undefined ? 'GB' : opts.default_billing_address_country
+    }
+
     return data
   }
 }


### PR DESCRIPTION
If a value is set for the `default_billing_address_country` on the
service, use this as the pre-filled value for the country select.

If no value is set, leave the field blank. This is achieved by adding an
option with the attributes `disabled selected value=""` to the select.
When the select control is converted into the country picker using
javascript from the `govuk-country-and-territory-autocomplete`
npm module, the field will be blank. When javascript is disabled, the
select has the disabled option "Pick a country or territory" selected
by default.

Ended up doing this in the template rather than in normalise-charge.js,
but removed an unused method from normalise-charge.js and improved the
unit tests to make it more understandable and robust.