### PR TITLE
PP-9099 revert minimist to a safe version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5380,7 +5380,7 @@
         "listr": "0.12.0",
         "lodash": "4.17.11",
         "log-symbols": "2.2.0",
-        "minimist": "1.2.0",
+        "minimist": "1.2.5",
         "moment": "2.22.2",
         "ramda": "0.24.1",
         "request": "2.87.0",
@@ -5877,7 +5877,7 @@
       "requires": {
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
-        "minimist": "^1.1.1"
+        "minimist": "^1.2.5"
       }
     },
     "dezalgo": {
@@ -7511,7 +7511,7 @@
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "1.2.5"
           }
         },
         "ms": {
@@ -8289,7 +8289,7 @@
       "integrity": "sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=",
       "dev": true,
       "requires": {
-        "minimist": "1.1.x"
+        "minimist": "1.2.5"
       },
       "dependencies": {
         "minimist": {
@@ -17478,7 +17478,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "^1.1.0"
+        "minimist": "^1.2.5"
       }
     },
     "sumchecker": {


### PR DESCRIPTION
## WHAT
- minimist must be on version 1.2.5 or above due to vulnerability
