### PR TITLE
PP-10204: Revert David's goodbye message, add Bristol/Manchester

### DIFF
--- a/app/utils/response-router.js
+++ b/app/utils/response-router.js
@@ -117,7 +117,7 @@ const actions = {
     code: 200,
     view: 'plain-message',
     locals: {
-      message: 'Thanks for everything, David.'
+      message: 'GOV.UK Pay is built by a team at the Government Digital Service in London, Manchester and Bristol. If you\'d like to join us, see https://gds.blog.gov.uk/jobs'
     }
   },
 

--- a/test/utils/response-router.test.js
+++ b/test/utils/response-router.test.js
@@ -180,7 +180,7 @@ describe('rendering behaviour', () => {
     HUMANS: {
       template: 'plain-message',
       code: 200,
-      message: 'Thanks for everything, David.'
+      message: 'GOV.UK Pay is built by a team at the Government Digital Service in London, Manchester and Bristol. If you\'d like to join us, see https://gds.blog.gov.uk/jobs'
     }
   }
 


### PR DESCRIPTION
The previous humans.txt message (see https://github.com/alphagov/pay-frontend/pull/3110/files) only mentioned the London office. Also, we're called GOV.UK Pay, not GOV.UK Payments.
