### PR TITLE
BAU Fix state enforcer logging

### DIFF
--- a/app/middleware/state-enforcer.js
+++ b/app/middleware/state-enforcer.js
@@ -13,12 +13,12 @@ const paths = require('../paths')
 const withAnalyticsError = require('../utils/analytics').withAnalyticsError
 
 module.exports = (req, res, next) => {
-  const correctStates = stateService.resolveStates(req.actionName)
+  let correctStates = stateService.resolveStates(req.actionName)
   const currentState = req.chargeData.status
 
   const paymentProvider = req.chargeData.payment_provider
   if (paymentProvider === 'stripe' && currentState === State.AUTH_3DS_READY) {
-    correctStates.push(State.AUTH_3DS_READY)
+    correctStates = correctStates.concat([State.AUTH_3DS_READY])
   }
   if (!correctStates.includes(currentState)) {
     logger.info(`State enforcer status doesn't match: current charge state from \


### PR DESCRIPTION
If the payment provider is Stripe, it seems we want to allow any page to load if the charge status is AUTHORISATION 3DS READY.

The code to do this was permanently pushing the AUTHORISATION 3DS READY state to the shared array of allowed states in `state.service.js`, so the array was growing increasingly larger. This resulted in strange behaviour such as including an array with `AUTHORISATION 3DS READY` repeated hundreds of times in the "State enforcer status doesn't match" log line.

This could have also resulted in allowing the AUTHORISATION 3DS READY state on any page for charges that are not Stripe, even though this was not the intention of the code. It's unclear whether this would have had any negative consequences.

Fix this to make a copy of the array, rather than adding to the shared array.


