### PR TITLE
PP-9153: Switch to new Mocha configuration format and set explicit longer timeout

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    reporter: 'spec',
+    require: ['./test/test-helpers/test-env.js', './test/test-helpers/supress-logs.js'],
+    exit: true,
+    timeout: 5000
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,0 @@
---reporter spec
---require ./test/test-helpers/test-env.js
---require ./test/test-helpers/supress-logs.js
---exit


### PR DESCRIPTION
## WHAT
Fixes the the issues of PACT tests failing when run locally by setting a longer timeout in Mocha configuration
and switches to new Mocha configuration format which fixes the deprecation warning:
```
 DeprecationWarning: Configuration via mocha.opts is DEPRECATED and will be removed from a future version of Mocha. Use RC files or package.json instead.
```

## HOW 
All tests should pass when run locally e.g. `npm test -- --forbid-only --forbid-pending`
Above deprecation warning should not appear

