### PR TITLE
PP-8695: Remove Jenkins ECS deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,13 +93,12 @@ pipeline {
         }
       }
     }
-    stage('Deploy') {
+    stage('Check Pact Compatibility') {
       when {
         branch 'master'
       }
       steps {
         checkPactCompatibility("frontend", gitCommit(), "test")
-        deployEcs("frontend")
       }
     }
     stage('Card Smoke Test') {


### PR DESCRIPTION
## WHAT
Jenkins doesn't deploy to ECS now and we have now removed the old EC2 based services so the deploy step is no longer required

