### PR TITLE
PP-10077 Nest Google Pay PaymentResponse object in Ajax request

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -140,56 +140,56 @@
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 25
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 25
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 25
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 25
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 51
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1ee4b74cf4b89c3cd9792a34a1fdfed2c8d4b71d",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 53
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "29537aaf22996353c2fe981aaa72e960b2ed2d70",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 53
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "6464ec4579ee376ccaa76867f536aa1061bc89bf",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 53
       }
     ],
     "test/cypress/integration/card/payment.cy.test.js": [
@@ -345,5 +345,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-13T18:11:33Z"
+  "generated_at": "2022-10-17T10:17:20Z"
 }

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -5,14 +5,16 @@ const { toggleSubmitButtons, showSpinnerAndHideMainContent, hideSpinnerAndShowMa
 const { email_collection_mode } = window.Charge // eslint-disable-line camelcase
 
 const submitGooglePayAuthRequest = (paymentResponse, ddcStatus, ddcResult) => {
-  var paymentData = paymentResponse.toJSON()
+  var requestBody = {
+    paymentResponse: paymentResponse
+  }
 
   if (ddcStatus) {
-    paymentData.worldpay3dsFlexDdcStatus = ddcStatus
+    requestBody.worldpay3dsFlexDdcStatus = ddcStatus
   }
 
   if (ddcResult) {
-    paymentData.worldpay3dsFlexDdcResult = ddcResult
+    requestBody.worldpay3dsFlexDdcResult = ddcResult
   }
 
   return fetch(`/web-payments-auth-request/google/${window.paymentDetails.chargeID}`, {
@@ -22,7 +24,7 @@ const submitGooglePayAuthRequest = (paymentResponse, ddcStatus, ddcResult) => {
       'Content-Type': 'application/json',
       'Accept-for-HTML': document.body.getAttribute('data-accept-header') || '*/*'
     },
-    body: JSON.stringify(paymentData)
+    body: JSON.stringify(requestBody)
   })
     .then(response => {
       ga('send', 'event', 'Google Pay', 'Successful', 'auth/capture request')

--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -10,25 +10,26 @@ const logselectedPayloadProperties = req => {
   const selectedPayloadProperties = {}
   const payload = req.body
 
-  if (payload.details && payload.details.paymentMethodData && payload.details.paymentMethodData.info) {
+  if (payload.paymentResponse && payload.paymentResponse.details
+    && payload.paymentResponse.details.paymentMethodData && payload.paymentResponse.details.paymentMethodData.info) {
     selectedPayloadProperties.details = {}
     selectedPayloadProperties.details.paymentMethodData = {}
     selectedPayloadProperties.details.paymentMethodData.info = {}
 
-    if ('cardDetails' in payload.details.paymentMethodData.info) {
-      selectedPayloadProperties.details.paymentMethodData.info.cardDetails = output(payload.details.paymentMethodData.info.cardDetails)
+    if ('cardDetails' in payload.paymentResponse.details.paymentMethodData.info) {
+      selectedPayloadProperties.details.paymentMethodData.info.cardDetails = output(payload.paymentResponse.details.paymentMethodData.info.cardDetails)
     }
 
-    if ('cardNetwork' in payload.details.paymentMethodData.info) {
-      selectedPayloadProperties.details.paymentMethodData.info.cardNetwork = output(payload.details.paymentMethodData.info.cardNetwork)
+    if ('cardNetwork' in payload.paymentResponse.details.paymentMethodData.info) {
+      selectedPayloadProperties.details.paymentMethodData.info.cardNetwork = output(payload.paymentResponse.details.paymentMethodData.info.cardNetwork)
     }
 
-    if ('payerName' in payload) {
-      selectedPayloadProperties.payerName = redact(payload.payerName)
+    if ('payerName' in payload.paymentResponse) {
+      selectedPayloadProperties.payerName = redact(payload.paymentResponse.payerName)
     }
 
-    if ('payerEmail' in payload) {
-      selectedPayloadProperties.payerEmail = redact(payload.payerEmail)
+    if ('payerEmail' in payload.paymentResponse) {
+      selectedPayloadProperties.payerEmail = redact(payload.paymentResponse.payerEmail)
     }
 
     if ('worldpay3dsFlexDdcResult' in payload) {
@@ -83,18 +84,18 @@ module.exports = req => {
   const payload = req.body
 
   const paymentInfo = {
-    last_digits_card_number: normaliseLastDigitsCardNumber(payload.details.paymentMethodData.info.cardDetails),
-    brand: normaliseCardName(payload.details.paymentMethodData.info.cardNetwork),
-    cardholder_name: nullable(payload.payerName || ''),
-    email: nullable(payload.payerEmail || ''),
+    last_digits_card_number: normaliseLastDigitsCardNumber(payload.paymentResponse.details.paymentMethodData.info.cardDetails),
+    brand: normaliseCardName(payload.paymentResponse.details.paymentMethodData.info.cardNetwork),
+    cardholder_name: nullable(payload.paymentResponse.payerName || ''),
+    email: nullable(payload.paymentResponse.payerEmail || ''),
     worldpay_3ds_flex_ddc_result: nullable(payload.worldpay3dsFlexDdcResult || ''),
     accept_header: req.headers['accept-for-html'],
     user_agent_header: req.headers['user-agent'],
     ip_address: userIpAddress(req)
   }
 
-  const paymentData = humps.decamelizeKeys(JSON.parse(payload.details.paymentMethodData.tokenizationData.token))
-  delete payload.details.paymentMethodData
+  const paymentData = humps.decamelizeKeys(JSON.parse(payload.paymentResponse.details.paymentMethodData.tokenizationData.token))
+  delete payload.paymentResponse.details.paymentMethodData
 
   return {
     payment_info: paymentInfo,

--- a/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
+++ b/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
@@ -10,24 +10,26 @@ const headers = {
 describe('normalise Google Pay payload', () => {
   it('should return the correct format for the payload', () => {
     const googlePayPayload = {
-      details: {
-        apiVersionMinor: 0,
-        apiVersion: 2,
-        paymentMethodData: {
-          description: 'Mastercard •••• 4242',
-          info: {
-            cardNetwork: 'MASTERCARD',
-            cardDetails: '4242'
-          },
-          tokenizationData: {
-            type: 'PAYMENT_GATEWAY',
-            token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
-          },
-          type: 'CARD'
-        }
+      paymentResponse: {
+        details: {
+          apiVersionMinor: 0,
+          apiVersion: 2,
+          paymentMethodData: {
+            description: 'Mastercard •••• 4242',
+            info: {
+              cardNetwork: 'MASTERCARD',
+              cardDetails: '4242'
+            },
+            tokenizationData: {
+              type: 'PAYMENT_GATEWAY',
+              token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+            },
+            type: 'CARD'
+          }
+        },
+        payerEmail: 'name@email.test',
+        payerName: 'Some Name'
       },
-      payerEmail: 'name@email.test',
-      payerName: 'Some Name',
       worldpay3dsFlexDdcStatus: 'valid DDC result',
       worldpay3dsFlexDdcResult: 'some long opaque string that’s a device data collection result'
     }
@@ -56,24 +58,26 @@ describe('normalise Google Pay payload', () => {
 
   it('should throw error for invalid the payload', () => {
     const googlePayPayload = {
-      details: {
-        apiVersionMinor: 0,
-        apiVersion: 2,
-        paymentMethodData: {
-          description: 'UnSupported card •••• 4242',
-          info: {
-            cardNetwork: 'UnSupportedCard',
-            cardDetails: '4242'
-          },
-          tokenizationData: {
-            type: 'PAYMENT_GATEWAY',
-            token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
-          },
-          type: 'CARD'
-        }
-      },
-      payerEmail: 'name@email.test',
-      payerName: 'Some Name'
+      paymentResponse: {
+        details: {
+          apiVersionMinor: 0,
+          apiVersion: 2,
+          paymentMethodData: {
+            description: 'UnSupported card •••• 4242',
+            info: {
+              cardNetwork: 'UnSupportedCard',
+              cardDetails: '4242'
+            },
+            tokenizationData: {
+              type: 'PAYMENT_GATEWAY',
+              token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+            },
+            type: 'CARD'
+          }
+        },
+        payerEmail: 'name@email.test',
+        payerName: 'Some Name'
+      }
     }
 
     expect(() => normalise({ headers: headers, body: googlePayPayload })).to.throw('Unrecognised card brand in Google Pay payload: UnSupportedCard')
@@ -81,20 +85,22 @@ describe('normalise Google Pay payload', () => {
 
   it('should return the correct format for the payload with min data', () => {
     const googlePayPayload = {
-      details: {
-        apiVersionMinor: 0,
-        apiVersion: 2,
-        paymentMethodData: {
-          description: 'Mastercard •••• 4242',
-          info: {
-            cardNetwork: 'MASTERCARD',
-            cardDetails: '4242'
-          },
-          tokenizationData: {
-            type: 'PAYMENT_GATEWAY',
-            token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
-          },
-          type: 'CARD'
+      paymentResponse: {
+        details: {
+          apiVersionMinor: 0,
+          apiVersion: 2,
+          paymentMethodData: {
+            description: 'Mastercard •••• 4242',
+            info: {
+              cardNetwork: 'MASTERCARD',
+              cardDetails: '4242'
+            },
+            tokenizationData: {
+              type: 'PAYMENT_GATEWAY',
+              token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+            },
+            type: 'CARD'
+          }
         }
       }
     }
@@ -122,20 +128,22 @@ describe('normalise Google Pay payload', () => {
 
   it('should return an empty string for last_digits_card_number when cardDetails does not have numeric values for the last 4 characters', () => {
     const googlePayPayload = {
-      details: {
-        apiVersionMinor: 0,
-        apiVersion: 2,
-        paymentMethodData: {
-          description: 'Mastercard •••• ABCD',
-          info: {
-            cardNetwork: 'MASTERCARD',
-            cardDetails: 'ABCD'
-          },
-          tokenizationData: {
-            type: 'PAYMENT_GATEWAY',
-            token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
-          },
-          type: 'CARD'
+      paymentResponse: {
+        details: {
+          apiVersionMinor: 0,
+          apiVersion: 2,
+          paymentMethodData: {
+            description: 'Mastercard •••• ABCD',
+            info: {
+              cardNetwork: 'MASTERCARD',
+              cardDetails: 'ABCD'
+            },
+            tokenizationData: {
+              type: 'PAYMENT_GATEWAY',
+              token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+            },
+            type: 'CARD'
+          }
         }
       }
     }
@@ -163,20 +171,22 @@ describe('normalise Google Pay payload', () => {
 
   it('should return an empty string for last_digits_card_number when cardDetails is a blank string', () => {
     const googlePayPayload = {
-      details: {
-        apiVersionMinor: 0,
-        apiVersion: 2,
-        paymentMethodData: {
-          description: 'cardDetails blank str',
-          info: {
-            cardNetwork: 'MASTERCARD',
-            cardDetails: ''
-          },
-          tokenizationData: {
-            type: 'PAYMENT_GATEWAY',
-            token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
-          },
-          type: 'CARD'
+      paymentResponse: {
+        details: {
+          apiVersionMinor: 0,
+          apiVersion: 2,
+          paymentMethodData: {
+            description: 'cardDetails blank str',
+            info: {
+              cardNetwork: 'MASTERCARD',
+              cardDetails: ''
+            },
+            tokenizationData: {
+              type: 'PAYMENT_GATEWAY',
+              token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+            },
+            type: 'CARD'
+          }
         }
       }
     }


### PR DESCRIPTION
When we make the Ajax request to `/web-payments-auth-request/google/CHARGE_ID`, we currently convert the `PaymentResponse` object received from Google Pay to JSON and then add the two new `worldpay3dsFlexDdcResult` and `worldpay3dsFlexDdcStatus` properties to it and then send that as the payload.

Instead, send a JSON payload containing a top-level `paymentResponse` property containing the unmodified `PaymentResponse` object from Google Pay alongside the `worldpay3dsFlexDdcResult` and `worldpay3dsFlexDdcStatus` properties, also at the top-level:

```json
{
  "paymentResponse": … the PaymentResponse object from Google Pay …,
  "worldpay3dsFlexDdcResult": "the DDC result string",
  "worldpay3dsFlexDdcStatus": "the DDC status string"
}
```

This means we are not modifying the `PaymentResponse` object (which is not really ours to modify).

Since Google Pay is currently disabled globally, it’s safe to change both the code that creates the Ajax request and the server- side code that processes the received Ajax request simultaneously without having to worry about supporting both shapes of data simultaneously for a while.

with @SandorArpa