### PR TITLE
PP-9333 Cypress coverage for setup agreements disclaimer

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -533,14 +533,14 @@
             })
           }}
                 {% endif %}
-                  {% if savePaymentInstrumentToAgreement and agreementId  and agreementDescription %}
-                   <div class="govuk-form-group">
+                  {% if savePaymentInstrumentToAgreement and agreementDescription %}
+                  <div id="agreement-setup-disclaimer" class="govuk-form-group">
                     <div class="govuk-inset-text">
-                     <p class="govuk-body">Your payment details will be saved for:</p>
-                       <p class="govuk-body">{{ agreementDescription }}</p>
-                     </div>
-                   </div>
-                   {% endif %}
+                      <p class="govuk-body">Your payment details will be saved for:</p>
+                      <p class="govuk-body">{{ agreementDescription }}</p>
+                    </div>
+                  </div>
+                  {% endif %}
                 <div>
                   {% if typos %}
                     {{

--- a/test/cypress/utils/card-payment-stubs.js
+++ b/test/cypress/utils/card-payment-stubs.js
@@ -38,9 +38,10 @@ function confirmPaymentDetailsStubs (chargeId, validPayment = {}, gatewayAccount
   ]
 }
 
-function checkCardDetailsStubs (chargeId, gatewayAccountId = 42) {
+function checkCardDetailsStubs (chargeId, gatewayAccountId = 42, additionalChargeOpts = {}) {
   return [
     chargeStubs.connectorGetChargeDetails({
+      ...additionalChargeOpts,
       chargeId,
       gatewayAccountId,
       status: 'ENTERING CARD DETAILS',

--- a/test/fixtures/payment.fixtures.js
+++ b/test/fixtures/payment.fixtures.js
@@ -202,6 +202,17 @@ const buildChargeDetails = function buildChargeDetails (opts) {
     data.auth_3ds_data = buildAuth3dsDetails(opts.auth3dsData)
   }
 
+  if (opts.agreement) {
+    const agreementId = 'a-valid-agreement-id'
+    data.agreement_id = opts.agreement.agreement_id || agreementId
+    data.agreement = {
+      agreement_id: opts.agreement.agreement_id || agreementId,
+      description: opts.agreement.description || 'a valid description',
+      reference: opts.agreement.reference || 'a-valid-reference'
+    }
+    data.save_payment_instrument_to_agreement = true
+  }
+
   return data
 }
 
@@ -277,6 +288,12 @@ const fixtures = {
         status: opts.status || 'CREATED',
         version: 1,
         walletType: null,
+        agreement_id: 'some-agreement-id',
+        agreement: {
+          description: 'A valid description',
+          reference: 'A valid reference'
+        },
+        save_payment_instrument_to_agreement: true,
         moto: opts.moto || false,
         events: [{
           gatewayEventDate: null,


### PR DESCRIPTION
Include agreements in charge response stub builder.

Assert that normal payment flows will not include the agreements setup
snippet.

Assert that payment flows with the appropriately flagged save payment
instrument to agreement properties will correctly show the agreements
human readable identifier.