### PR TITLE
PP-10278 Throw error if card brand is not available in Google Pay payload

### DIFF
--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -41,6 +41,10 @@ const logSelectedPayloadProperties = req => {
 }
 
 const normaliseCardName = cardName => {
+  if (!cardName) {
+    throw new Error('Card brand is not available in Google Pay payload')
+  }
+
   switch (cardName) {
     case 'MASTERCARD':
       return 'master-card'
@@ -81,8 +85,8 @@ module.exports = req => {
   const payload = req.body
 
   const paymentInfo = {
-    last_digits_card_number: normaliseLastDigitsCardNumber(payload.paymentResponse.details.paymentMethodData.info.cardDetails),
-    brand: normaliseCardName(payload.paymentResponse.details.paymentMethodData.info.cardNetwork),
+    last_digits_card_number: normaliseLastDigitsCardNumber(lodash.get(payload, 'paymentResponse.details.paymentMethodData.info.cardDetails', '')),
+    brand: normaliseCardName(lodash.get(payload, 'paymentResponse.details.paymentMethodData.info.cardNetwork', '')),
     cardholder_name: nullable(payload.paymentResponse.payerName || ''),
     email: nullable(payload.paymentResponse.payerEmail || ''),
     worldpay_3ds_flex_ddc_result: nullable(payload.worldpay3dsFlexDdcResult || ''),

--- a/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
+++ b/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
@@ -122,6 +122,35 @@ describe('normalise Google Pay payload', () => {
     })).to.throw('Unrecognised card brand in Google Pay payload: UnSupportedCard')
   })
 
+  it('should throw error if card brand is not available', () => {
+    const googlePayPayload = {
+      paymentResponse: {
+        details: {
+          apiVersionMinor: 0,
+          apiVersion: 2,
+          paymentMethodData: {
+            description: 'UnSupported card •••• 4242',
+            info: {
+              cardDetails: '4242'
+            },
+            tokenizationData: {
+              type: 'PAYMENT_GATEWAY',
+              token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+            },
+            type: 'CARD'
+          }
+        },
+        payerEmail: 'name@email.test',
+        payerName: 'Some Name'
+      }
+    }
+
+    expect(() => normalise({
+      headers: headers,
+      body: googlePayPayload
+    })).to.throw('Card brand is not available in Google Pay payload')
+  })
+
   it('should return the correct format for the payload with min data', () => {
     const googlePayPayload = {
       paymentResponse: {


### PR DESCRIPTION
## WHAT

- For some Google Pay payments, `paymentMethodData.info` is not available in the payload and so is the card brand.
- It is causing unchecked exceptions with the error `TypeError: Cannot read properties of undefined (reading 'info')`.
- Throw error if card_brand is not available in the payload as it is mandatory.

