### PR TITLE
PP-8858 Don't log error when apps return 500

### DIFF
--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -40,7 +40,7 @@ function _getAdminUsers (url, description, findOptions, loggingFields = {}, call
       if (SUCCESS_CODES.includes(response.statusCode)) {
         return new Service(response.body)
       } else {
-        if (response.statusCode > 499 && response.statusCode < 600) {
+        if (response.statusCode > 500 && response.statusCode < 600) {
           logger.error(`Error communicating with ${url}`, {
             ...loggingFields,
             service: 'adminusers',

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -70,7 +70,7 @@ function _putConnector (url, payload, description, loggingFields = {}, callingFu
     .then(response => {
       logger.info('PUT to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
       incrementStatusCodeCounter(callingFunctionName, response.statusCode)
-      if (response.statusCode > 499 && response.statusCode < 600) {
+      if (response.statusCode > 500 && response.statusCode < 600) {
         logger.error(`Error communicating with ${url}`, {
           ...loggingFields,
           service: 'connector',
@@ -110,7 +110,7 @@ function _postConnector (url, payload, description, loggingFields = {}, callingF
   ).then(response => {
     logger.info('POST to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
     incrementStatusCodeCounter(callingFunctionName, response.statusCode)
-    if (response.statusCode > 499 && response.statusCode < 600) {
+    if (response.statusCode > 500 && response.statusCode < 600) {
       logger.error(`Error communicating with ${url}`, {
         ...loggingFields,
         service: 'connector',
@@ -150,7 +150,7 @@ function _patchConnector (url, payload, description, loggingFields = {}, calling
   ).then(response => {
     logger.info('PATCH to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
     incrementStatusCodeCounter(callingFunctionName, response.statusCode)
-    if (response.statusCode > 499 && response.statusCode < 600) {
+    if (response.statusCode > 500 && response.statusCode < 600) {
       logger.error(`Error communicating with ${url}`, {
         ...loggingFields,
         service: 'connector',


### PR DESCRIPTION
500 indicates an internal error occurred. In this case, the app the
internal error occurred in should decide whether to log an error so that
it gets reported to Sentry. Currently, this causes a lot of noise in
Sentry.

Continue to log an error if the status code is >500 as this would
indicate that there has been some problem with communicating with the
app and likely needs investigating.