### PR TITLE
PP-10059 DVLA Accessibility - stop overwriting labels with error messages

### DIFF
--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -237,14 +237,20 @@ var init = function () {
   var replaceLabel = function (validation, formGroup) {
     var label = formGroup.querySelectorAll('[data-label-replace]')[0]
     if (label.length === 0) return
+
+    var  errorElement = label.parentNode.parentNode.querySelector('.govuk-error-message') 
+
     if (validation) {
-      label.textContent = validation
-      label.setAttribute('role', 'alert')
-      label.classList.add('govuk-error-message')
+      if (errorElement){ 
+        errorElement.parentNode.removeChild(errorElement)
+      }
+
+      var errorElementHtml = '<p class="govuk-error-message" role="alert">' + validation + '</p>'
+      label.parentNode.insertAdjacentHTML("afterend", errorElementHtml)
     } else {
-      label.textContent = label.getAttribute('data-original-label')
-      label.setAttribute('role', '')
-      label.classList.remove('govuk-error-message')
+      if (errorElement){
+        errorElement.parentNode.removeChild(errorElement)
+      }
     }
   }
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -171,12 +171,13 @@
                         data-original-label="{{ __p("cardDetails.cardNo") }}">
                       {{ __p("cardDetails.cardNo") }}
                     </span>
-                    {% if highlightErrorFields.cardNo %}
-                      <p class="govuk-error-message" id="error-card-no">
-                        {{ highlightErrorFields.cardNo }}
-                      </p>
-                    {% endif %}
                   </label>
+
+                  {% if highlightErrorFields.cardNo %}
+                    <p class="govuk-error-message" id="error-card-no">
+                      {{ highlightErrorFields.cardNo }}
+                    </p>
+                  {% endif %}
 
                   {% if moto and gatewayAccount.motoMaskCardNumberInput %}
                     {% set cardNumberInputType = 'password' %}
@@ -186,7 +187,7 @@
                     {% set cardNumberAutoCompleteType = 'cc-number' %}
                   {% endif %}
 
-                  <p class="govuk-body-s accepted-cards-hint withdrawal-text govuk-!-margin-bottom-0">
+                  <p class="govuk-body accepted-cards-hint withdrawal-text govuk-!-margin-bottom-0">
                     {% if withdrawalText === 'debit_credit' %}
                       {{ __p("cardDetails.withdrawalText").debit_credit }}
                     {% endif %}
@@ -285,12 +286,14 @@
                     class="card-holder-name-label">
                       {{ __p("cardDetails.cardholderName") }}
                     </span>
-                    {% if highlightErrorFields.cardholderName %}
-                      <p class="govuk-error-message" id="error-cardholder-name">
-                        {{ highlightErrorFields.cardholderName }}
-                      </p>
-                    {% endif %}
                   </label>
+
+                  {% if highlightErrorFields.cardholderName %}
+                    <p class="govuk-error-message" id="error-cardholder-name">
+                      {{ highlightErrorFields.cardholderName }}
+                    </p>
+                  {% endif %}
+
                   <input id="cardholder-name"
                   type="text"
                   name="cardholderName"
@@ -320,12 +323,13 @@
                         </span>
                       </span>
                     </span>
-                    {% if highlightErrorFields.cvc %}
-                      <p class="govuk-error-message" id="error-cvc">
-                        {{ highlightErrorFields.cvc }}
-                      </p>
-                    {% endif %}
                   </label>
+
+                  {% if highlightErrorFields.cvc %}
+                    <p class="govuk-error-message" id="error-cvc">
+                      {{ highlightErrorFields.cvc }}
+                    </p>
+                  {% endif %}
 
                   {% if moto and gatewayAccount.motoMaskCardSecurityCodeInput %}
                     {% set securityCodeInputType = 'password' %}
@@ -370,12 +374,14 @@
                               data-original-label="{{ __p("cardDetails.country") }}">
                               {{ __p("cardDetails.country") }}
                             </span>
-                            {% if highlightErrorFields.addressCountry %}
-                              <p class="govuk-error-message" id="error-address-country">
-                                {{ highlightErrorFields.addressCountry }}
-                              </p>
-                            {% endif %}
                           </label>
+
+                          {% if highlightErrorFields.addressCountry %}
+                            <p class="govuk-error-message" id="error-address-country">
+                              {{ highlightErrorFields.addressCountry }}
+                            </p>
+                          {% endif %}
+
                           <select name="addressCountry" class="govuk-select" id="address-country" autocomplete="billing country-name">
                             {% if not countryCode | length and service and service.defaultBillingAddressCountry %}
                               {% set countryCode = service.defaultBillingAddressCountry %}
@@ -396,13 +402,14 @@
                               data-original-label="{{ __p("cardDetails.building") }}">
                                   {{ __p("cardDetails.building") }}
                             </span>
-
-                            {% if highlightErrorFields.addressLine1 %}
-                              <p class="govuk-error-message" id="error-address-line-1">
-                                {{ highlightErrorFields.addressLine1 }}
-                              </p>
-                            {% endif %}
                           </label>
+
+                          {% if highlightErrorFields.addressLine1 %}
+                            <p class="govuk-error-message" id="error-address-line-1">
+                              {{ highlightErrorFields.addressLine1 }}
+                            </p>
+                          {% endif %}
+
                           <input id="address-line-1"
                             type="text"
                             name="addressLine1"
@@ -428,12 +435,14 @@
                           data-original-label="{{ __p("cardDetails.city") }}">
                               {{ __p("cardDetails.city") }}
                             </span>
-                            {% if highlightErrorFields.addressCity %}
-                              <p class="govuk-error-message" id="error-address-city">
-                                {{ highlightErrorFields.addressCity }}
-                              </p>
-                            {% endif %}
                           </label>
+
+                          {% if highlightErrorFields.addressCity %}
+                            <p class="govuk-error-message" id="error-address-city">
+                              {{ highlightErrorFields.addressCity }}
+                            </p>
+                          {% endif %}
+
                           <input id="address-city"
                             type="text"
                             name="addressCity"
@@ -450,13 +459,14 @@
                               data-original-label="{{ __p("cardDetails.postcode") }}">
                               {{ __p("cardDetails.postcode") }}
                             </span>
+                          </label>
 
-                            {% if highlightErrorFields.addressPostcode %}
+                          {% if highlightErrorFields.addressPostcode %}
                               <p class="govuk-error-message" id="error-address-postcode">
                                 {{ highlightErrorFields.addressPostcode }}
                               </p>
-                            {% endif %}
-                          </label>
+                          {% endif %}
+
                           <input id="address-postcode"
                             type="text"
                             name="addressPostcode"
@@ -484,26 +494,28 @@
                         <div class="govuk-form-group {% if highlightErrorFields.email %} govuk-form-group--error{% endif %}" data-validation="email">
                           <label id="email-lbl" for="email" class="govuk-label">
                             <span
-                        class="email-label"
-                        data-label-replace="email"
-                        data-original-label="{{ __p("cardDetails.email") }}">
-                              {{ __p("cardDetails.email") }}
+                              class="email-label"
+                              data-label-replace="email"
+                              data-original-label="{{ __p("cardDetails.email") }}">
+                                {{ __p("cardDetails.email") }}
                             </span>
-                            {% if highlightErrorFields.email %}
+                          </label>
+
+                          {% if highlightErrorFields.email %}
                               <p class="govuk-error-message" id="error-email">
                                 {{ highlightErrorFields.email }}
                               </p>
                             {% endif %}
-                          </label>
+
                           <input id="email"
-                        type="email"
-                        name="email"
-                        maxlength="254"
-                        class="govuk-input govuk-!-width-full"
-                        value="{{ email }}"
-                        autocomplete="email"
-                        data-confirmation="true"
-                        data-confirmation-label="{{ __p("cardDetails.emailConfirmation") }} "/>
+                            type="email"
+                            name="email"
+                            maxlength="254"
+                            class="govuk-input govuk-!-width-full"
+                            value="{{ email }}"
+                            autocomplete="email"
+                            data-confirmation="true"
+                            data-confirmation-label="{{ __p("cardDetails.emailConfirmation") }} "/>
                         </div>
                       </div>
                     </fieldset>
@@ -511,35 +523,35 @@
                 {% endif %}
                 {% if typos %}
                   {{
-            govukRadios({
-              name: 'email-typo-sugestion',
-              errorMessage: {
-                text: __p("fieldErrors.fields.email.typo"),
-                classes: 'govuk-!-width-three-quarters'
-              },
-              items: [
-                {
-                  id: 'email-corrected',
-                  value: typos.full,
-                  html: typos.address + '@<strong>' + typos.domain + '</strong>',
-                  checked: true
-                },
-                {
-                  id: 'email-uncorrected',
-                  value: email,
-                  text: email
-                }
-              ]
-            })
-          }}
+                    govukRadios({
+                      name: 'email-typo-sugestion',
+                      errorMessage: {
+                        text: __p("fieldErrors.fields.email.typo"),
+                        classes: 'govuk-!-width-three-quarters'
+                      },
+                      items: [
+                        {
+                          id: 'email-corrected',
+                          value: typos.full,
+                          html: typos.address + '@<strong>' + typos.domain + '</strong>',
+                          checked: true
+                        },
+                        {
+                          id: 'email-uncorrected',
+                          value: email,
+                          text: email
+                        }
+                      ]
+                    })
+                  }}
                 {% endif %}
                   {% if savePaymentInstrumentToAgreement and agreementDescription %}
