### PR TITLE
PP-8693 Handle 402 payment response from connector

### DIFF
--- a/app/controllers/charge.controller.js
+++ b/app/controllers/charge.controller.js
@@ -101,9 +101,10 @@ const handleCreateResponse = (req, res, charge, response) => {
         redirect(res).toConfirm(req.chargeId)
       }
       break
+    case 402:
     case 500:
-      logging.failedChargePost(500, getLoggingFields(req))
-      responseRouter.systemErrorResponse(req, res, '500 response when authorising charge', withAnalytics(charge, { returnUrl: routeFor('return', charge.id) }))
+      logging.failedChargePost(response.statusCode, getLoggingFields(req))
+      responseRouter.systemErrorResponse(req, res, `${response.statusCode} response when authorising charge`, withAnalytics(charge, { returnUrl: routeFor('return', charge.id) }))
       break
     default:
       redirect(res).toNew(req.chargeId)
@@ -206,7 +207,10 @@ module.exports = {
       delete payload.address
     }
     try {
-      const response = await connectorClient({ correlationId }).chargeAuth({ chargeId: req.chargeId, payload }, getLoggingFields(req))
+      const response = await connectorClient({ correlationId }).chargeAuth({
+        chargeId: req.chargeId,
+        payload
+      }, getLoggingFields(req))
       handleCreateResponse(req, res, charge, response)
     } catch (err) {
       logging.failedChargePatch(err.message, getLoggingFields(req))

--- a/app/controllers/three-d-secure.controller.js
+++ b/app/controllers/three-d-secure.controller.js
@@ -70,8 +70,9 @@ const handleThreeDsResponse = (req, res, charge) => response => {
     case 409:
       redirect(res).toAuthWaiting(charge.id)
       break
+    case 402:
     case 500:
-      responseRouter.systemErrorResponse(req, res, '3DS response 500', withAnalytics(charge))
+      responseRouter.systemErrorResponse(req, res, `3DS response ${response.statusCode}`, withAnalytics(charge))
       break
     default:
       responseRouter.errorResponse(req, res, '3DS unknown response', withAnalytics(charge))

--- a/app/controllers/web-payments/handle-auth-response.controller.js
+++ b/app/controllers/web-payments/handle-auth-response.controller.js
@@ -64,8 +64,9 @@ const handleAuthResponse = (req, res, charge) => response => {
       }
       break
     case 400:
+    case 402:
     case 500:
-      logging.failedChargePost(500, getLoggingFields(req))
+      logging.failedChargePost(response.statusCode, getLoggingFields(req))
       responseRouter.systemErrorResponse(req, res, 'Wallet authorisation error response', withAnalytics(
         charge,
         { returnUrl: routeFor('return', charge.id) },

--- a/test/controllers/web-payments/handle-auth-response.controller.test.js
+++ b/test/controllers/web-payments/handle-auth-response.controller.test.js
@@ -192,7 +192,6 @@ describe('The web payments handle auth response controller', () => {
     }
     const mockCookies = {
       getSessionVariable: (req, key) => {
-        // expect(key).to.be(`ch_${chargeId}.webPaymentAuthResponse`)
         return {
           statusCode: 200
         }
@@ -216,6 +215,40 @@ describe('The web payments handle auth response controller', () => {
     expect(res.render.calledWith('errors/system-error', systemErrorObj)).to.be.true // eslint-disable-line
     done()
   })
+
+  it('should show error page and delete connector response if connector response is in the session and status is 402', done => {
+    const mockCharge = sinon.spy()
+    const res = {
+      redirect: sinon.spy(),
+      render: sinon.spy(),
+      status: sinon.spy()
+    }
+    const mockCookies = {
+      getSessionVariable: (req, key) => {
+        return {
+          statusCode: 402
+        }
+      },
+      deleteSessionVariable: sinon.spy()
+    }
+    const systemErrorObj = {
+      viewName: 'SYSTEM_ERROR',
+      returnUrl: '/return/3',
+      analytics: {
+        analyticsId: 'test-1234',
+        type: 'test',
+        paymentProvider: 'sandbox',
+        path: '/handle-payment-response/3/error',
+        amount: '4.99',
+        testingVariant: 'original'
+      }
+    }
+    requireHandleAuthResponseController(mockCharge, mockNormaliseCharge, mockCookies)(req, res)
+    expect(mockCookies.deleteSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
+    expect(res.render.calledWith('errors/system-error', systemErrorObj)).to.be.true // eslint-disable-line
+    done()
+  })
+
   it('show error page and delete connector response if connector response is in the session and status code is 400', done => {
     const mockCharge = () => {
       return {
@@ -235,7 +268,6 @@ describe('The web payments handle auth response controller', () => {
     }
     const mockCookies = {
       getSessionVariable: () => {
-        // expect(key).to.be(`ch_${chargeId}.webPaymentAuthResponse`)
         return {
           statusCode: 400
         }

--- a/test/integration/three-d-secure.ft.test.js
+++ b/test/integration/three-d-secure.ft.test.js
@@ -447,6 +447,18 @@ describe('chargeTests', function () {
         .end(done)
     })
 
+    it('should send 3ds data to connector and render an error if connector returns an 402', function (done) {
+      const cookieValue = cookie.create(chargeId)
+      nock(process.env.CONNECTOR_HOST)
+        .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
+        .post(`${connectorChargePath}${chargeId}/3ds`, { pa_response: 'aPaResponse' }).reply(402)
+      defaultAdminusersResponseForGetService(gatewayAccountId)
+
+      postChargeRequest(app, cookieValue, { PaRes: 'aPaResponse' }, chargeId, true, '/3ds_handler')
+        .expect(500)
+        .end(done)
+    })
+
     it('should send 3ds data to connector and render an error if connector returns an invalid status code', function (done) {
       const cookieValue = cookie.create(chargeId)
       nock(process.env.CONNECTOR_HOST)


### PR DESCRIPTION
## WHAT
 - Handles 402 status code from connector for payments.
- At the moment connector returns a 500 status code for gateway errors for which frontend logs the error "Error communicating with connector.." which is not accurate.
- So, connector is going to return 402 instead for gateway errors. Frontend will continue to show an error page to users.
      - https://github.com/alphagov/pay-connector/pull/4145