### PR TITLE
PP-9314: add accept-language header to payload

### DIFF
--- a/app/services/normalise-charge.js
+++ b/app/services/normalise-charge.js
@@ -148,7 +148,8 @@ module.exports = (function () {
       address: addressForApi(req.body),
       accept_header: req.header('accept'),
       user_agent_header: req.header('user-agent'),
-      ip_address: userIpAddress(req)
+      ip_address: userIpAddress(req),
+      accept_language_header: req.header('accept-language')
     }
     if (req.body.worldpay3dsFlexDdcResult) {
       payload.worldpay_3ds_flex_ddc_result = req.body.worldpay3dsFlexDdcResult

--- a/test/services/normalise-charge.test.js
+++ b/test/services/normalise-charge.test.js
@@ -7,4 +7,37 @@ describe('normalise', function () {
     expect(normalise.expiryDate('01', '17')).to.eql('01/17')
     expect(normalise.expiryDate('01', '2017')).to.eql('01/17')
   })
+
+  it('includes headers in payload', function () {
+    const headers =    {
+      'accept': 'application/json',
+      'x-request-id': 'unique-id',
+      'x-forwarded-for': '127.0.0.1',
+      'user-agent': 'Mozilla/5.0',
+      'accept-language': 'fr;q=0.9, fr-CH;q=1.0, en;q=0.8, de;q=0.7, *;q=0.5'
+    }
+    const card = '4242424242424242'
+    
+    const payload =   { body: {
+      "chargeId": "42mdrsshtsk4chpeoifhlgf4lk",
+      "cardNo": card,
+      "expiryMonth": "01",
+      "expiryYear": "20",
+      "cardholderName": "Joe Bloggs",
+      "cvc": "111",
+      "addressCountry": "GB",
+      "addressLine1": "1 Horse Guards",
+      "addressCity": "London",
+      "addressPostcode": "E1 8QS" },
+      header: headerName => {
+        return headers[headerName]
+      },
+      headers: headers
+    }
+
+    expect(normalise.apiPayload(payload, card).accept_language_header).to.eql('fr;q=0.9, fr-CH;q=1.0, en;q=0.8, de;q=0.7, *;q=0.5');
+    expect(normalise.apiPayload(payload, card).accept_header).to.eql('application/json');
+    expect(normalise.apiPayload(payload, card).user_agent_header).to.eql('Mozilla/5.0');
+  })
+
 })


### PR DESCRIPTION
## WHAT
Add `accept-language` header to payload, as this will be used by Connector as part of 3DS flow.

## HOW 
Couldn't find a good place to add a test for this, if you can think of one let me know!