-                  <div id="agreement-setup-disclaimer" class="govuk-form-group govuk-!-width-three-quarters {% if shouldShowEmail %}govuk-!-margin-top-6{% else %}govuk-!-margin-top-8{% endif %} pay-!-border-top"">
-                    <div class="govuk-inset-text">
-                      <p class="govuk-hint govuk-!-margin-bottom-0">Your payment details will be saved for:</p>
-                      <p class="govuk-body-l">{{ agreementDescription }}</p>
+                     <div id="agreement-setup-disclaimer" class="govuk-form-group govuk-!-width-three-quarters {% if shouldShowEmail %}govuk-!-margin-top-6{% else %}govuk-!-margin-top-8{% endif %} pay-!-border-top">
+                      <div class="govuk-inset-text">
+                        <p class="govuk-hint govuk-!-margin-bottom-0">Your payment details will be saved for:</p>
+                        <p class="govuk-body-l">{{ agreementDescription }}</p>
+                      </div>
                     </div>
-                  </div>
                   {% endif %}
                 <div>
                   {% if typos %}

--- a/test/cypress/integration/card/moto-mask-payment.cy.test.js
+++ b/test/cypress/integration/card/moto-mask-payment.cy.test.js
@@ -151,31 +151,29 @@ describe('Standard card payment flow', () => {
       cy.get('#cvc').invoke('attr', 'autocomplete').should('eq', 'cc-csc')
     })
 
