### PR TITLE
PP-9099 Bump product pages to 4.9.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5408,7 +5408,7 @@
         "listr": "0.12.0",
         "lodash": "4.17.11",
         "log-symbols": "2.2.0",
-        "minimist": "1.2.5",
+        "minimist": "1.2.0",
         "moment": "2.22.2",
         "ramda": "0.24.1",
         "request": "2.87.0",
@@ -5905,7 +5905,7 @@
       "requires": {
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
-        "minimist": "^1.2.5"
+        "minimist": "^1.1.1"
       }
     },
     "dezalgo": {
@@ -7539,7 +7539,7 @@
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
-            "minimist": "1.2.5"
+            "minimist": "0.0.8"
           }
         },
         "ms": {
@@ -8317,7 +8317,7 @@
       "integrity": "sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.5"
+        "minimist": "1.1.x"
       },
       "dependencies": {
         "minimist": {
@@ -14527,8 +14527,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.9.15/pay-product-page-4.9.15.tgz",
-      "integrity": "sha512-j710ja1e3Ol3xAdNmYpkruDtLRYsOOFXZHvu3Yl6pv3TgpieBHsMhQmpA1/1iemMoMuTaz+VGa5CzaKd0FbSSg==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.9.16/pay-product-page-4.9.16.tgz",
+      "integrity": "sha512-JbS6La/NCfRUnu6yEX75F6wXkPJWchAX8GhSBP8NP0G6qLEnhhlqG0wwmezTK0Ltg2e2xX8toBjw47dBGjF2QQ==",
       "dev": true
     },
     "pbkdf2": {
@@ -17506,7 +17506,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.1.0"
       }
     },
     "sumchecker": {

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "node-sass": "7.0.1",
     "nodemon": "^2.0.15",
     "nyc": "15.1.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.9.15/pay-product-page-4.9.15.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.9.16/pay-product-page-4.9.16.tgz",
     "proxyquire": "~2.1.3",
     "sass-lint": "^1.13.1",
     "sinon": "12.0.x",


### PR DESCRIPTION
    - Made sure I used the version of Node as specified in Package.json - 12.22.7
      - This means the package-lock.json had to be updated for some minor dependencies
        that are specific for this version of Node.



