### PR TITLE
BAU: Dependabot ignore Node v18+

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,7 @@ updates:
 - package-ecosystem: docker
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
     time: "03:00"
   ignore:
   - dependency-name: "node"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,10 @@ updates:
   schedule:
     interval: weekly
     time: "03:00"
+  ignore:
+  - dependency-name: "node"
+    versions:
+    - ">= 18"
   open-pull-requests-limit: 10
   labels:
   - govuk-pay


### PR DESCRIPTION
## WHAT
We don't want Dependabot to attempt to bump the major version of the Node base image above v16.

Also changes the checking schedule to daily - if there's a security patch we want it ASAP (not sure why it was weekly to begin with...).