-    it('should allow a valid card number to be entered', () => {
+    it('should display an error when a invalid card number is entered', () => {
+      cy.task('setupStubs', checkCardDetailsStubs)
+
+      cy.get('#card-no').type('1234567890')
+      cy.get('#card-no').blur()
+
+      cy.get('#card-no').should('have.class', 'govuk-input--error')
+      cy.get('#card-no-lbl').parent().find('.govuk-error-message').should('contain', 'Card number is not the correct length')
+    })
+
+    it('should allow a valid card number to be entered and remove existing error messages', () => {
       cy.task('setupStubs', checkCardDetailsStubs)
 
       cy.server()
       cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
 
+      cy.get('#card-no').clear()
       cy.get('#card-no').type(validPayment.cardNumber)
       cy.get('#card-no').blur()
 
       cy.wait('@checkCard')
       cy.get('#card-no').should('not.have.class', 'govuk-input--error')
-    })
-
-    it('should display an error when a invalid card number is entered', () => {
-      cy.task('setupStubs', checkCardDetailsStubs)
-
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
-
-      cy.get('#card-no').type('1234567890')
-      cy.get('#card-no').blur()
-
-      cy.wait('@checkCard')
-      cy.get('#card-no').should('have.class', 'govuk-input--error')
-      cy.get('#card-no-lbl').should('contain', 'Card number is not the correct length')
+      cy.get('#card-no').parent().find('.govuk-error-message').should('not.exist')
     })
   })
 
@@ -196,21 +194,22 @@ describe('Standard card payment flow', () => {
       cy.get('#cvc').invoke('attr', 'autocomplete').should('eq', 'off')
     })
 
