### PR TITLE
PP-11082 Update google pay CSP to include www subdomain

### DIFF
--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -44,7 +44,7 @@ if (allowUnsafeEvalScripts) {
 }
 
 // Google Analytics, Google Pay
-const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com', 'https://google.com/pay', 'https://pay.google.com']
+const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com', 'https://google.com/pay', 'https://www.google.com/pay', 'https://pay.google.com']
 
 const skipSendingCspHeader = (req, res, next) => { next() }
 


### PR DESCRIPTION
We're seeing CSP rule violations for Google Pay, starting on Friday 26th May and ramping up Tuesday 30th May. Investigating this it looks like Google is now trying to connect to the `www.` subdomain rather than the previously used `google.com`. This observation doesn't come from an official source so we should see reason about if it resolves the issue before locking in the change.

Relates to https://github.com/alphagov/pay-frontend/pull/3370
