### PR TITLE
PP-10966 Fix bugs with inline expiry date validation

### DIFF
--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -160,11 +160,7 @@ var init = function () {
 
     var validation = validationFor(validationName)
 
-    if (validation) {
-      input.classList.add('govuk-input--error')
-    } else {
-      input.classList.remove('govuk-input--error')
-    }
+    toggleErrorCssClassOnField(validation, input)
 
     if (input === cardInput) {
       checkCardType(validation, formGroup)
@@ -172,6 +168,32 @@ var init = function () {
     }
 
     replaceOnError(validation, formGroup)
+  }
+
+  var toggleErrorCssClassOnField = function (validation, input) {
+    var CSS_ERROR_CLASS = 'govuk-input--error'
+    var EXPIRY_MONTH_ELEMENT_ID = 'expiry-month'
+    var EXPIRY_YEAR_ELEMENT_ID = 'expiry-year'
+    var expiryMonthElement = document.getElementById('expiry-month')
+    var expiryYearElement = document.getElementById('expiry-year')
+
+    var isAnExpiryDateField = (input.id === EXPIRY_MONTH_ELEMENT_ID) || (input.id === EXPIRY_YEAR_ELEMENT_ID)
+
+    if (validation) {
+      if (isAnExpiryDateField) {
+        expiryMonthElement.classList.add(CSS_ERROR_CLASS)
+        expiryYearElement.classList.add(CSS_ERROR_CLASS)
+      } else {
+        input.classList.add(CSS_ERROR_CLASS)
+      }
+    } else {
+      if (isAnExpiryDateField) {
+        expiryMonthElement.classList.remove(CSS_ERROR_CLASS)
+        expiryYearElement.classList.remove(CSS_ERROR_CLASS)
+      } else {
+        input.classList.remove(CSS_ERROR_CLASS)
+      }
+    }
   }
 
   var checkCardType = function (validation, formGroup) {
@@ -239,17 +261,17 @@ var init = function () {
     var label = formGroup.querySelectorAll('[data-label-replace]')[0]
     if (label.length === 0) return
 
-    var  errorElement = label.parentNode.parentNode.querySelector('.govuk-error-message') 
+    var errorElement = label.parentNode.parentNode.querySelector('.govuk-error-message')
 
     if (validation) {
-      if (errorElement){ 
+      if (errorElement) {
         errorElement.parentNode.removeChild(errorElement)
       }
 
       var errorElementHtml = '<p class="govuk-error-message" role="alert">' + validation + '</p>'
-      label.parentNode.insertAdjacentHTML("afterend", errorElementHtml)
+      label.parentNode.insertAdjacentHTML('afterend', errorElementHtml)
     } else {
-      if (errorElement){
+      if (errorElement) {
         errorElement.parentNode.removeChild(errorElement)
       }
     }

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -250,6 +250,7 @@
                       <label class="govuk-label govuk-date-input__label" for="expiry-month">{{ __p("cardDetails.expiryMonth") }}</label>
                       <input
                   id="expiry-month"
+                  data-cy="expiry-month"
                   type="text"
                   inputmode="numeric"
                   pattern="[0-9]*"
@@ -264,6 +265,7 @@
                       <label for="expiry-year" class="govuk-label govuk-date-input__label">{{ __p("cardDetails.expiryYear") }}</label>
                       <input
                 id="expiry-year"
+                data-cy="expiry-year"
                 type="text"
                 inputmode="numeric"
                 pattern="[0-9]*"
@@ -295,6 +297,7 @@
                   {% endif %}
 
                   <input id="cardholder-name"
+                  data-cy="cardholder-name"
                   type="text"
                   name="cardholderName"
                   maxlength="200"

--- a/test/cypress/integration/card/card-details-page-validation.cy.test.js
+++ b/test/cypress/integration/card/card-details-page-validation.cy.test.js
@@ -31,4 +31,23 @@ describe('Card details page validation', () => {
     cy.get('.address-city-label').should('exist')
     cy.get('.address-postcode-label').should('exist')
   })
+
+  it('Should perform inline validation of the expiry date correctly', () => {
+    cy.task('setupStubs', createPaymentChargeStubs)
+    cy.visit(`/secure/${tokenId}`)
+
+    cy.get('[data-cy=expiry-month]').type('01')
+    cy.get('[data-cy=expiry-year]').type('23')
+    cy.get('[data-cy=cardholder-name]').click()
+    cy.get('[data-cy=expiry-month]').should('have.class', 'govuk-input--error')
+    cy.get('[data-cy=expiry-year]').should('have.class', 'govuk-input--error')
+
+    const nextYearIn2Digits = (new Date().getFullYear() + 1).toString().slice(-2)
+
+    cy.get('[data-cy=expiry-year]').clear().type(nextYearIn2Digits)
+    cy.get('[data-cy=cardholder-name]').click()
+
+    cy.get('[data-cy=expiry-month]').not('have.class', 'govuk-input--error')
+    cy.get('[data-cy=expiry-year]').not('have.class', 'govuk-input--error')
+  })
 })


### PR DESCRIPTION
- Update the expiry date inline validation as follows:
  - Whenever there is an inline error with the expiry date, when the user goes to another field, then it will show a red outline on both the month and year fields.
  - Currently it was only doing it on the year field.
- Add a Cypress test to test this.


