### PR TITLE
PP-11244 Prepare for changing find charge by token response

### DIFF
--- a/test/cypress/integration/card/awaiting-auth.cy.test.js
+++ b/test/cypress/integration/card/awaiting-auth.cy.test.js
@@ -49,7 +49,6 @@ describe('Awaiting auth', () => {
     cy.get('#address-postcode').type(validPayment.postcode)
     cy.get('#email').type(validPayment.email)
 
-
     const paymentDetails = {
       cardNumber: validPayment.cardNumber,
       expiryMonth: validPayment.expiryMonth,

--- a/test/cypress/integration/card/billing-address-collection.cy.test.js
+++ b/test/cypress/integration/card/billing-address-collection.cy.test.js
@@ -28,7 +28,6 @@ describe('Billing address collection', () => {
         tokenId, chargeId, 'en', gatewayAccountId, serviceOpts, {}, {}, chargeOpts)
 
       it('Should show billing address section and populate with default billing address', () => {
-
         cy.task('setupStubs', createPaymentChargeStubs)
         cy.visit(`/secure/${tokenId}`)
 
@@ -82,7 +81,6 @@ describe('Billing address collection', () => {
       tokenId, chargeId, 'en', gatewayAccountId, serviceOpts, {}, {}, chargeOpts)
 
     it('Should not show the billing address section and allow valid card submission', () => {
-
       cy.task('setupStubs', createPaymentChargeStubs)
       cy.visit(`/secure/${tokenId}`)
 
@@ -94,7 +92,6 @@ describe('Billing address collection', () => {
       cy.get('#address-line-2').should('not.exist')
       cy.get('#address-city').should('not.exist')
       cy.get('#address-postcode').should('not.exist')
-
 
       cy.task('clearStubs')
 

--- a/test/cypress/integration/card/email-typo.cy.test.js
+++ b/test/cypress/integration/card/email-typo.cy.test.js
@@ -127,7 +127,6 @@ describe('Standard card payment flow', () => {
       cy.get('#cardholder-name').should(($td) => expect($td).to.contain(validPayment.name))
       cy.get('#email').should(($td) => expect($td).to.contain(validPayment.email))
 
-
       cy.task('clearStubs')
       cy.task('setupStubs', submitPaymentCaptureStubs)
 

--- a/test/cypress/integration/card/payment.cy.test.js
+++ b/test/cypress/integration/card/payment.cy.test.js
@@ -147,7 +147,6 @@ describe('Standard card payment flow', () => {
       cy.get('#address-postcode').type(validPayment.postcode)
       cy.get('#email').type(validPayment.email)
 
-
       const lastFourCardDigits = validPayment.cardNumber.toString().slice(-4)
 
       cy.task('clearStubs')

--- a/test/fixtures/payment.fixtures.js
+++ b/test/fixtures/payment.fixtures.js
@@ -258,9 +258,7 @@ const fixtures = {
   tokenResponse: (opts = {}) => {
     return {
       used: opts.used,
-      charge: {
-        externalId: opts.chargeExternalId
-      }
+      charge: {}
     }
   },
 

--- a/test/unit/charge.controller.test.js
+++ b/test/unit/charge.controller.test.js
@@ -6,7 +6,7 @@ describe('walletEnabled', () => {
     { walletToggle: true, gatewayAccountId: '1', payTestGatewayAccounts: ['5', '10', '15', '20'], expected: true },
     { walletToggle: false, gatewayAccountId: '1', payTestGatewayAccounts: ['5', '10', '15', '20'], expected: false },
     { walletToggle: false, gatewayAccountId: '15', payTestGatewayAccounts: ['5', '10', '15', '20'], expected: true },
-    { walletToggle: false, gatewayAccountId: '15', payTestGatewayAccounts: [], expected: false },
+    { walletToggle: false, gatewayAccountId: '15', payTestGatewayAccounts: [], expected: false }
   ]
 
   testData.forEach(({ walletToggle, gatewayAccountId, payTestGatewayAccounts, expected }) => {

--- a/test/unit/clients/connector-client-token.pact.test.js
+++ b/test/unit/clients/connector-client-token.pact.test.js
@@ -50,7 +50,7 @@ describe('connector client - tokens', function () {
         tokenId: TOKEN
       })
       expect(res.body.used).to.be.equal(false)
-      expect(res.body.charge.externalId).to.be.equal('chargeExternalId')
+      expect(res.body.charge).to.exist // eslint-disable-line
     })
   })
 })


### PR DESCRIPTION
Want to change the response schema for the connector GET `/v1/frontend/tokens/{chargeTokenId}` endpoint to use the FrontendChargeResponse schema for the embedded charge object in the response, rather than ChargeEntity.

Support both versions of the response temporarily by checking which fields are returned in the response. This will be updated again to remove support for the old response schema after the connector change is made.

This will allow https://github.com/alphagov/pay-connector/pull/4602 to be merged.

