### PR TITLE
PP-10074 Update roadmap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "node-sass": "7.0.3",
         "nodemon": "^2.0.20",
         "nyc": "15.1.x",
-        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.10.12/pay-product-page-4.10.12.tgz",
+        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.11.0/pay-product-page-4.11.0.tgz",
         "proxyquire": "~2.1.3",
         "sinon": "14.0.x",
         "standard": "^14.3.x",
@@ -14889,9 +14889,9 @@
       }
     },
     "node_modules/pay-product-page": {
-      "version": "4.10.12",
-      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.10.12/pay-product-page-4.10.12.tgz",
-      "integrity": "sha512-I51ltZVDIsFKkC4CAvNMEQ4V89PXqOB/rTeANLQug2MF8e15ElQ6KrHoZQxovF7BiI9Zc0hDfkdFcUrmiDxdIw==",
+      "version": "4.11.0",
+      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.11.0/pay-product-page-4.11.0.tgz",
+      "integrity": "sha512-Pz/f/ryUnMMffE3mS5Esh8Z4RcEuQAbMW1gpt8ahFR5ILKr2jnxG5QnXXjd287X/TEYu/ZTTFavTMnMzcI+OEA==",
       "dev": true
     },
     "node_modules/pbkdf2": {
@@ -31819,8 +31819,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.10.12/pay-product-page-4.10.12.tgz",
-      "integrity": "sha512-I51ltZVDIsFKkC4CAvNMEQ4V89PXqOB/rTeANLQug2MF8e15ElQ6KrHoZQxovF7BiI9Zc0hDfkdFcUrmiDxdIw==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.11.0/pay-product-page-4.11.0.tgz",
+      "integrity": "sha512-Pz/f/ryUnMMffE3mS5Esh8Z4RcEuQAbMW1gpt8ahFR5ILKr2jnxG5QnXXjd287X/TEYu/ZTTFavTMnMzcI+OEA==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "node-sass": "7.0.3",
     "nodemon": "^2.0.20",
     "nyc": "15.1.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.10.12/pay-product-page-4.10.12.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.11.0/pay-product-page-4.11.0.tgz",
     "proxyquire": "~2.1.3",
     "sinon": "14.0.x",
     "standard": "^14.3.x",


### PR DESCRIPTION
## WHAT
- Bumps product pages to the latest version which includes updates to the roadmap https://github.com/alphagov/pay-product-page/commit/d2fa90f11a697dcb731a12751bcdd0a930de2187
