### PR TITLE
PP-9289 Country select - update autocomplete attribute

### DIFF
--- a/app/assets/javascripts/browsered/helpers.js
+++ b/app/assets/javascripts/browsered/helpers.js
@@ -14,8 +14,7 @@ const initialiseAddressCountryAutocomplete = () => {
       displayMenu: 'overlay'
     })
 
-    var noOpAutocompleteIdentifier = Math.random().toString(36).substring(2, 15)
-    document.getElementById('address-country').setAttribute('autocomplete', noOpAutocompleteIdentifier)
+    document.getElementById('address-country').setAttribute('autocomplete', 'country-disabled-autocomplete')
   }
 
   autocompleteScript.setAttribute('type', 'text/javascript')


### PR DESCRIPTION
- For the `Country` select-  autocomplete attribute
  - Replace it from a random number to `country-disabled-autocomplete`
  - This is so that it is more descriptive.
  - This is a workaround for the Chrome bug which does not respect
    `autocomplete=off`


