### PR TITLE
PP-10947 Remove `body-parser` NPM module and replace with Express functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
         "@govuk-pay/pay-js-commons": "^3.8.11",
         "@sentry/node": "7.51.2",
-        "body-parser": "1.20.x",
         "cert-info": "^1.5.1",
         "change-case": "2.3.x",
         "chokidar": "^3.5.3",
@@ -3447,6 +3446,7 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
       "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -3470,6 +3470,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3477,7 +3478,8 @@
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
     },
     "node_modules/body/node_modules/bytes": {
       "version": "1.0.0",
@@ -13464,6 +13466,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -20388,6 +20391,7 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
       "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "dev": true,
       "requires": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -20407,6 +20411,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -20414,7 +20419,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "dev": true
         }
       }
     },
@@ -28192,6 +28198,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
       "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
     "@govuk-pay/pay-js-commons": "^3.8.11",
     "@sentry/node": "7.51.2",
-    "body-parser": "1.20.x",
     "cert-info": "^1.5.1",
     "change-case": "2.3.x",
     "chokidar": "^3.5.3",

--- a/server.js
+++ b/server.js
@@ -6,7 +6,6 @@ const crypto = require('crypto')
 const express = require('express')
 const nunjucks = require('nunjucks')
 const favicon = require('serve-favicon')
-const bodyParser = require('body-parser')
 const i18n = require('i18n')
 const staticify = require('staticify')(path.join(__dirname, 'public'))
 const compression = require('compression')
@@ -69,8 +68,8 @@ function initialiseGlobalMiddleware (app) {
     next()
   })
 
-  app.use(bodyParser.json())
-  app.use(bodyParser.urlencoded({ extended: true }))
+  app.use(express.json())
+  app.use(express.urlencoded())
 
   app.use(compression())
 


### PR DESCRIPTION
- Good article about this here: https://medium.com/@mmajdanski/express-body-parser-and-why-may-not-need-it-335803cd048c
- We are using a new version of Express, which means we no longer need the `body-parser` module.
  - We can use Express's built functions to replace what `body-parser`
  - Express's functions are based on the code from `body-parser`


