### PR TITLE
PP-7216 update country list

### DIFF
--- a/app/data/countries-autocomplete-graph.json
+++ b/app/data/countries-autocomplete-graph.json
@@ -5482,6 +5482,23 @@
       "en-GB": "Burkina Fasoupper"
     }
   },
+  "nym:Burma": {
+    "edges": {
+      "from": [
+        "country:MM"
+      ]
+    },
+    "meta": {
+      "canonical": false,
+      "canonical-mask": 0,
+      "display-name": false,
+      "stable-name": false
+    },
+    "names": {
+      "cy": false,
+      "en-GB": "Burma"
+    }
+  },
   "nym:Byelarus": {
     "edges": {
       "from": [
@@ -11551,6 +11568,23 @@
       "en-GB": "Macedon"
     }
   },
+  "nym:Macedonia": {
+    "edges": {
+      "from": [
+        "country:MK"
+      ]
+    },
+    "meta": {
+      "canonical": false,
+      "canonical-mask": 0,
+      "display-name": false,
+      "stable-name": false
+    },
+    "names": {
+      "cy": false,
+      "en-GB": "Macedonia"
+    }
+  },
   "nym:Madagascar": {
     "edges": {
       "from": [
@@ -17465,6 +17499,23 @@
     "names": {
       "cy": false,
       "en-GB": "Swatini"
+    }
+  },
+  "nym:Swaziland": {
+    "edges": {
+      "from": [
+        "country:SZ"
+      ]
+    },
+    "meta": {
+      "canonical": false,
+      "canonical-mask": 0,
+      "display-name": false,
+      "stable-name": false
+    },
+    "names": {
+      "cy": false,
+      "en-GB": "Swaziland"
     }
   },
   "nym:Swiss Confederation": {

--- a/app/data/countries-autocomplete-graph.json
+++ b/app/data/countries-autocomplete-graph.json
@@ -1820,7 +1820,7 @@
     },
     "names": {
       "cy": false,
-      "en-GB": "Macedonia"
+      "en-GB": "North Macedonia"
     }
   },
   "country:ML": {
@@ -1852,7 +1852,7 @@
     },
     "names": {
       "cy": false,
-      "en-GB": "Burma"
+      "en-GB": "Myanmar (Burma)"
     }
   },
   "country:MN": {
@@ -2668,7 +2668,7 @@
     },
     "names": {
       "cy": false,
-      "en-GB": "Swaziland"
+      "en-GB": "Eswatini"
     }
   },
   "country:TD": {
@@ -10344,7 +10344,7 @@
       "en-GB": "Kingdom of Spain"
     }
   },
-  "nym:Kingdom of Swaziland": {
+  "nym:Kingdom of Eswatini": {
     "edges": {
       "from": [
         "country:SZ"
@@ -10358,7 +10358,7 @@
     },
     "names": {
       "cy": false,
-      "en-GB": "Kingdom of Swaziland"
+      "en-GB": "Kingdom of Eswatini"
     }
   },
   "nym:Kingdom of Sweden": {
@@ -14900,7 +14900,7 @@
       "en-GB": "Republic of Lithuanialietuva"
     }
   },
-  "nym:Republic of Macedonia": {
+  "nym:Republic of North Macedonia": {
     "edges": {
       "from": [
         "country:MK"
@@ -14914,7 +14914,7 @@
     },
     "names": {
       "cy": false,
-      "en-GB": "Republic of Macedonia"
+      "en-GB": "Republic of North Macedonia"
     }
   },
   "nym:Republic of Madagascar": {
@@ -18810,7 +18810,7 @@
       "en-GB": "The Kingdom of Spain"
     }
   },
-  "nym:The Kingdom of Swaziland": {
+  "nym:The Kingdom of Eswatini": {
     "edges": {
       "from": [
         "country:SZ"
@@ -18824,7 +18824,7 @@
     },
     "names": {
       "cy": false,
-      "en-GB": "The Kingdom of Swaziland"
+      "en-GB": "The Kingdom of Eswatini"
     }
   },
   "nym:The Kingdom of Sweden": {
@@ -19881,7 +19881,7 @@
       "en-GB": "The Republic of Lithuania"
     }
   },
-  "nym:The Republic of Macedonia": {
+  "nym:The Republic of North Macedonia": {
     "edges": {
       "from": [
         "country:MK"
@@ -19895,7 +19895,7 @@
     },
     "names": {
       "cy": false,
-      "en-GB": "The Republic of Macedonia"
+      "en-GB": "The Republic of North Macedonia"
     }
   },
   "nym:The Republic of Madagascar": {
@@ -21581,7 +21581,7 @@
       "en-GB": "Umbuso weSwatini"
     }
   },
-  "nym:Union of burma": {
+  "nym:Union of Myanmar": {
     "edges": {
       "from": [
         "country:MM"
@@ -21595,7 +21595,7 @@
     },
     "names": {
       "cy": false,
-      "en-GB": "Union of burma"
+      "en-GB": "Union of Myanmar"
     }
   },
   "nym:Union of the Comoros": {

--- a/app/data/countries.json
+++ b/app/data/countries.json
@@ -140,7 +140,7 @@
     "country:BF"
   ],
   [
-    "Burma",
+    "Myanmar (Burma)",
     "country:MM"
   ],
   [
@@ -516,7 +516,7 @@
     "territory:MO"
   ],
   [
-    "Macedonia",
+    "North Macedonia",
     "country:MK"
   ],
   [
@@ -848,7 +848,7 @@
     "territory:SJ"
   ],
   [
-    "Swaziland",
+    "Eswatini",
     "country:SZ"
   ],
   [

--- a/test/services/countries.test.js
+++ b/test/services/countries.test.js
@@ -9,5 +9,7 @@ describe('countries', function () {
 
   it('should translate country code to name', function () {
     expect(translateCountryISOtoName('GB')).to.eql('United Kingdom')
+    expect(translateCountryISOtoName('SZ')).to.eql('Eswatini')
+    
   })
 })


### PR DESCRIPTION
## WHAT
Updates country list based on diff against CSV from https://data.gov.uk/dataset/0b412b57-6934-4f28-b495-640cdc7e8f7f/foreign-commonwealth-and-development-office-geographical-names-index (I wrote a [little python script](https://gist.github.com/gidsg/84e15fb65fe9eea159324369b33f2870) to compare the CSV against our current JSON.)

**Question** should we add the old names as synonyms for the new ones in the autocomplete graph?

## HOW 
Updated country names should appear in country picker on payment page e.g. North Macedonia.
![Screenshot 2021-09-28 at 11 18 33](https://user-images.githubusercontent.com/1764158/135087186-844e118a-cb70-4854-921a-1419c453a874.png)