-    it('should allow a valid security code to be entered', () => {
-      cy.get('#cvc').clear()
-      cy.get('#cvc').type(validPayment.securityCode)
-      cy.get('#cvc').blur()
-
-      cy.get('#cvc').should('not.have.class', 'govuk-input--error')
-    })
-
     it('should display an error when a invalid security code is entered', () => {
       cy.get('#cvc').clear()
       cy.get('#cvc').type('11')
       cy.get('#cvc').blur()
 
       cy.get('#cvc').should('have.class', 'govuk-input--error')
-      cy.get('#cvc-lbl').should('contain', 'Enter a valid card security code')
+      cy.get('#cvc-lbl').parent().find('.govuk-error-message').should('contain', 'Enter a valid card security code')
+    })
+
+    it('should allow a valid security code to be entered and remove existing error messages', () => {
+      cy.get('#cvc').clear()
+      cy.get('#cvc').type(validPayment.securityCode)
+      cy.get('#cvc').blur()
+
+      cy.get('#cvc').should('not.have.class', 'govuk-input--error')
+      cy.get('#cvc-lbl').parent().find('.govuk-error-message').should('not.exist')
     })
   })
 

--- a/test/cypress/integration/card/payment.cy.test.js
+++ b/test/cypress/integration/card/payment.cy.test.js
@@ -195,7 +195,7 @@ describe('Standard card payment flow', () => {
       cy.get('#card-no').type('4000160000000004')
       cy.get('#card-no').blur()
       cy.wait('@checkCard')
-      cy.get('#card-no-lbl').should('contain', 'Prepaid cards are not accepted')
+      cy.get('#card-no-lbl').parent().find('.govuk-error-message').should('contain', 'Prepaid cards are not accepted')
     })
 
     it('should allow prepaid cards if gateway account is configured to allow', () => {
@@ -238,7 +238,7 @@ describe('Standard card payment flow', () => {
       cy.get('#card-no').blur()
 
       cy.get('#card-no').should('have.class', 'govuk-input--error')
-      cy.get('#card-no-lbl').should('contain', 'Card number is not the correct length')
+      cy.get('#card-no-lbl').parent().find('.govuk-error-message').should('contain', 'Card number is not the correct length')
     })
   })
 
@@ -266,7 +266,7 @@ describe('Standard card payment flow', () => {
       cy.get('#card-no').blur()
 
       cy.get('#card-no').should('have.class', 'govuk-input--error')
-      cy.get('#card-no-lbl').should('contain', 'Nid yw rhif y cerdyn yr hyd cywir')
+      cy.get('#card-no-lbl').parent().find('.govuk-error-message').should('contain', 'Nid yw rhif y cerdyn yr hyd cywir')
     })
   })
 


### PR DESCRIPTION
# DAC Audit issue identified by DVLA.

## Client side JS Validation -  form-validation.js

### Before changes:
Before error messages: 
<img width="454" alt="image" src="https://user-images.githubusercontent.com/59831992/189831812-a431e104-e1bf-4596-92e7-e5c5e7fcd066.png">

Error messages - were overwriting labels which is wrong:
<img width="370" alt="image" src="https://user-images.githubusercontent.com/59831992/189832040-31d2d9b1-e5d0-4ea5-9521-7ab4154f2e74.png">

### After changes

Updated code:
- No longer overwrites labels.
- Error message is a separate element that is no longer embedded in the label element.

<img width="625" alt="image" src="https://user-images.githubusercontent.com/59831992/189837244-03ea132e-2301-47de-8b4d-7ecc7eccc3f2.png">

## Server side validation - charge.njk
- When JS is disabled, make the error messages are not part of the label, make them their own element.

## Credit card hint text:

Credit card hint text is too small - make this bigger:

<img width="710" alt="image" src="https://user-images.githubusercontent.com/59831992/189839016-981ed678-9a8c-4122-965b-b2919a76cab0.png">

## Full details of changes

- Update Javascript to add error elements rather than overwrite labels.
- When the error is relaced with a new error - create the element again from scratch so that screen readers are alerted.
- Add the error message outside of the label instead of adding it inside the label.
  - This is more semantically correct.
  - Also consistent with Design system.
- Make sure the code works with IE11
  - Use `removeChild` instead of `remove`.
- Credit card hint text
  - Update to use the right size text.
- `charge.njk`
  - For server validation - move error messages so that they are outside of the label element.
  - This is consistent with Design system and semantically correct.
- Update Cypress tests - `moto-mask-payment.cy.test.js` & `payment.cy.test.js`
  - Update selector for error messages.
  - Update tests when entering a valid value - to make sure that there are no errors.
