### PR TITLE
BAU bump product pages 4.12.20 -> 4.12.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "nock": "13.3.0",
         "nodemon": "^2.0.20",
         "nyc": "15.1.x",
-        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.20/pay-product-page-4.12.20.tgz",
+        "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.21/pay-product-page-4.12.21.tar",
         "proxyquire": "~2.1.3",
         "sass": "^1.58.0",
         "sinon": "15.0.x",
@@ -13651,9 +13651,9 @@
       }
     },
     "node_modules/pay-product-page": {
-      "version": "4.12.20",
-      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.12.20/pay-product-page-4.12.20.tgz",
-      "integrity": "sha512-2pcVXL1TqMIOMPIZYgV4RnWVjarRbxF3xA0jvsVZXY5IxHIVFSSvIoIfmItMuqa/Y2MwtSlotnQ13kKhf/mUvA==",
+      "version": "4.12.21",
+      "resolved": "https://github.com/alphagov/pay-product-page/releases/download/4.12.21/pay-product-page-4.12.21.tar",
+      "integrity": "sha512-AMoZ9jZ3F9v8vU2sKUUXPOnDGT6DwSBU4hOo3isIbpsGWtBIxtgkgyod0IaHLPpqjXtrgKSaMAE7cfw71VHboQ==",
       "dev": true
     },
     "node_modules/pbkdf2": {
@@ -29458,8 +29458,8 @@
       "dev": true
     },
     "pay-product-page": {
-      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.12.20/pay-product-page-4.12.20.tgz",
-      "integrity": "sha512-2pcVXL1TqMIOMPIZYgV4RnWVjarRbxF3xA0jvsVZXY5IxHIVFSSvIoIfmItMuqa/Y2MwtSlotnQ13kKhf/mUvA==",
+      "version": "https://github.com/alphagov/pay-product-page/releases/download/4.12.21/pay-product-page-4.12.21.tar",
+      "integrity": "sha512-AMoZ9jZ3F9v8vU2sKUUXPOnDGT6DwSBU4hOo3isIbpsGWtBIxtgkgyod0IaHLPpqjXtrgKSaMAE7cfw71VHboQ==",
       "dev": true
     },
     "pbkdf2": {

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "nock": "13.3.0",
     "nodemon": "^2.0.20",
     "nyc": "15.1.x",
-    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.20/pay-product-page-4.12.20.tgz",
+    "pay-product-page": "https://github.com/alphagov/pay-product-page/releases/download/4.12.21/pay-product-page-4.12.21.tar",
     "proxyquire": "~2.1.3",
     "sass": "^1.58.0",
     "sinon": "15.0.x",


### PR DESCRIPTION
## WHAT

- bump product-pages `4.12.20` -> `4.12.21`

Archive extension has changed to `.tar`, this is an intentional change.


