### PR TITLE
ZD-5142783: Bump pay-js-commons to 3.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-crypto/decrypt-node": "^1.0.3",
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-        "@govuk-pay/pay-js-commons": "^3.8.4",
+        "@govuk-pay/pay-js-commons": "^3.8.5",
         "@sentry/node": "7.29.0",
         "body-parser": "1.20.x",
         "cert-info": "^1.5.1",
@@ -1928,9 +1928,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.4.tgz",
-      "integrity": "sha512-WRcu1GzXDjv+lWNJHPuqLBvZnnt3re0H0v9yj2BWq49peleuu9DIpJFLA/zjpdaN8tdjuTL/CNNNqm9eWptV5Q==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.5.tgz",
+      "integrity": "sha512-oRICWXwwcatw/itGHS+gOznM7BLyY/P8hFZtk5Xyry9DHNmfQCp8siOpc+aG/qhk4BCKf8NoqBLGxlvERq1beg==",
       "dependencies": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.40",
@@ -20278,9 +20278,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.4.tgz",
-      "integrity": "sha512-WRcu1GzXDjv+lWNJHPuqLBvZnnt3re0H0v9yj2BWq49peleuu9DIpJFLA/zjpdaN8tdjuTL/CNNNqm9eWptV5Q==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.5.tgz",
+      "integrity": "sha512-oRICWXwwcatw/itGHS+gOznM7BLyY/P8hFZtk5Xyry9DHNmfQCp8siOpc+aG/qhk4BCKf8NoqBLGxlvERq1beg==",
       "requires": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.40",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "^3.8.4",
+    "@govuk-pay/pay-js-commons": "^3.8.5",
     "@sentry/node": "7.29.0",
     "body-parser": "1.20.x",
     "cert-info": "^1.5.1",


### PR DESCRIPTION
Pulls in additional custom branding updates.
