### PR TITLE
PP-10077 Google Pay: send Worldpay 3DS Flex DDC result to connector

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -168,28 +168,28 @@
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 49
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1ee4b74cf4b89c3cd9792a34a1fdfed2c8d4b71d",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 51
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "29537aaf22996353c2fe981aaa72e960b2ed2d70",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 51
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "6464ec4579ee376ccaa76867f536aa1061bc89bf",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 51
       }
     ],
     "test/cypress/integration/card/payment.cy.test.js": [
@@ -345,5 +345,5 @@
       }
     ]
   },
-  "generated_at": "2021-08-13T15:14:42Z"
+  "generated_at": "2022-10-13T18:11:33Z"
 }

--- a/app/controllers/charge.controller.js
+++ b/app/controllers/charge.controller.js
@@ -140,11 +140,7 @@ module.exports = {
 
     const { worldpay3dsFlexDdcStatus } = req.body
     if (worldpay3dsFlexDdcStatus) {
-      logger.info(`Payment details submitted for a Worldpay 3DS Flex charge. DDC status is: ${worldpay3dsFlexDdcStatus}`,
-        {
-          ...getLoggingFields(req),
-          worldpay_3ds_flex_ddc_status: worldpay3dsFlexDdcStatus
-        })
+      logging.worldpay3dsFlexDdcStatus(worldpay3dsFlexDdcStatus, getLoggingFields(req))
     }
 
     if (charge.status === State.AUTH_READY) return redirect(res).toAuthWaiting(req.chargeId)

--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -30,6 +30,10 @@ const logselectedPayloadProperties = req => {
     if ('payerEmail' in payload) {
       selectedPayloadProperties.payerEmail = redact(payload.payerEmail)
     }
+
+    if ('worldpay3dsFlexDdcResult' in payload) {
+      selectedPayloadProperties.worldpay3dsFlexDdcResult = redact(payload.worldpay3dsFlexDdcResult)
+    }
   }
 
   logger.info('Received Google Pay payload', {
@@ -83,6 +87,7 @@ module.exports = req => {
     brand: normaliseCardName(payload.details.paymentMethodData.info.cardNetwork),
     cardholder_name: nullable(payload.payerName || ''),
     email: nullable(payload.payerEmail || ''),
+    worldpay_3ds_flex_ddc_result: nullable(payload.worldpay3dsFlexDdcResult || ''),
     accept_header: req.headers['accept-for-html'],
     user_agent_header: req.headers['user-agent'],
     ip_address: userIpAddress(req)

--- a/app/controllers/web-payments/payment-auth-request.controller.js
+++ b/app/controllers/web-payments/payment-auth-request.controller.js
@@ -2,6 +2,7 @@
 
 // NPM dependencies
 const logger = require('../../utils/logger')(__filename)
+const logging = require('../../utils/logging')
 const { getLoggingFields } = require('../../utils/logging-fields-helper')
 const connectorClient = require('../../services/clients/connector.client')
 const normaliseApplePayPayload = require('./apple-pay/normalise-apple-pay-payload')
@@ -12,7 +13,14 @@ const { setSessionVariable } = require('../../utils/cookies')
 module.exports = (req, res) => {
   const { chargeId, params } = req
   const { provider } = params
+
+  const { worldpay3dsFlexDdcStatus } = req.body
+  if (worldpay3dsFlexDdcStatus) {
+    logging.worldpay3dsFlexDdcStatus(worldpay3dsFlexDdcStatus, getLoggingFields(req))
+  }
+
   const payload = provider === 'apple' ? normaliseApplePayPayload(req) : normaliseGooglePayPayload(req)
+
   return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet({ chargeId, provider, payload }, getLoggingFields(req))
     .then(data => {
       setSessionVariable(req, `ch_${(chargeId)}.webPaymentAuthResponse`, {

--- a/app/utils/logging.js
+++ b/app/utils/logging.js
@@ -37,3 +37,10 @@ exports.failedChargePatch = (err, loggingFields = {}) => {
     error: err
   })
 }
+
+exports.worldpay3dsFlexDdcStatus = (ddcStatus, loggingFields = {}) => {
+  logger.info(`Payment details submitted for a Worldpay 3DS Flex charge. DDC status is: ${ddcStatus}`, {
+    ...loggingFields,
+    worldpay_3ds_flex_ddc_status: ddcStatus
+  })
+}

--- a/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
+++ b/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
@@ -26,8 +26,10 @@ describe('normalise Google Pay payload', () => {
           type: 'CARD'
         }
       },
-      payerEmail: 'name@email.fyi',
-      payerName: 'Some Name'
+      payerEmail: 'name@email.test',
+      payerName: 'Some Name',
+      worldpay3dsFlexDdcStatus: 'valid DDC result',
+      worldpay3dsFlexDdcResult: 'some long opaque string that’s a device data collection result'
     }
 
     const normalisedPayload = normalise({ headers: headers, body: googlePayPayload })
@@ -37,7 +39,8 @@ describe('normalise Google Pay payload', () => {
           last_digits_card_number: '4242',
           brand: 'master-card',
           cardholder_name: 'Some Name',
-          email: 'name@email.fyi',
+          email: 'name@email.test',
+          worldpay_3ds_flex_ddc_result: 'some long opaque string that’s a device data collection result',
           accept_header: 'text/html;q=1.0, */*;q=0.9',
           user_agent_header: 'Mozilla/5.0',
           ip_address: '203.0.113.1'
@@ -69,7 +72,7 @@ describe('normalise Google Pay payload', () => {
           type: 'CARD'
         }
       },
-      payerEmail: 'name@email.fyi',
+      payerEmail: 'name@email.test',
       payerName: 'Some Name'
     }
 
@@ -103,6 +106,7 @@ describe('normalise Google Pay payload', () => {
           brand: 'master-card',
           cardholder_name: null,
           email: null,
+          worldpay_3ds_flex_ddc_result: null,
           accept_header: 'text/html;q=1.0, */*;q=0.9',
           user_agent_header: 'Mozilla/5.0',
           ip_address: '203.0.113.1'
@@ -143,6 +147,7 @@ describe('normalise Google Pay payload', () => {
           brand: 'master-card',
           cardholder_name: null,
           email: null,
+          worldpay_3ds_flex_ddc_result: null,
           accept_header: 'text/html;q=1.0, */*;q=0.9',
           user_agent_header: 'Mozilla/5.0',
           ip_address: '203.0.113.1'
@@ -183,6 +188,7 @@ describe('normalise Google Pay payload', () => {
           brand: 'master-card',
           cardholder_name: null,
           email: null,
+          worldpay_3ds_flex_ddc_result: null,
           accept_header: 'text/html;q=1.0, */*;q=0.9',
           user_agent_header: 'Mozilla/5.0',
           ip_address: '203.0.113.1'

--- a/test/fixtures/wallet-payment.fixtures.js
+++ b/test/fixtures/wallet-payment.fixtures.js
@@ -7,7 +7,8 @@ const fixtures = {
         last_digits_card_number: ops.lastDigitsCardNumber !== undefined ? ops.lastDigitsCardNumber : successfulLastDigitsCardNumber,
         brand: 'master-card',
         cardholder_name: 'Some Name',
-        email: 'name@email.fyi',
+        email: 'name@email.test',
+        worldpay_3ds_flex_ddc_result: 'some long opaque string that’s a device data collection result',
         accept_header: 'text/html;q=1.0, */*;q=0.9',
         user_agent_header: 'Mozilla/5.0',
         ip_address: '203.0.113.1'


### PR DESCRIPTION
When processing a request to `/web-payments-auth-request/google/CHARGE_ID` (sent as an Ajax request from the browser), process the Worldpay 3DS Flex device data collection result and status.

Send the DDC result to `/v1/frontend/charges/CHARGE_ID/wallets/google on connector` as `worldpay_3ds_flex_ddc_result` inside the existing `payment_info` object.

Log the DDC status in the same way we do for a regular card payment for which we performed device data collection.