### PR TITLE
PP-10904 Make Worldpay Cypress tests standalone

### DIFF
--- a/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js
+++ b/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js
@@ -66,105 +66,54 @@ describe('Worldpay 3ds flex card payment flow', () => {
   const worldpay3dsFlexDdcStub = worldpay3dsFlexDdcIframePost(worldpaySessionId, true)
   const worldpay3dsFlexDdcStubFailure = worldpay3dsFlexDdcIframePost(worldpaySessionId, false)
 
-  beforeEach(() => {
-    // this test is for the full process, the session should be maintained
-    // as it would for an actual payment flow
-    Cypress.Cookies.preserveOnce('frontend_state')
-  })
+  function enterCardPaymentDetails () {
+    cy.log('Should enter and validate a correct card')
 
-  const setUpAndCheckCardPaymentPage = () => {
-    describe('Secure card payment page', () => {
-      it('Should setup the payment and load the page', () => {
-        cy.task('setupStubs', createPaymentChargeStubsEnglish)
-        cy.visit(`/secure/${tokenId}`)
+    cy.task('clearStubs')
+    cy.task('setupStubs', checkCardDetailsStubs)
 
-        // 1. Charge will be created using this id as a token (GET)
-        // 2. Token will be deleted (DELETE)
-        // 3. Charge will be fetched (GET)
-        // 4. Service related to charge will be fetched (GET)
-        // 5. Charge status will be updated (PUT)
-        // 6. Client will be redirected to /card_details/:chargeId (304)
-        cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-      })
+    cy.server()
+    cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
 
-      it('Should enter and validate a correct card', () => {
-        cy.task('setupStubs', checkCardDetailsStubs)
+    cy.get('#card-no').type(validPayment.cardNumber)
+    cy.get('#card-no').blur()
 
-        cy.server()
-        cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+    // 7. Charge status will be fetched (GET)
+    // 8. CardID POST to verify that entered card is correct - this is configured to return valid
+    cy.wait('@checkCard')
+    cy.get('#card-no').should('not.have.class', 'govuk-input--error')
 
-        cy.get('#card-no').type(validPayment.cardNumber)
-        cy.get('#card-no').blur()
+    cy.log('Should enter payment details')
 
-        // 7. Charge status will be fetched (GET)
-        // 8. CardID POST to verify that entered card is correct - this is configured to return valid
-        cy.wait('@checkCard')
-        cy.get('#card-no').should('not.have.class', 'govuk-input--error')
-      })
-
-      it('Should enter payment details', () => {
-        cy.get('#expiry-month').type(validPayment.expiryMonth)
-        cy.get('#expiry-year').type(validPayment.expiryYear)
-        cy.get('#cardholder-name').type(validPayment.name)
-        cy.get('#cvc').type(validPayment.securityCode)
-        cy.get('#address-line-1').type(validPayment.addressLine1)
-        cy.get('#address-city').type(validPayment.city)
-        cy.get('#address-postcode').type(validPayment.postcode)
-        cy.get('#email').type(validPayment.email)
-      })
-    })
+    cy.get('#expiry-month').type(validPayment.expiryMonth)
+    cy.get('#expiry-year').type(validPayment.expiryYear)
+    cy.get('#cardholder-name').type(validPayment.name)
+    cy.get('#cvc').type(validPayment.securityCode)
+    cy.get('#address-line-1').type(validPayment.addressLine1)
+    cy.get('#address-city').type(validPayment.city)
+    cy.get('#address-postcode').type(validPayment.postcode)
+    cy.get('#email').type(validPayment.email)
   }
 
-  const setUpAndCheckCardPaymentPageWithGooglePay = () => {
-    describe('Secure card payment page', () => {
-      it('Setup Google Pay', () => {
-        cy.task('setupStubs', createGooglePayPaymentChargeStubsEnglish)
-        cy.visit(`/card_details/${chargeId}`, {
-          onBeforeLoad: win => {
-            // Stub Payment Request API
-            if (win.PaymentRequest) {
-              // If we’re running in headed mode
-              cy.stub(win, 'PaymentRequest', getMockPaymentRequest(validGooglePayment))
-            } else {
-              // else headless
-              win.PaymentRequest = getMockPaymentRequest(validGooglePayment)
-            }
-          }
-        })
-      })
-
-      it('Should enter and validate a correct card', () => {
-        cy.task('setupStubs', checkCardDetailsStubs)
-
-        cy.server()
-        cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
-
-        cy.get('#card-no').type(validPayment.cardNumber)
-        cy.get('#card-no').blur()
-
-        // 7. Charge status will be fetched (GET)
-        // 8. CardID POST to verify that entered card is correct - this is configured to return valid
-        cy.wait('@checkCard')
-        cy.get('#card-no').should('not.have.class', 'govuk-input--error')
-      })
-
-      it('Should enter payment details', () => {
-        cy.get('#expiry-month').type(validPayment.expiryMonth)
-        cy.get('#expiry-year').type(validPayment.expiryYear)
-        cy.get('#cardholder-name').type(validPayment.name)
-        cy.get('#cvc').type(validPayment.securityCode)
-        cy.get('#address-line-1').type(validPayment.addressLine1)
-        cy.get('#address-city').type(validPayment.city)
-        cy.get('#address-postcode').type(validPayment.postcode)
-        cy.get('#email').type(validPayment.email)
-      })
-    })
-  }
-
-  setUpAndCheckCardPaymentPage()
   describe('Valid DDC response', () => {
-    it('Form is submitted with the session ID from the DDC response', () => {
+    it('Should submit the payment form with the session ID from a valid DDC response', () => {
+      cy.task('setupStubs', createPaymentChargeStubsEnglish)
+      cy.visit(`/secure/${tokenId}`)
+
+      // 1. Charge will be created using this id as a token (GET)
+      // 2. Token will be deleted (DELETE)
+      // 3. Charge will be fetched (GET)
+      // 4. Service related to charge will be fetched (GET)
+      // 5. Charge status will be updated (PUT)
+      // 6. Client will be redirected to /card_details/:chargeId (304)
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+
+      enterCardPaymentDetails()
+
+      cy.task('clearStubs')
       cy.task('setupStubs', [...confirmPaymentDetailsStubs, worldpay3dsFlexDdcStub])
+
+      cy.log('Should submit form with the session ID from the DDC response')
 
       cy.get('#card-details').submit().should($form => {
         const formVal = $form.first()[0].elements.worldpay3dsFlexDdcResult.value
@@ -175,9 +124,22 @@ describe('Worldpay 3ds flex card payment flow', () => {
     })
   })
 
-  setUpAndCheckCardPaymentPage()
   describe('Worldpay responds with status=false', () => {
-    it('submitting confirmation should not include the hidden input containing the session ID', () => {
+    it('Should not include the hidden input containing the session ID when submitting confirmation ', () => {
+      cy.task('setupStubs', createPaymentChargeStubsEnglish)
+      cy.visit(`/secure/${tokenId}`)
+
+      // 1. Charge will be created using this id as a token (GET)
+      // 2. Token will be deleted (DELETE)
+      // 3. Charge will be fetched (GET)
+      // 4. Service related to charge will be fetched (GET)
+      // 5. Charge status will be updated (PUT)
+      // 6. Client will be redirected to /card_details/:chargeId (304)
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+
+      enterCardPaymentDetails()
+
+      cy.task('clearStubs')
       cy.task('setupStubs', [...confirmPaymentDetailsStubs, worldpay3dsFlexDdcStubFailure])
 
       cy.get('#card-details').submit().should($form => {
@@ -189,13 +151,30 @@ describe('Worldpay 3ds flex card payment flow', () => {
     })
   })
 
-  setUpAndCheckCardPaymentPage()
   describe('DDC times out', () => {
-    it('iframe post should still submit the form but without the worldpaySessionId', () => {
+    it('Should submit the form from the iframe post without the worldpaySessionId ', () => {
+      cy.log('Should setup a standard payment page')
+
+      cy.task('setupStubs', createPaymentChargeStubsEnglish)
+      cy.visit(`/secure/${tokenId}`)
+
+      // 1. Charge will be created using this id as a token (GET)
+      // 2. Token will be deleted (DELETE)
+      // 3. Charge will be fetched (GET)
+      // 4. Service related to charge will be fetched (GET)
+      // 5. Charge status will be updated (PUT)
+      // 6. Client will be redirected to /card_details/:chargeId (304)
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+
+      enterCardPaymentDetails()
+
       const confirmPaymentDetailsStubsPop = _.cloneDeep(confirmPaymentDetailsStubs)
       confirmPaymentDetailsStubsPop.pop()
 
+      cy.task('clearStubs')
       cy.task('setupStubs', confirmPaymentDetailsStubs)
+
+      cy.log('Should submit the form from the iframe post but without the worldpaySessionId')
 
       cy.get('#card-details').submit().should($form => {
         const formVal = $form.first()[0].elements.worldpay3dsFlexDdcResult
@@ -204,11 +183,43 @@ describe('Worldpay 3ds flex card payment flow', () => {
     })
   })
 
-  setUpAndCheckCardPaymentPageWithGooglePay()
-  describe('Web payment text is not displayed on DDC spinner screen', () => {
-    it('iframe post should still submit the form but without the worldpaySessionId', () => {
+  describe('DDC times out when Google pay is an option', () => {
+    it('Should submit the form from the iframe post without the worldpaySessionId when Google pay option is present', () => {
+      cy.log('Should setup a Google pay payment page')
+
+      cy.task('setupStubs', createGooglePayPaymentChargeStubsEnglish)
+
+      cy.visit(`/secure/${tokenId}`, {
+        onBeforeLoad: win => {
+          // Stub Payment Request API
+          if (win.PaymentRequest) {
+            // If we’re running in headed mode
+            cy.stub(win, 'PaymentRequest', getMockPaymentRequest(validGooglePayment))
+          } else {
+            // else headless
+            win.PaymentRequest = getMockPaymentRequest(validGooglePayment)
+          }
+        }
+      })
+
+      // 1. Charge will be created using this id as a token (GET)
+      // 2. Token will be deleted (DELETE)
+      // 3. Charge will be fetched (GET)
+      // 4. Service related to charge will be fetched (GET)
+      // 5. Charge status will be updated (PUT)
+      // 6. Client will be redirected to /card_details/:chargeId (304)
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+
+      enterCardPaymentDetails()
+
+      cy.task('clearStubs')
       cy.task('setupStubs', confirmPaymentDetailsStubs)
+
+      cy.log('Should submit the form from the iframe post but without the worldpaySessionId')
+
       cy.get('#card-details').submit()
+
+      cy.log('Should hide the web payment text on the DDC spinner screen')
 
       cy.get('.google-pay-container').should('have.attr', 'style', 'display: none;')
       cy.get('.web-payment-button-section').should('have.attr', 'style', 'display: none;')


### PR DESCRIPTION
- Cypress best practices suggest that having tests rely on the state of previous tests is an anti-pattern.
- Combine tests and remove use of Cypress.Cookies.preserveOnce() so that tests can be run independently.


