### PR TITLE
PP-9148 override minimist to 1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "mailcheck": "^1.1.1",
         "memory-cache": "^0.2.0",
         "metrics": "0.1.21",
-        "minimist": "^1.2.5",
+        "minimist": "1.2.5",
         "moment-timezone": "^0.5.34",
         "morgan": "1.10.x",
         "nunjucks": "^3.2.3",
@@ -59,7 +59,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-string": "^1.4.0",
         "cheerio": "^1.0.0-rc.10",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "5.0.0",
         "dotenv": "^16.0.0",
         "envfile": "^5.2.0",
@@ -25793,7 +25793,7 @@
         "listr": "^0.14.3",
         "lodash": "^4.17.19",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "1.2.5",
         "moment": "^2.27.0",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.3.0",
@@ -27431,7 +27431,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.5"
           }
         },
         "ms": {
@@ -29879,7 +29879,7 @@
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "1.2.5"
       }
     },
     "jsonfile": {
@@ -34951,7 +34951,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.5"
           }
         },
         "ms": {
@@ -35949,7 +35949,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.5"
           }
         },
         "ms": {
@@ -36278,7 +36278,7 @@
       "requires": {
         "deglob": "^4.0.1",
         "get-stdin": "^7.0.0",
-        "minimist": "^1.2.5",
+        "minimist": "1.2.5",
         "pkg-conf": "^3.1.0"
       },
       "dependencies": {
@@ -36556,7 +36556,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "^1.1.0"
+        "minimist": "1.2.5"
       }
     },
     "sumchecker": {
@@ -37838,7 +37838,7 @@
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "1.2.5"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
       "locales/*"
     ]
   },
+  "overrides": {
+    "minimist": "1.2.5"
+  },
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
@@ -95,7 +98,7 @@
     "mailcheck": "^1.1.1",
     "memory-cache": "^0.2.0",
     "metrics": "0.1.21",
-    "minimist": "^1.2.5",
+    "minimist": "1.2.5",
     "moment-timezone": "^0.5.34",
     "morgan": "1.10.x",
     "nunjucks": "^3.2.3",


### PR DESCRIPTION
## WHAT
Override `minimist` to `1.2.5` to prevent security warnings