### PR TITLE
BAU Replace version parsing with shared output

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,20 +8,29 @@ permissions:
   contents: read
 
 jobs:
-  install-and-compile:
+  version:
     runs-on: ubuntu-18.04
-    name: Install and compile
-
+    name: Parse versions
+    outputs: 
+      node-version: ${{ steps.parse-node-version.outputs.nvmrc }}
     steps:
       - name: Checkout
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - name: Parse Node version
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: parse-node-version
+        run: echo "::set-output name=nvmrc::$(cat .nvmrc)"
+  install-and-compile:
+    runs-on: ubuntu-18.04
+    name: Install and compile
+    needs: version
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
       - name: Setup
         uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
         with:
-          node-version: "${{ steps.parse-node-version.outputs.NVMRC }}"
+          node-version: ${{ needs.version.outputs.node-version }}
       - name: Cache build directories
         uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
         with:
@@ -54,18 +63,15 @@ jobs:
   unit-tests:
     runs-on: ubuntu-18.04
     name: Unit tests
-    needs: install-and-compile
+    needs: [version, install-and-compile]
 
     steps:
       - name: Checkout
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
-      - name: Parse Node version
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-        id: parse-node-version
       - name: Setup
         uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
         with:
-          node-version: "${{ steps.parse-node-version.outputs.NVMRC }}"
+          node-version: ${{ needs.version.outputs.node-version }}
       - name: Cache build directories
         uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
         with:
@@ -85,18 +91,15 @@ jobs:
   cypress-tests:
     runs-on: ubuntu-18.04
     name: Cypress tests
-    needs: install-and-compile
+    needs: [version, install-and-compile]
 
     steps:
       - name: Checkout
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
-      - name: Parse Node version
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-        id: parse-node-version
       - name: Setup
         uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
         with:
-          node-version: "${{ steps.parse-node-version.outputs.NVMRC }}"
+          node-version: ${{ needs.version.outputs.node-version }}
       - name: Cache build directories
         uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
         with:


### PR DESCRIPTION
Make use of the `outputs` and `needs` links between jobs to share the
Node version parsed from the nvmrc file.


