### PR TITLE
ZD-4848316 Update Pay product page to version 4.9.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14491,8 +14491,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.9.17/pay-product-page-4.9.17.tgz",
-      "integrity": "sha512-1eOEARR/S8d2dF3CTliFPaxMC88/S025a5uxcbWMBd83b4cF6M2/sWYriK3oUskuNVfsPoWi6Wol0OohN9O43A==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.9.19/pay-product-page-4.9.19.tgz",
+      "integrity": "sha512-Gq+OcbibWLWM4EHB5y10VfDwVYYai5bK/4rEoCkj4UVUm3NbpX39MoKvNq0i5+KTSlk02J+zG3UJukHN0SUpfg==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "node-sass": "7.0.1",
     "nodemon": "^2.0.15",
     "nyc": "15.1.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.9.17/pay-product-page-4.9.17.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.9.19/pay-product-page-4.9.19.tgz",
     "proxyquire": "~2.1.3",
     "sass-lint": "^1.13.1",
     "sinon": "12.0.x",


### PR DESCRIPTION
https://www.payments.service.gov.uk/payment-service-provider/

Remove outdated text about PSP reprocurement, which mentions June 2021 as if it’s in the future.