### PR TITLE
PP-10077 Add Google Pay Worldpay 3DS Flex DDC iframe

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -589,6 +589,9 @@
           </div>
           {% if worldpay3dsFlexDdcJwt %}
             <iframe id="worldpay3dsFlexDdcIframe" src="/public/worldpay/worldpay-3ds-flex-ddc.html" class="govuk-!-display-none"></iframe>
+            {% if allowGooglePay %}
+              <iframe id="googlePayWorldpay3dsFlexDdcIframe" src="/public/worldpay/worldpay-3ds-flex-ddc.html" class="govuk-!-display-none"></iframe>
+            {% endif %}
           {% endif %}
       </main>
     </div>


### PR DESCRIPTION
If both Google Pay and Worldpay 3DS Flex are enabled, add an additional device data collection iframe to the enter card details page. This iframe is identical to the other one except that it has a different ID and will be used exclusively for device data collection for Google Pay payments.

with @SandorArpa