### PR TITLE
PP-10839 Include Google Pay cross origin redirect in CSP

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -44,7 +44,7 @@ if (allowUnsafeEvalScripts) {
 }
 
 // Google Analytics, Google Pay
-const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com', 'https://google.com/pay']
+const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com', 'https://google.com/pay', 'https://pay.google.com']
 
 const skipSendingCspHeader = (req, res, next) => { next() }
 


### PR DESCRIPTION
When a domain included in the content security policy results in a cross-origin redirect, the redirected resource also needs to be included in the policy to allow the connection.

We've seen Google Pay payments work since updating the CSP to allow `google.com/pay` however we're continuing to see CSP violations. If we're continuing to block connects we may see Google Pay payment continue to silently fail, include the redirect address to allow connection to both.

Relates to https://github.com/alphagov/pay-frontend/pull/3368

