### PR TITLE
ZD-5142738: Bump pay-js-commons with npm upgrade pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-crypto/decrypt-node": "^1.0.3",
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-        "@govuk-pay/pay-js-commons": "^3.8.2",
+        "@govuk-pay/pay-js-commons": "^3.8.3",
         "@sentry/node": "7.29.0",
         "body-parser": "1.20.x",
         "cert-info": "^1.5.1",
@@ -59,7 +59,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-string": "^1.4.0",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "7.7.0",
         "dotenv": "^16.0.3",
         "envfile": "^5.2.0",
@@ -1928,29 +1928,18 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.2.tgz",
-      "integrity": "sha512-Ezpex31o5tcdQsy7jyBif4HPFUPnNRBUpt8N55/sDcaUA/QQ9wozT2nwYXYF6XwkW4cRrJL6DnrMxy0IGIFFjg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.3.tgz",
+      "integrity": "sha512-eToZ6HDyneXHYld3YrjEMQLzfYrqDwP9/JAP0auZudjA87BVCVu9LnMqAmnbFrokqajiP0kPQ2xDJ37CBLn8rw==",
       "dependencies": {
         "lodash": "4.17.21",
-        "moment-timezone": "0.5.38",
+        "moment-timezone": "0.5.40",
         "rfc822-validate": "1.0.0",
         "slugify": "1.6.5",
         "winston": "3.8.2"
       },
       "engines": {
         "node": "^16.14.0"
-      }
-    },
-    "node_modules/@govuk-pay/pay-js-commons/node_modules/moment-timezone": {
-      "version": "0.5.38",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.38.tgz",
-      "integrity": "sha512-nMIrzGah4+oYZPflDvLZUgoVUO4fvAqHstvG3xAUnMolWncuAiLDWNnJZj6EwJGMGfb1ZcuTFE6GI3hNOVWI/Q==",
-      "dependencies": {
-        "moment": ">= 2.9.0"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@hapi/bourne": {
@@ -20289,25 +20278,15 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.2.tgz",
-      "integrity": "sha512-Ezpex31o5tcdQsy7jyBif4HPFUPnNRBUpt8N55/sDcaUA/QQ9wozT2nwYXYF6XwkW4cRrJL6DnrMxy0IGIFFjg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.3.tgz",
+      "integrity": "sha512-eToZ6HDyneXHYld3YrjEMQLzfYrqDwP9/JAP0auZudjA87BVCVu9LnMqAmnbFrokqajiP0kPQ2xDJ37CBLn8rw==",
       "requires": {
         "lodash": "4.17.21",
-        "moment-timezone": "0.5.38",
+        "moment-timezone": "0.5.40",
         "rfc822-validate": "1.0.0",
         "slugify": "1.6.5",
         "winston": "3.8.2"
-      },
-      "dependencies": {
-        "moment-timezone": {
-          "version": "0.5.38",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.38.tgz",
-          "integrity": "sha512-nMIrzGah4+oYZPflDvLZUgoVUO4fvAqHstvG3xAUnMolWncuAiLDWNnJZj6EwJGMGfb1ZcuTFE6GI3hNOVWI/Q==",
-          "requires": {
-            "moment": ">= 2.9.0"
-          }
-        }
       }
     },
     "@hapi/bourne": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "^3.8.2",
+    "@govuk-pay/pay-js-commons": "^3.8.3",
     "@sentry/node": "7.29.0",
     "body-parser": "1.20.x",
     "cert-info": "^1.5.1",


### PR DESCRIPTION
## WHAT
Update pay-js-commons in package-lock.json and then ran npm upgrade pay-js-commons.


