### PR TITLE
PP-10077 Recover from unexpected Google Pay Ajax response

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -23,6 +23,11 @@ const processPayment = paymentData => {
         return response.json().then(data => {
           window.location.href = data.url
         })
+      } else {
+        hideSpinnerAndShowMainContent()
+        toggleSubmitButtons()
+        showErrorSummary(i18n.fieldErrors.webPayments.failureTitle, i18n.fieldErrors.webPayments.failureBody)
+        ga('send', 'event', 'Google Pay', 'Error', 'During authorisation/capture')
       }
     })
     .catch(err => {


### PR DESCRIPTION
If the Google Pay Ajax call results in an unexpected HTTP status code, hide the spinner and display the main content (which is the same thing we’d do for other errors).

with @SandorArpa and @kbottla