### PR TITLE
PP-8716 Web performance - add hash to image assets in Nunjucks file

### DIFF
--- a/app/views/auth-waiting.njk
+++ b/app/views/auth-waiting.njk
@@ -34,7 +34,7 @@
     <h1 class="govuk-heading-l form-title">{{ __p("authorisation.checkingDetails") }}</h1>
     <p class="govuk-body-l lede">{{ __p("authorisation.checkingDetailsDescription") }}</p>
     <div id="spinner">
-      <img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/>
+      <img src="{{ getVersionedPath('/images/spinner.gif') }}" alt="{{ __p("authorisation.spinnerAltText") }}"/>
     </div>
   </div>
 </div>

--- a/app/views/capture-waiting.njk
+++ b/app/views/capture-waiting.njk
@@ -34,7 +34,7 @@
     <h1 class="govuk-heading-l form-title">{{ __p("authorisation.processing") }}</h1>
     <p class="govuk-body-l lede">{{ __p("authorisation.processingPayment") }}</p>
     <div id="spinner">
-      <img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/>
+      <img src="{{ getVersionedPath('/images/spinner.gif') }}" alt="{{ __p("authorisation.spinnerAltText") }}"/>
     </div>
   </div>
 </div>

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -123,7 +123,7 @@
                 <h2 class="govuk-heading-m">{{ __p("cardDetails.webPayments.payWithGooglePay") }}</h2>
 
                 {% set GooglePayButtonHTML %}
-                  <img class="google-pay-image" src="/images/google-pay-logo.svg" alt="Google Pay">
+                  <img class="google-pay-image" src="{{ getVersionedPath('/images/google-pay-logo.svg') }}" alt="Google Pay">
                 {% endset %}
 
                 <form class="govuk-!-width-three-quarters web-payments-container">
@@ -142,7 +142,7 @@
                 </form>
               </div>
             {% endif %}
-            <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
+            <div id="spinner" class="hidden"><img src="{{ getVersionedPath('/images/spinner.gif') }}" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
 
             <div id="card-details-wrap">
               {% if allowApplePay or allowGooglePay %}
@@ -207,7 +207,7 @@
                           data-credit="{{ currentAllowedCard.credit }}"
                           data-debit="{{ currentAllowedCard.debit }}"
                         >
-                          <img src="/images/transparent-accessibiliity.gif" alt="{{ currentAllowedCard.brand | replace("-", " ") | title }}" />
+                          <img src="{{ getVersionedPath('/images/transparent-accessibiliity.gif') }}" alt="{{ currentAllowedCard.brand | replace("-", " ") | title }}" />
                         </li>
                       {% endfor %}
                     {% endif %}
@@ -344,11 +344,11 @@
                   class="govuk-input govuk-input--width-3 cvc"
                   maxlength="4"
                   autocomplete="{{securityCodeAutoCompleteType}}"/>
-                  <img src="/images/security-code.png" class="generic-cvc" alt="{{ __p("cardDetails.cvcTip") }}"/>
+                  <img src="{{ getVersionedPath('/images/security-code.png') }}" class="generic-cvc" alt="{{ __p("cardDetails.cvcTip") }}"/>
                   <span class="either hidden">
                     {{ __p("commonConjunctions.or") }}
                   </span>
-                  <img src="/images/amex-security-code.png" class="amex-cvc hidden" alt="{{ __p("cardDetails.amexcvcTip") }}"/>
+                  <img src="{{ getVersionedPath('/images/amex-security-code.png') }}" class="amex-cvc hidden" alt="{{ __p("cardDetails.amexcvcTip") }}"/>
                 </div>
                 {% if collectBillingAddress %}
                   <div class="govuk-!-width-three-quarters govuk-!-padding-top-4 govuk-!-margin-top-8 pay-!-border-top">

--- a/app/views/errors/incorrect-state/capture-waiting.njk
+++ b/app/views/errors/incorrect-state/capture-waiting.njk
@@ -34,7 +34,7 @@
     <h1 class="govuk-heading-l">{{ __p("authorisation.processing") }}</h1>
     <p class="govuk-body-l lede">{{ __p("authorisation.processingPayment") }}</p>
     <div id="spinner">
-      <img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/>
+      <img src="{{ getVersionedPath('/images/spinner.gif') }}" alt="{{ __p("authorisation.spinnerAltText") }}"/>
     </div>
   </div>
 </div>

--- a/app/views/includes/custom.njk
+++ b/app/views/includes/custom.njk
@@ -3,7 +3,7 @@
     <div class="govuk-header__logo">
       <span class="govuk-header__link--homepage">
         <span class="govuk-header__logotype">
-          <img src="{{ service.customBranding.imageUrl }}" class="govuk-header__logotype-crown custom-branding-image" alt="">
+          <img src="{{getVersionedPath('service.customBranding.imageUrl') }}" class="govuk-header__logotype-crown custom-branding-image" alt="">
         </span>
       </span>
     </div>

--- a/server.js
+++ b/server.js
@@ -52,7 +52,10 @@ function initialiseGlobalMiddleware (app) {
       logger.info(message)
     }
   }
-  app.set('settings', { getVersionedPath: staticify.getVersionedPath })
+
+  app.locals.getVersionedPath = function (path) {
+    return NODE_ENV === 'production' ? staticify.getVersionedPath(path) : path
+  }
 
   app.use(/\/((?!images|public|stylesheets|javascripts).)*/, loggingMiddleware())
   app.use(favicon(path.join(__dirname, '/node_modules/govuk-frontend/govuk/assets/images', 'favicon.ico')))


### PR DESCRIPTION
- Add the 'staticify.getVersionedPath' function to app.locals
  - This makes the function available in Nunjuks templates.
  - For production - it will return hashed versions of image assets
    - E.g. Change `image.png` to `image.d5e5c73.png`
- Update Nunjuks templates
  - Update image tags to use `getVersionedPath`
    - E.g. `<img src="test.gif" />` to `<img src="{{ getVersionedPath('test.gif') }}" />`

## WHAT
- Add the `staticify.getVersionedPath` to  Express `app.locals`.  So it is available in Nunjucks templates.
Use the Staticify library to do the following:
- For Production - generate Hashed image paths using the `staticify.getVersionedPath`

## HOW 
- Go to the Charge pages and check the inline images - you should see the assets appearing Hashed.
![image](https://user-images.githubusercontent.com/59831992/136784296-b21b0173-435a-4843-b21b-583acddb7be1.png)



