### PR TITLE
PP-9148 Cache Cypress with version in key

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,11 +35,14 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
+      - name: Parse Cypress version
+        id: parse-cypress-version
+        run: echo "::set-output name=CYPRESS_VERSION::$(jq -r '.devDependencies.cypress' package.json)"
       - name: Cache Cypress
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
         with:
           path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress
+          key: ${{ runner.os }}-cypress-${{ steps.parse-cypress-version.outputs.CYPRESS_VERSION }}
       - name: Install dependencies
         run: npm ci
       - name: Compile
@@ -90,11 +93,14 @@ jobs:
             govuk_modules
             public
           key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Parse Cypress version
+        id: parse-cypress-version
+        run: echo "::set-output name=CYPRESS_VERSION::$(jq -r '.devDependencies.cypress' package.json)"
       - name: Cache Cypress
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
         with:
           path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress
+          key: ${{ runner.os }}-cypress-${{ steps.parse-cypress-version.outputs.CYPRESS_VERSION }}
       - name: Run cypress tests
         run: |
           npm run cypress:server > /dev/null 2>&1 &


### PR DESCRIPTION
In our workflow for running tests on PRs, we cache Cypress so that it doesn't need to be downloaded and installed for each test run, as this takes a number of minutes. This cache is persisted between action runs.

We were caching with the key `Linux-cypress` not taking into account versioning. This means that if we tried to update our Cypress version, we would probably end up with multiple Cypress versions in the same cache due to restoring the existing version from the cache and then installing the new version when we run `npm install`.

To ensure that we only cache and restore the required version, retrieve the Cypress version number from the package.json file and append this to the cache key.