### PR TITLE
PP-10278 GooglePay payments: Log properties all the time

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,56 +155,56 @@
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
         "is_verified": false,
-        "line_number": 25
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 65
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1ee4b74cf4b89c3cd9792a34a1fdfed2c8d4b71d",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 67
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "29537aaf22996353c2fe981aaa72e960b2ed2d70",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 67
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "6464ec4579ee376ccaa76867f536aa1061bc89bf",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 67
       }
     ],
     "test/cypress/integration/card/payment.cy.test.js": [
@@ -376,5 +376,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-08T16:55:02Z"
+  "generated_at": "2022-11-10T10:37:13Z"
 }

--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -5,37 +5,33 @@ const { getLoggingFields } = require('../../../utils/logging-fields-helper')
 const { output, redact } = require('../../../utils/structured-logging-value-helper')
 const userIpAddress = require('../../../utils/user-ip-address')
 const humps = require('humps')
+const lodash = require('lodash')
 
-const logselectedPayloadProperties = req => {
-  const selectedPayloadProperties = {}
+const logSelectedPayloadProperties = req => {
   const payload = req.body
 
-  if (payload.paymentResponse && payload.paymentResponse.details
-    && payload.paymentResponse.details.paymentMethodData && payload.paymentResponse.details.paymentMethodData.info) {
-    selectedPayloadProperties.paymentResponse = {}
-    selectedPayloadProperties.paymentResponse.details = {}
-    selectedPayloadProperties.paymentResponse.details.paymentMethodData = {}
-    selectedPayloadProperties.paymentResponse.details.paymentMethodData.info = {}
+  const selectedPayloadProperties = lodash.pick(payload, [
+    'worldpay3dsFlexDdcResult',
+    'paymentResponse.payerName',
+    'paymentResponse.payerEmail',
+    'paymentResponse.details.paymentMethodData.info.cardDetails',
+    'paymentResponse.details.paymentMethodData.info.cardNetwork'
+  ])
 
-    if ('cardDetails' in payload.paymentResponse.details.paymentMethodData.info) {
-      selectedPayloadProperties.paymentResponse.details.paymentMethodData.info.cardDetails = output(payload.paymentResponse.details.paymentMethodData.info.cardDetails)
-    }
-
-    if ('cardNetwork' in payload.paymentResponse.details.paymentMethodData.info) {
-      selectedPayloadProperties.paymentResponse.details.paymentMethodData.info.cardNetwork = output(payload.paymentResponse.details.paymentMethodData.info.cardNetwork)
-    }
-
-    if ('payerName' in payload.paymentResponse) {
-      selectedPayloadProperties.paymentResponse.payerName = redact(payload.paymentResponse.payerName)
-    }
-
-    if ('payerEmail' in payload.paymentResponse) {
-      selectedPayloadProperties.paymentResponse.payerEmail = redact(payload.paymentResponse.payerEmail)
-    }
-
-    if ('worldpay3dsFlexDdcResult' in payload) {
-      selectedPayloadProperties.worldpay3dsFlexDdcResult = redact(payload.worldpay3dsFlexDdcResult)
-    }
+  if (lodash.has(payload, 'worldpay3dsFlexDdcResult')) {
+    selectedPayloadProperties.worldpay3dsFlexDdcResult = redact(payload.worldpay3dsFlexDdcResult)
+  }
+  if (lodash.has(payload, 'paymentResponse.payerName')) {
+    selectedPayloadProperties.paymentResponse.payerName = redact(payload.paymentResponse.payerName)
+  }
+  if (lodash.has(payload, 'paymentResponse.payerEmail')) {
+    selectedPayloadProperties.paymentResponse.payerEmail = redact(payload.paymentResponse.payerEmail)
+  }
+  if (lodash.has(payload, 'paymentResponse.details.paymentMethodData.info.cardDetails')) {
+    selectedPayloadProperties.paymentResponse.details.paymentMethodData.info.cardDetails = output(payload.paymentResponse.details.paymentMethodData.info.cardDetails)
+  }
+  if (lodash.has(payload, 'paymentResponse.details.paymentMethodData.info.cardNetwork')) {
+    selectedPayloadProperties.paymentResponse.details.paymentMethodData.info.cardNetwork = output(payload.paymentResponse.details.paymentMethodData.info.cardNetwork)
   }
 
   logger.info('Received Google Pay payload', {
@@ -80,7 +76,7 @@ const nullable = word => {
 }
 
 module.exports = req => {
-  logselectedPayloadProperties(req)
+  logSelectedPayloadProperties(req)
 
   const payload = req.body
 


### PR DESCRIPTION
## WHAT
- We currently log info about GooglePay payload only if all info we use is available.
      So updated to log if any field we use is available in the payload.
- Also simplifies handling properties
