### PR TITLE
PP-10904 Make footer Cypress tests standalone

### DIFF
--- a/test/cypress/integration/card/footer.cy.test.js
+++ b/test/cypress/integration/card/footer.cy.test.js
@@ -6,10 +6,6 @@ describe('The footer displayed on payment pages', () => {
   const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
   const language = 'en'
 
-  beforeEach(() => {
-    Cypress.Cookies.preserveOnce('frontend_state')
-  })
-
   it('should display the service name and address when service has full organisation details', () => {
     // use a unique gateway account id per test as services are cached
     const gatewayAccountId = lodash.random(999999999)


### PR DESCRIPTION
- Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.
- Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.

