### PR TITLE
PP-10077 Make Google Pay and Apple Pay spinner cover whole page

### DIFF
--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const chargeValidation = require('../../../utils/charge-validation')
+const { toggleSubmitButtons } = require('./helpers')
 const { submitWithWorldpay3dsFlexDdcResult } = require('./worldpay-3ds-flex-ddc')
 
 var init = function () {
@@ -60,7 +61,7 @@ var init = function () {
     }
 
     if (!validations.hasError) {
-      document.getElementById('submit-card-details').setAttribute('disabled', 'disabled')
+      toggleSubmitButtons()
       if (typeof Charge.worldpay_3ds_flex_ddc_jwt === 'string' && Charge.worldpay_3ds_flex_ddc_jwt !== '') {
         submitWithWorldpay3dsFlexDdcResult(e.target)
       } else {

--- a/app/assets/javascripts/browsered/helpers.js
+++ b/app/assets/javascripts/browsered/helpers.js
@@ -22,7 +22,73 @@ const initialiseAddressCountryAutocomplete = () => {
   document.getElementsByTagName('head')[0].appendChild(autocompleteScript)
 }
 
+const toggleButton = (button) => {
+  if (button) {
+    button[button.getAttribute('disabled') ? 'removeAttribute' : 'setAttribute']('disabled', 'disabled')
+  }
+}
+
+const toggleSubmitButtons = () => {
+  toggleButton(document.getElementById('submit-card-details'))
+  toggleButton(document.getElementById('apple-pay-payment-method-submit'))
+  toggleButton(document.getElementById('google-pay-payment-method-submit'))
+}
+
+const showSpinnerAndHideMainContent = () => {
+  document.getElementById('card-details-wrap').classList.add('hidden')
+  const errorSummary = document.getElementById('error-summary')
+  errorSummary.classList.add('hidden')
+  errorSummary.setAttribute('aria-hidden', 'true')
+
+  var paymentDetailsHeader = document.querySelector('.web-payment-button-section')
+  if (typeof paymentDetailsHeader !== 'undefined' && paymentDetailsHeader !== null) {
+    paymentDetailsHeader.style.display = 'none'
+  }
+
+  var applePayContainer = document.querySelector('.apple-pay-container')
+  if (typeof applePayContainer !== 'undefined' && applePayContainer !== null) {
+    applePayContainer.style.display = 'none'
+  }
+
+  var googlePayContainer = document.querySelector('.google-pay-container')
+  if (typeof googlePayContainer !== 'undefined' && googlePayContainer !== null) {
+    googlePayContainer.style.display = 'none'
+  }
+
+  document.getElementById('spinner').classList.remove('hidden')
+}
+
+const hideSpinnerAndShowMainContent = () => {
+  document.getElementById('card-details-wrap').classList.remove('hidden')
+
+  if (document.getElementsByClassName('govuk-error-summary__list')[0].childElementCount > 0) {
+    const errorSummary = document.getElementById('error-summary')
+    errorSummary.classList.remove('hidden')
+    errorSummary.setAttribute('aria-hidden', 'false')
+  }
+
+  var paymentDetailsHeader = document.querySelector('.web-payment-button-section')
+  if (typeof paymentDetailsHeader !== 'undefined' && paymentDetailsHeader !== null) {
+    paymentDetailsHeader.style.display = 'block'
+  }
+
+  var applePayContainer = document.querySelector('.apple-pay-container')
+  if (typeof applePayContainer !== 'undefined' && applePayContainer !== null) {
+    applePayContainer.style.display = 'block'
+  }
+
+  var googlePayContainer = document.querySelector('.google-pay-container')
+  if (typeof googlePayContainer !== 'undefined' && googlePayContainer !== null) {
+    googlePayContainer.style.display = 'bock'
+  }
+
+  document.getElementById('spinner').classList.add('hidden')
+}
+
 module.exports = {
   setGlobalChargeId,
+  toggleSubmitButtons,
+  showSpinnerAndHideMainContent,
+  hideSpinnerAndShowMainContent,
   initialiseAddressCountryAutocomplete
 }

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -1,10 +1,12 @@
 'use strict'
 
-const { getGooglePaymentsConfiguration, showErrorSummary, toggleWaiting } = require('./helpers')
+const { getGooglePaymentsConfiguration, showErrorSummary } = require('./helpers')
+const { toggleSubmitButtons, showSpinnerAndHideMainContent, hideSpinnerAndShowMainContent } = require('../helpers')
 const { email_collection_mode } = window.Charge // eslint-disable-line camelcase
 
 const processPayment = paymentData => {
-  toggleWaiting('google-pay-payment-method-submit')
+  toggleSubmitButtons()
+  showSpinnerAndHideMainContent()
 
   return fetch(`/web-payments-auth-request/google/${window.paymentDetails.chargeID}`, {
     method: 'POST',
@@ -24,7 +26,8 @@ const processPayment = paymentData => {
       }
     })
     .catch(err => {
-      toggleWaiting('google-pay-payment-method-submit')
+      hideSpinnerAndShowMainContent()
+      toggleSubmitButtons()
       showErrorSummary(i18n.fieldErrors.webPayments.failureTitle, i18n.fieldErrors.webPayments.failureBody)
       ga('send', 'event', 'Google Pay', 'Error', 'During authorisation/capture')
       return err

--- a/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
+++ b/app/assets/javascripts/browsered/worldpay-3ds-flex-ddc.js
@@ -1,25 +1,6 @@
 'use strict'
 
-const toggleWaiting = () => {
-  document.getElementById('card-details-wrap').classList.toggle('hidden')
-  document.getElementById('spinner').classList.toggle('hidden')
-  document.getElementById('error-summary').classList.add('hidden')
-
-  var paymentDetailsHeader = document.querySelector('.web-payment-button-section')
-  if (typeof paymentDetailsHeader !== 'undefined' && paymentDetailsHeader !== null) {
-    paymentDetailsHeader.style.display = 'none'
-  }
-
-  var applePayContainer = document.querySelector('.apple-pay-container')
-  if (typeof applePayContainer !== 'undefined' && applePayContainer !== null) {
-    applePayContainer.style.display = 'none'
-  }
-
-  var googlePayContainer = document.querySelector('.google-pay-container')
-  if (typeof googlePayContainer !== 'undefined' && googlePayContainer !== null) {
-    googlePayContainer.style.display = 'none'
-  }
-}
+const { showSpinnerAndHideMainContent } = require('./helpers')
 
 const addWorldpaySessionIdToForm = (form, worldpaySessionId) => {
   const worldpaySessionIdFormInput = document.createElement('input')
@@ -67,7 +48,7 @@ const submitWithWorldpay3dsFlexDdcResult = form => {
     }
   })
 
-  toggleWaiting()
+  showSpinnerAndHideMainContent()
 
   const initiateDeviceDataCollection = iFrameContent => {
     const innerForm = iFrameContent.getElementById('collectionForm')


### PR DESCRIPTION
Make it so that when we are processing a Google Pay or Apple Pay payment we hide the majority of the page while showing the spinner (currently none of the page is hidden). In addition, disable all the submit buttons when the spinner is shown (currently only the Google Pay or Apple Pay submit button is disabled).

This brings the appearance of the spinner into line with when we do Worldpay 3DS Flex device data collection. Also make it so that when the spinner is shown for DDC we disable all the submit buttons (currently only the card details submit button is disabled).

with @SandorArpa