### PR TITLE
PP-10077 Update Google Pay Cypress tests for device data collection

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -244,28 +244,28 @@
         "filename": "test/cypress/integration/web-payments/google-pay.cy.test.js",
         "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 33
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/cypress/integration/web-payments/google-pay.cy.test.js",
         "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 33
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/cypress/integration/web-payments/google-pay.cy.test.js",
         "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 33
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/cypress/integration/web-payments/google-pay.cy.test.js",
         "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
         "is_verified": false,
-        "line_number": 30
+        "line_number": 33
       }
     ],
     "test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js": [
@@ -345,5 +345,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-17T10:17:20Z"
+  "generated_at": "2022-10-20T17:14:49Z"
 }


### PR DESCRIPTION
Update Google Pay Cypress tests to reflect the fact that we now do device data collection when Worldpay 3DS Flex is enabled (which is the standard configuration now).
    
with @alexbishop1