### PR TITLE
BAU: Bump product pages from 4.12.2 to 4.12.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "node-sass": "7.0.3",
         "nodemon": "^2.0.20",
         "nyc": "15.1.x",
-        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.2/pay-product-page-4.12.2.tgz",
+        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.3/pay-product-page-4.12.3.tgz",
         "proxyquire": "~2.1.3",
         "sinon": "14.0.x",
         "standard": "^14.3.x",
@@ -14311,9 +14311,9 @@
       }
     },
     "node_modules/pay-product-page": {
-      "version": "4.12.2",
-      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.12.2/pay-product-page-4.12.2.tgz",
-      "integrity": "sha512-zsBqU1I5uTCbYCvKIdINkfIULSmcUW5MJmZscwlWgAg5IyH8uFznu8n7Ix8eMI2jGO8VRreS6KCNHEhp8Azc3A==",
+      "version": "4.12.3",
+      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.12.3/pay-product-page-4.12.3.tgz",
+      "integrity": "sha512-N+sy/mA/VqS/YvTTbkeKf160+UP79FcwNbgbZCa/NSlewaL5cj7T0iSdXvuukklQ1lUoKisvBB4su7FyKosS8g==",
       "dev": true
     },
     "node_modules/pbkdf2": {
@@ -30776,8 +30776,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.12.2/pay-product-page-4.12.2.tgz",
-      "integrity": "sha512-zsBqU1I5uTCbYCvKIdINkfIULSmcUW5MJmZscwlWgAg5IyH8uFznu8n7Ix8eMI2jGO8VRreS6KCNHEhp8Azc3A==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.12.3/pay-product-page-4.12.3.tgz",
+      "integrity": "sha512-N+sy/mA/VqS/YvTTbkeKf160+UP79FcwNbgbZCa/NSlewaL5cj7T0iSdXvuukklQ1lUoKisvBB4su7FyKosS8g==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "node-sass": "7.0.3",
     "nodemon": "^2.0.20",
     "nyc": "15.1.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.2/pay-product-page-4.12.2.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.3/pay-product-page-4.12.3.tgz",
     "proxyquire": "~2.1.3",
     "sinon": "14.0.x",
     "standard": "^14.3.x",


### PR DESCRIPTION
## WHAT
- Updated product pages to 4.12.3 https://github.com/alphagov/pay-product-page/commit/eb1e69d129ebd7f0227abe4290fcbbc23b0c2b10 (performance stats)