### PR TITLE
BAU: Remove Docker dependabot version restrictions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,15 +56,6 @@ updates:
   - govuk-pay
   - dependencies
   - docker
-  ignore:
-  - dependency-name: node
-    versions:
-    - ">= 14.a"
-    - "< 15"
-  - dependency-name: node
-    versions:
-    - ">= 15.a"
-    - "< 16"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
## WHAT

We are now firmly on node16 so the old 'ignore' config for node14/15 is no longer needed. This old config also might be the reason Dependabot is not providing updates for Node base images - the `pay-stream-s3-sqs` repo has the same Dockerfile setup but no Dependabot restrictions, and the updates are appearing as expected (see https://github.com/alphagov/pay-stream-s3-sqs/pull/579 for example).

We may need to put in a new ignore to stop Dependabot trying to bump us to node18, but that doesn't seem to have happened on `pay-stream-s3-sqs` yet.

