### PR TITLE
PP-10947 Update deprecated `express.urlencoded`

### DIFF
--- a/server.js
+++ b/server.js
@@ -69,7 +69,7 @@ function initialiseGlobalMiddleware (app) {
   })
 
   app.use(express.json())
-  app.use(express.urlencoded())
+  app.use(express.urlencoded({ extended: true }))
 
   app.use(compression())
 


### PR DESCRIPTION
- When removing the `body-parser` NPM module, switched to using the Express functions instead.
- However, we need to update how we call `express.urlencoded`.  As we were getting deprecation warnings.
- Function call has been updated to explicitely set the `extended: true` option.
  - This removes the deprecation warnings.
- More information about this here: https://stackoverflow.com/questions/25471856/express-throws-error-as-body-parser-deprecated-undefined-extended

