### PR TITLE
PP-10839 Update `frontend` csp re google pay changes

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -43,8 +43,8 @@ if (allowUnsafeEvalScripts) {
   scriptSourceCardDetails.push("'unsafe-eval'")
 }
 
-// Google analytics, Google pay uses standard Payment Request API so requires no exceptions
-const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com']
+// Google Analytics, Google Pay
+const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com', 'https://google.com/pay']
 
 const skipSendingCspHeader = (req, res, next) => { next() }
 


### PR DESCRIPTION
## WHAT

- google recently updated guidance for payment handler api usage, we now need to ensure the domains of HTTP requests sent from the browser are added to the connect-src directive
- see this blog post for more information: https://developer.chrome.com/blog/payment-handler-csp-connect-src


