### PR TITLE
PP-9846 Update agreement disclaimer style to match page

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -468,8 +468,8 @@
                     </fieldset>
                   </div>
                 {% endif %}
-                {% if (gatewayAccount.emailCollectionMode === 'MANDATORY')
-                  or(gatewayAccount.emailCollectionMode === 'OPTIONAL') %}
+                {% set shouldShowEmail = (gatewayAccount.emailCollectionMode === 'MANDATORY') or (gatewayAccount.emailCollectionMode === 'OPTIONAL') %}
+                {% if shouldShowEmail %}
                   <div class="govuk-!-width-three-quarters email-container govuk-!-padding-top-4 govuk-!-margin-top-8 pay-!-border-top">
                     <fieldset class="govuk-fieldset" aria-describedby="email-hint">
                       <div>
@@ -534,10 +534,10 @@
           }}
                 {% endif %}
                   {% if savePaymentInstrumentToAgreement and agreementDescription %}
-                  <div id="agreement-setup-disclaimer" class="govuk-form-group">
+                  <div id="agreement-setup-disclaimer" class="govuk-form-group govuk-!-width-three-quarters {% if shouldShowEmail %}govuk-!-margin-top-6{% else %}govuk-!-margin-top-8{% endif %} pay-!-border-top"">
                     <div class="govuk-inset-text">
-                      <p class="govuk-body">Your payment details will be saved for:</p>
-                      <p class="govuk-body">{{ agreementDescription }}</p>
+                      <p class="govuk-hint govuk-!-margin-bottom-0">Your payment details will be saved for:</p>
+                      <p class="govuk-body-l">{{ agreementDescription }}</p>
                     </div>
                   </div>
                   {% endif %}


### PR DESCRIPTION
Follow components already set on the payment page to make this
disclaimer fit in with the flow of the page.

Add a container border to separate it from entering the above details.

![localhost_9000_card_details_bme9eobtfsaup9175chor1hv8e](https://user-images.githubusercontent.com/2844572/181519431-13644efa-09c4-4b18-a0fe-d24534924d29.png)

![localhost_9000_card_details_bme9eobtfsaup9175chor1hv8e(Pixel 5)](https://user-images.githubusercontent.com/2844572/181519426-46c4c300-6242-4a02-8e15-7c3abd0e42a1.png)

