### PR TITLE
PP-10887 Add novalidate to all forms

### DIFF
--- a/app/assets/iframe/worldpay-3ds-flex-ddc.html
+++ b/app/assets/iframe/worldpay-3ds-flex-ddc.html
@@ -6,7 +6,7 @@
     <meta name="robots" content="noindex, nofollow">
   </head>
   <body>
-    <form id="collectionForm" name="devicedata" method="POST" action="">
+    <form id="collectionForm" name="devicedata" method="POST" action="" novalidate>
       <input type="hidden" id="input-bin" name="Bin" value="">
       <input type="hidden" id="input-jwt" name="JWT" value="">
     </form>

--- a/app/views/auth-3ds-required-in.njk
+++ b/app/views/auth-3ds-required-in.njk
@@ -7,7 +7,7 @@
 <noscript>
     <p class="govuk-body-l lede">{{ __p("authorisation.approved") }}</p>
 </noscript>
-<form name="three_ds_required" method="post" action="{{ threeDsHandlerUrl }}" target="_top">
+<form name="three_ds_required" method="post" action="{{ threeDsHandlerUrl }}" target="_top" novalidate>
     {% if paResponse %}
         <input type="hidden" name="PaRes" value="{{ paResponse }}"/>
     {% endif %}

--- a/app/views/auth-3ds-required-out.njk
+++ b/app/views/auth-3ds-required-out.njk
@@ -7,7 +7,7 @@
 <noscript>
   <p class="govuk-body-l lede">{{ __p("authorisation.approvalNeeded") }}</p>
 </noscript>
-<form name="three_ds_required" method="post" action="{{ postUrl }}">
+<form name="three_ds_required" method="post" action="{{ postUrl }}" novalidate>
   {% if paRequest %}
   <input type="hidden" name="PaReq" value="{{ paRequest }}"/>
   {% endif %}

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -102,7 +102,7 @@
                 <span class="govuk-visually-hidden">Apple Pay</span>
                 {% endset %}
 
-                <form class="govuk-!-width-three-quarters web-payments-container">
+                <form class="govuk-!-width-three-quarters web-payments-container" novalidate>
                   <input type="hidden" name="payment-method" value="Apple Pay"/>
                   {{
                     govukButton({
@@ -126,7 +126,7 @@
                   <img class="google-pay-image" src="/images/google-pay-logo.svg" alt="Google Pay">
                 {% endset %}
 
-                <form class="govuk-!-width-three-quarters web-payments-container">
+                <form class="govuk-!-width-three-quarters web-payments-container" novalidate>
                   <input type="hidden" name="payment-method" value="Google Pay"/>
                   {{
                     govukButton({
@@ -579,7 +579,7 @@
                   {% endif %}
                 </div>
               </form>
-              <form id="cancel" name="cancel" method="POST" action="{{ post_cancel_action }}" class="form">
+              <form id="cancel" name="cancel" method="POST" action="{{ post_cancel_action }}" class="form" novalidate>
                 <div>
                   <input id="cancel-payment" type="submit" class="button-reset" value="{{ __p("commonButtons.cancelButton") }}" name="cancel">
                   <input id="csrf2" name="csrfToken" type="hidden" value="{{ csrf }}"/>

--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -115,7 +115,7 @@
               })
             }}
 
-          <form id="confirmation" method="POST" action="{{ confirmPath }}" class="form">
+          <form id="confirmation" method="POST" action="{{ confirmPath }}" class="form" novalidate>
             <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
             <input id="chargeId" name="chargeId" type="hidden" value="{{ charge.id }}"/>
             {% set confirmButtonHTML %}
@@ -132,7 +132,7 @@
             }}
           </form>
 
-          <form id="cancel" name="cancel" method="POST" action="{{ post_cancel_action }}" class="form">
+          <form id="cancel" name="cancel" method="POST" action="{{ post_cancel_action }}" class="form" novalidate>
             <div>
               <input id="cancel-payment" type="submit" class="button-reset" value="{{ __p("commonButtons.cancelButton") }}" name="cancel">
               <input id="csrf2" name="csrfToken" type="hidden" value="{{ csrf }}"/>


### PR DESCRIPTION
Add a `novalidate` attribute to all `form` elements to disable built-in HTML5 browser client-side validation.

The Design System says to do this at https://design-system.service.gov.uk/patterns/validation/:

> HTML5 validation is a type of client side validation built into browsers. Do not use it because:
> 
> • the visual style, placement and content of HTML5 error messages cannot be made consistent with the GOV.UK Design System
> • we know that the GOV.UK Design System error message and error summary components are accessible
> 
> To turn off HTML5 validation, add ‘novalidate’ to your form tags.

Strictly speaking, this only needs to be done for forms that contain validatable fields (and all the ones in frontend seem to have this attribute already) but it’s easiest just to add it to all `form` elements.