### PR TITLE
PP-9403 Log number of payments in session

### DIFF
--- a/app/utils/session.js
+++ b/app/utils/session.js
@@ -31,7 +31,7 @@ const validateSessionCookie = function validateSessionCookie (req) {
     return false
   } else if (!cookie.getSessionVariable(req, 'ch_' + chargeId)) {
     logger.info('ChargeId was not found on the session', {
-      ...getLoggingFields,
+      ...getLoggingFields(req),
       referrer: req.get('Referrer'),
       url: req.originalUrl,
       method: req.method,
@@ -39,6 +39,10 @@ const validateSessionCookie = function validateSessionCookie (req) {
     })
     return false
   }
+  logger.info('ChargeId found on session', {
+    ...getLoggingFields(req),
+    number_of_payments_on_cookie: cookie.getSessionVariableNames(req).length
+  })
   return true
 }
 


### PR DESCRIPTION
In order to determine how many payments are in progress at a time for different users, log the number of payments in the session cookie every time a payment is retrieved from it.


