### PR TITLE
PP-9375: switch to snyk hosted package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@babel/preset-env": "^7.16.11",
         "@pact-foundation/pact": "^9.17.2",
         "@pact-foundation/pact-node": "^10.17.1",
+        "@snyk/protect": "^1.865.x",
         "browserify": "17.0.x",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
@@ -88,7 +89,6 @@
         "proxyquire": "~2.1.3",
         "sass-lint": "^1.13.1",
         "sinon": "13.0.x",
-        "snyk": "^1.865.x",
         "standard": "^14.3.x",
         "superagent": "^7.1.1",
         "supertest": "^6.2.2"
@@ -2728,6 +2728,18 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "node_modules/@snyk/protect": {
+      "version": "1.865.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.865.0.tgz",
+      "integrity": "sha512-WacS+RsOR9IdyjsJI+H9JouU0OPr+j5xTR9GOqH/Hc0/O0+RhJqjdGv08fgmxm8YLSOq9obV2EDonPUc/mljNQ==",
+      "dev": true,
+      "bin": {
+        "snyk-protect": "bin/snyk-protect"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -18203,18 +18215,6 @@
         "sentence-case": "^1.1.2"
       }
     },
-    "node_modules/snyk": {
-      "version": "1.865.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.865.0.tgz",
-      "integrity": "sha512-Cgl23n7rBSZL4O8h31UKeDvZJdxuAVg5KId/zupE07H1JXR4IjBMU9J1MYyJVki08tt9MGFWPeUq4ppML1G5XQ==",
-      "dev": true,
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/socks": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
@@ -23311,6 +23311,12 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "@snyk/protect": {
+      "version": "1.865.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.865.0.tgz",
+      "integrity": "sha512-WacS+RsOR9IdyjsJI+H9JouU0OPr+j5xTR9GOqH/Hc0/O0+RhJqjdGv08fgmxm8YLSOq9obV2EDonPUc/mljNQ==",
       "dev": true
     },
     "@szmarczak/http-timer": {
@@ -35582,12 +35588,6 @@
       "requires": {
         "sentence-case": "^1.1.2"
       }
-    },
-    "snyk": {
-      "version": "1.865.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.865.0.tgz",
-      "integrity": "sha512-Cgl23n7rBSZL4O8h31UKeDvZJdxuAVg5KId/zupE07H1JXR4IjBMU9J1MYyJVki08tt9MGFWPeUq4ppML1G5XQ==",
-      "dev": true
     },
     "socks": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cypress:server": "mb | node -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
     "cypress:test": "cypress run",
     "cypress:test-headed": "cypress open",
-    "snyk-protect": "snyk protect",
+    "snyk-protect": "snyk-protect",
     "publish-pacts": "./bin/publish-pacts.js"
   },
   "husky": {
@@ -117,6 +117,7 @@
     "@babel/preset-env": "^7.16.11",
     "@pact-foundation/pact": "^9.17.2",
     "@pact-foundation/pact-node": "^10.17.1",
+    "@snyk/protect": "^1.865.x",
     "browserify": "17.0.x",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
@@ -152,7 +153,6 @@
     "proxyquire": "~2.1.3",
     "sass-lint": "^1.13.1",
     "sinon": "13.0.x",
-    "snyk": "^1.865.x",
     "standard": "^14.3.x",
     "superagent": "^7.1.1",
     "supertest": "^6.2.2"


### PR DESCRIPTION
## WHAT
Switch to snyk hosted package

Fixes Deprecation warning
```
⚠ WARNING: Starting from 31 March 2022, the protect command will be removed.
Please use the @snyk/protect package instead.
For more info: https://snyk.co/ueln7
```

## HOW 
build should still pass


