### PR TITLE
PP-9648 Bump product page to 4.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "node-sass": "7.0.3",
         "nodemon": "^2.0.20",
         "nyc": "15.1.x",
-        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.11.5/pay-product-page-4.11.5.tgz",
+        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.0/pay-product-page-4.12.0.tgz",
         "proxyquire": "~2.1.3",
         "sinon": "14.0.x",
         "standard": "^14.3.x",
@@ -14342,9 +14342,9 @@
       }
     },
     "node_modules/pay-product-page": {
-      "version": "4.11.5",
-      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.11.5/pay-product-page-4.11.5.tgz",
-      "integrity": "sha512-MqMXtB9k8tqrE8Pevw4xRlGnFIWPpPR0XM6qF86XDI8s6NtJ/DYt6FUPjUQi24Rps03PxHRcu/ZpfUFbDnakeA==",
+      "version": "4.12.0",
+      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.12.0/pay-product-page-4.12.0.tgz",
+      "integrity": "sha512-V7gkFJEH0r45zXnrT1AmuteEZrSu+twNq4iNzURS4XjpZ6e0RHOOItiNRXSJCebaKvKqPXrZPFtFAI8o/sIH6A==",
       "dev": true
     },
     "node_modules/pbkdf2": {
@@ -30834,8 +30834,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.11.5/pay-product-page-4.11.5.tgz",
-      "integrity": "sha512-MqMXtB9k8tqrE8Pevw4xRlGnFIWPpPR0XM6qF86XDI8s6NtJ/DYt6FUPjUQi24Rps03PxHRcu/ZpfUFbDnakeA==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.12.0/pay-product-page-4.12.0.tgz",
+      "integrity": "sha512-V7gkFJEH0r45zXnrT1AmuteEZrSu+twNq4iNzURS4XjpZ6e0RHOOItiNRXSJCebaKvKqPXrZPFtFAI8o/sIH6A==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "node-sass": "7.0.3",
     "nodemon": "^2.0.20",
     "nyc": "15.1.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.11.5/pay-product-page-4.11.5.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.0/pay-product-page-4.12.0.tgz",
     "proxyquire": "~2.1.3",
     "sinon": "14.0.x",
     "standard": "^14.3.x",


### PR DESCRIPTION
## WHAT
- Bump product page to latest https://github.com/alphagov/pay-product-page/pull/524
