### PR TITLE
PP-9148 Fix "promisifying" request for Cypress setup

### DIFF
--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -29,7 +29,10 @@ module.exports = (on, config) => {
     },
 
     clearStubs () {
-      return requestPromise.delete(stubServerURL)
+      return requestPromise({
+        method: 'DELETE',
+        url: stubServerURL
+      })
     }
   })
   return config


### PR DESCRIPTION
Before each Cypress test runs, we make a request to Mountebank to DELETE
the existing imposter, so a new imposter can be set up for the test.

On Jenkins we are seeing calls to DELETE the imposter happening after
POST requests to setup a new imposter for the test on occasion. When
this happens, the POST request fails as there is an existing imposter.

If looks like the task to clear the stubs isn't returning a promise, as
we are calling the `delete` method on the `request` library directly
without wrapping it in a promise. If we use the default method of
`request`, as we do for POSTing the imposter, this function is wrapped
in a promise using `util.promisify(request)`.


