### PR TITLE
PP-10242 Product page > Privacy Page - bump product page npm module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "nock": "13.2.9",
         "nodemon": "^2.0.20",
         "nyc": "15.1.x",
-        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.12/pay-product-page-4.12.12.tgz",
+        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.13/pay-product-page-4.12.13.tgz",
         "proxyquire": "~2.1.3",
         "sass": "^1.57.0",
         "sinon": "15.0.x",
@@ -13636,9 +13636,9 @@
       }
     },
     "node_modules/pay-product-page": {
-      "version": "4.12.12",
-      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.12.12/pay-product-page-4.12.12.tgz",
-      "integrity": "sha512-duXpi2wOjQBERXOLqFysZcC+bEZTBGkUP+4J5FajNlyT2RaTCQJxE2nhoLlSYvRmUcBTUirYY7b1v+VFPJNVEQ==",
+      "version": "4.12.13",
+      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.12.13/pay-product-page-4.12.13.tgz",
+      "integrity": "sha512-WN6N9UPms3RhIIkowlMz2X8b05mdZzynpRCSdvBA5WxsIWsmDCcrjoEHoQiztdMUjAuM0haIoTdapB+XMSPlBA==",
       "dev": true
     },
     "node_modules/pbkdf2": {
@@ -29434,8 +29434,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.12.12/pay-product-page-4.12.12.tgz",
-      "integrity": "sha512-duXpi2wOjQBERXOLqFysZcC+bEZTBGkUP+4J5FajNlyT2RaTCQJxE2nhoLlSYvRmUcBTUirYY7b1v+VFPJNVEQ==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.12.13/pay-product-page-4.12.13.tgz",
+      "integrity": "sha512-WN6N9UPms3RhIIkowlMz2X8b05mdZzynpRCSdvBA5WxsIWsmDCcrjoEHoQiztdMUjAuM0haIoTdapB+XMSPlBA==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "nock": "13.2.9",
     "nodemon": "^2.0.20",
     "nyc": "15.1.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.12/pay-product-page-4.12.12.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.13/pay-product-page-4.12.13.tgz",
     "proxyquire": "~2.1.3",
     "sass": "^1.57.0",
     "sinon": "15.0.x",


### PR DESCRIPTION
- This will enable the latest content for the `product pages > privacy page`.


