### PR TITLE
PP-11244 Remove handling for old GET token response

### DIFF
--- a/app/controllers/secure.controller.js
+++ b/app/controllers/secure.controller.js
@@ -27,24 +27,13 @@ exports.new = async function (req, res) {
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   try {
     const tokenResponse = await Charge(correlationId).findByToken(chargeTokenId, getLoggingFields(req))
-    let chargeId, gatewayAccountId, gatewayAccountType
 
-    // Temporarily support both the new and old response schemas from connector
-    if (tokenResponse.charge.externalId) {
-      chargeId = tokenResponse.charge.externalId
-      gatewayAccountId = tokenResponse.charge.gatewayAccount.gateway_account_id
-      gatewayAccountType = tokenResponse.charge.gatewayAccount.type
-    } else {
-      chargeId = tokenResponse.charge.charge_id
-      gatewayAccountId = tokenResponse.charge.gateway_account.gateway_account_id
-      gatewayAccountType = tokenResponse.charge.gateway_account.type
-    }
-
+    const chargeId = tokenResponse.charge.charge_id
     const chargeStatus = tokenResponse.charge.status
 
     setLoggingField(req, PAYMENT_EXTERNAL_ID, chargeId)
-    setLoggingField(req, GATEWAY_ACCOUNT_ID, gatewayAccountId)
-    setLoggingField(req, GATEWAY_ACCOUNT_TYPE, gatewayAccountType)
+    setLoggingField(req, GATEWAY_ACCOUNT_ID, tokenResponse.charge.gateway_account.gateway_account_id)
+    setLoggingField(req, GATEWAY_ACCOUNT_TYPE, tokenResponse.charge.gateway_account.type)
 
     if (tokenResponse.used === true) {
       if (!getSessionVariable(req, createChargeIdSessionKey(chargeId))) {

--- a/test/controllers/secure.controller.test.js
+++ b/test/controllers/secure.controller.test.js
@@ -6,76 +6,36 @@ const expect = require('chai').expect
 
 const paths = require('../../app/paths.js')
 const withAnalyticsError = require('../../app/utils/analytics').withAnalyticsError
-const { validChargeDetails } = require('../fixtures/payment.fixtures')
+const { validTokenResponse } = require('../fixtures/payment.fixtures')
 
 require('../test-helpers/html-assertions.js')
 
-const chargeId = 'ch_dh6kpbb4k82oiibbe4b9haujjk'
+const chargeId = 'dh6kpbb4k82oiibbe4b9haujjk'
 
-const mockCharge = (function () {
-  const mock = function (withSuccess, chargeObject) {
-    return function () {
-      return {
-        findByToken: function () {
-          return new Promise(function (resolve, reject) {
-            if (withSuccess) {
-              resolve(chargeObject)
-            } else {
-              reject(new Error('UNAUTHORISED'))
-            }
-          })
-        }
-      }
-    }
-  }
+const findByTokenFailureStub = () => Promise.reject(new Error('UNAUTHORISED'))
 
-  return {
-    withSuccess: function (chargeObject) {
-      return mock(true, chargeObject)
-    },
-    withFailure: function () {
-      return mock(false)
-    }
-  }
-}())
+function getFindByTokenSuccessStub (used, chargeStatus) {
+  return () => Promise.resolve(validTokenResponse({
+    used,
+    chargeId,
+    status: chargeStatus
+  }))
+}
 
-const mockToken = (function () {
-  const mock = function (withSuccess) {
-    return {
-      markTokenAsUsed: function () {
-        return new Promise(function (resolve, reject) {
-          if (withSuccess) {
-            resolve()
-          } else {
-            reject(new Error('err'))
-          }
-        })
-      }
-    }
-  }
+const requireSecureController = function (findByTokenStub, markTokenAsUsedSuccessful, mockedResponseRouter) {
+  const markTokenAsUsedStub = markTokenAsUsedSuccessful ? () => Promise.resolve() : () => Promise.reject(new Error('err'))
 
-  return {
-    withSuccess: function () {
-      return mock(true)
-    },
-    withFailure: function () {
-      return mock(false)
-    }
-  }
-}())
-
-const requireSecureController = function (mockedCharge, mockedToken, mockedResponseRouter) {
   return proxyquire('../../app/controllers/secure.controller.js', {
     '../utils/response-router': mockedResponseRouter,
-    '../models/charge.js': mockedCharge,
-    '../models/token.js': mockedToken,
-    csrf: function () {
-      return {
-        secretSync: function () {
-          return 'foo'
-        }
-      }
-    }
+    '../models/charge.js': () => ({
+      findByToken: findByTokenStub
+    }),
+    '../models/token.js': {
+      markTokenAsUsed: markTokenAsUsedStub
+    },
+    csrf: () => ({
+      secretSync: () => 'foo'
+    })
   })
 }
 
@@ -83,7 +43,6 @@ describe('secure controller', function () {
   describe('get method', function () {
     let request
     let response
-    let chargeObject
     let responseRouter
 
     before(function () {
@@ -99,20 +58,6 @@ describe('secure controller', function () {
         status: sinon.spy()
       }
 
-      chargeObject = {
-        used: false,
-        charge: {
-          externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
-          status: 'CREATED',
-          gatewayAccount: {
-            service_name: 'Service Name',
-            analytics_id: 'bla-1234',
-            type: 'live'
-          },
-          payment_provider: 'worldpay'
-        }
-      }
-
       responseRouter = {
         response: sinon.spy(),
         systemErrorResponse: sinon.spy()
@@ -121,7 +66,7 @@ describe('secure controller', function () {
 
     describe('when the token is invalid', function () {
       it('should display the "Your payment session has expired" page', async function () {
-        await requireSecureController(mockCharge.withFailure(), mockToken.withSuccess(), responseRouter).new(request, response)
+        await requireSecureController(findByTokenFailureStub, true, responseRouter).new(request, response)
         expect(responseRouter.response.calledWith(request, response, 'UNAUTHORISED')).to.be.true // eslint-disable-line
       })
     })
@@ -129,32 +74,18 @@ describe('secure controller', function () {
     describe('when the token is valid', function () {
       describe('and not marked as used successfully', function () {
         it('should display the generic error page', async function () {
-          await requireSecureController(mockCharge.withSuccess(), mockToken.withFailure(), responseRouter).new(request, response)
+          await requireSecureController(getFindByTokenSuccessStub(false, 'CREATED'), false, responseRouter).new(request, response)
           expect(responseRouter.systemErrorResponse.calledWith(request, response, 'Error exchanging payment token', withAnalyticsError())).to.be.true // eslint-disable-line
         })
       })
 
-      describe('when the token is used successfully', function () {
-        describe('old connector token response', () => {
-          it('should store the service name into the session and redirect', async function () {
-            await requireSecureController(mockCharge.withSuccess(chargeObject), mockToken.withSuccess(), responseRouter).new(request, response)
-            expect(response.redirect.calledWith(303, paths.generateRoute('card.new', {chargeId: chargeObject.charge.externalId}))).to.be.true // eslint-disable-line
-            expect(request.frontend_state).to.have.all.keys(chargeId)
-            expect(request.frontend_state.ch_dh6kpbb4k82oiibbe4b9haujjk).to.eql({
-              csrfSecret: 'foo' // pragma: allowlist secret
-            })
-          })
-        })
-
-        describe('new connector token response', () => {
-          it('should store the service name into the session and redirect', async function () {
-            const newChargeObject = validChargeDetails({ chargeId })
-            await requireSecureController(mockCharge.withSuccess(newChargeObject), mockToken.withSuccess(), responseRouter).new(request, response)
-            expect(response.redirect.calledWith(303, paths.generateRoute('card.new', {chargeId: chargeObject.charge.externalId}))).to.be.true // eslint-disable-line
-            expect(request.frontend_state).to.have.all.keys(chargeId)
-            expect(request.frontend_state.ch_dh6kpbb4k82oiibbe4b9haujjk).to.eql({
-              csrfSecret: 'foo' // pragma: allowlist secret
-            })
+      describe('and the token is marked as used successfully', function () {
+        it('should store the service name into the session and redirect', async function () {
+          await requireSecureController(getFindByTokenSuccessStub(false, 'CREATED'), true, responseRouter).new(request, response)
+          expect(response.redirect.calledWith(303, paths.generateRoute('card.new', {chargeId: chargeId}))).to.be.true // eslint-disable-line
+          expect(request.frontend_state).to.have.all.keys('ch_' + chargeId)
+          expect(request.frontend_state.ch_dh6kpbb4k82oiibbe4b9haujjk).to.eql({
+            csrfSecret: 'foo' // pragma: allowlist secret
           })
         })
       })
@@ -166,20 +97,7 @@ describe('secure controller', function () {
             params: { chargeTokenId: 1 },
             headers: { 'x-Request-id': 'unique-id' }
           }
-          const charge = {
-            used: true,
-            charge: {
-              externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
-              status: 'AUTHORISATION SUCCESS',
-              gatewayAccount: {
-                service_name: 'Service Name',
-                analytics_id: 'bla-1234',
-                type: 'live'
-              },
-              payment_provider: 'worldpay'
-            }
-          }
-          await requireSecureController(mockCharge.withSuccess(charge), mockToken.withSuccess(), responseRouter).new(requestWithEmptyCookie, response)
+          await requireSecureController(getFindByTokenSuccessStub(true, 'CREATED'), true, responseRouter).new(requestWithEmptyCookie, response)
           expect(responseRouter.response.calledWith(requestWithEmptyCookie, response, 'UNAUTHORISED')).to.be.true // eslint-disable-line
         })
       })
@@ -190,20 +108,7 @@ describe('secure controller', function () {
             params: { chargeTokenId: 1 },
             headers: { 'x-Request-id': 'unique-id' }
           }
-          const charge = {
-            used: true,
-            charge: {
-              externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
-              status: 'AUTHORISATION SUCCESS',
-              gatewayAccount: {
-                service_name: 'Service Name',
-                analytics_id: 'bla-1234',
-                type: 'live'
-              },
-              payment_provider: 'worldpay'
-            }
-          }
-          await requireSecureController(mockCharge.withSuccess(charge), mockToken.withSuccess(), responseRouter).new(requestWithoutCookie, response)
+          await requireSecureController(getFindByTokenSuccessStub(true, 'CREATED'), true, responseRouter).new(requestWithoutCookie, response)
           expect(responseRouter.response.calledWith(requestWithoutCookie, response, 'UNAUTHORISED')).to.be.true // eslint-disable-line
         })
       })
@@ -219,20 +124,7 @@ describe('secure controller', function () {
             params: { chargeTokenId: 1 },
             headers: { 'x-Request-id': 'unique-id' }
           }
-          const charge = {
-            used: true,
-            charge: {
-              externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
-              status: 'AUTHORISATION SUCCESS',
-              gatewayAccount: {
-                service_name: 'Service Name',
-                analytics_id: 'bla-1234',
-                type: 'live'
-              },
-              payment_provider: 'worldpay'
-            }
-          }
-          await requireSecureController(mockCharge.withSuccess(charge), mockToken.withSuccess(), responseRouter).new(requestWithWrongCookie, response)
+          await requireSecureController(getFindByTokenSuccessStub(true, 'CREATED'), true, responseRouter).new(requestWithWrongCookie, response)
           expect(responseRouter.response.calledWith(requestWithWrongCookie, response, 'UNAUTHORISED')).to.be.true // eslint-disable-line
         })
       })
@@ -248,26 +140,14 @@ describe('secure controller', function () {
             params: { chargeTokenId: 1 },
             headers: { 'x-Request-id': 'unique-id' }
           }
-          const charge = {
-            used: true,
-            charge: {
-              externalId: 'dh6kpbb4k82oiibbe4b9haujjk',
-              status: 'AUTHORISATION SUCCESS',
-              gatewayAccount: {
-                service_name: 'Service Name',
-                analytics_id: 'bla-1234',
-                type: 'live'
-              },
-              payment_provider: 'worldpay'
-            }
-          }
-          await requireSecureController(mockCharge.withSuccess(charge), mockToken.withSuccess(), responseRouter).new(requestWithFrontendStateCookie, response)
+
+          await requireSecureController(getFindByTokenSuccessStub(true, 'AUTHORISATION_SUCCESS'), true, responseRouter).new(requestWithFrontendStateCookie, response)
           const opts = {
             chargeId: 'dh6kpbb4k82oiibbe4b9haujjk',
             returnUrl: '/return/dh6kpbb4k82oiibbe4b9haujjk'
           }
           expect(responseRouter.response.calledWith(requestWithFrontendStateCookie, response, 'AUTHORISATION_SUCCESS', opts)).to.be.true // eslint-disable-line
-          expect(requestWithFrontendStateCookie.frontend_state).to.have.all.keys(chargeId)
+          expect(requestWithFrontendStateCookie.frontend_state).to.have.all.keys('ch_' + chargeId)
           expect(requestWithFrontendStateCookie.frontend_state.ch_dh6kpbb4k82oiibbe4b9haujjk).to.eql({
             csrfSecret: 'foo' // pragma: allowlist secret
           })

--- a/test/cypress/integration/web-payments/apple-pay.cy.test.js
+++ b/test/cypress/integration/web-payments/apple-pay.cy.test.js
@@ -4,7 +4,7 @@ const {
   connectorUpdateChargeStatus
 } = require('../../utils/stub-builders/charge-stubs')
 const {
-  connectorCreateChargeFromToken,
+  connectorFindChargeByToken,
   connectorMarkTokenAsUsed
 } = require('../../utils/stub-builders/token-stubs')
 const { adminUsersGetService } = require('../../utils/stub-builders/service-stubs')
@@ -49,7 +49,7 @@ describe('Apple Pay payment flow', () => {
   }
 
   const createPaymentChargeStubs = [
-    connectorCreateChargeFromToken({ tokenId }),
+    connectorFindChargeByToken({ tokenId }),
     connectorMarkTokenAsUsed(tokenId),
     connectorGetChargeDetails({
       chargeId,

--- a/test/cypress/integration/web-payments/google-pay.cy.test.js
+++ b/test/cypress/integration/web-payments/google-pay.cy.test.js
@@ -5,7 +5,7 @@ const {
   connectorWorldpay3dsFlexDdcJwt
 } = require('../../utils/stub-builders/charge-stubs')
 const {
-  connectorCreateChargeFromToken,
+  connectorFindChargeByToken,
   connectorMarkTokenAsUsed
 } = require('../../utils/stub-builders/token-stubs')
 const { adminUsersGetService } = require('../../utils/stub-builders/service-stubs')
@@ -70,7 +70,7 @@ describe('Google Pay payment flow', () => {
         integrationVersion3ds: 2,
         paymentProvider: 'worldpay'
       }]),
-      connectorCreateChargeFromToken({ tokenId }),
+      connectorFindChargeByToken({ tokenId }),
       connectorMarkTokenAsUsed(tokenId),
       connectorUpdateChargeStatus(chargeId),
       adminUsersGetService(),

--- a/test/cypress/utils/card-payment-stubs.js
+++ b/test/cypress/utils/card-payment-stubs.js
@@ -71,7 +71,7 @@ function buildCancelChargeStub (chargeId, gatewayAccountId = 42, providerOpts = 
 function buildCreatePaymentChargeStubs (tokenId, chargeId, language = 'en', gatewayAccountId = 42,
   serviceOpts = {}, providerOpts = {}, gatewayAccountOpts = {}, additionalChargeOpts = {}) {
   return [
-    tokenStubs.connectorCreateChargeFromToken({
+    tokenStubs.connectorFindChargeByToken({
       ...additionalChargeOpts,
       tokenId,
       gatewayAccountId,
@@ -113,7 +113,7 @@ function buildChargeFromTokenNotFound (tokenId) {
 
 function buildUsedTokenAndReturnPaymentChargeStubs (tokenId, chargeId, status, gatewayAccountId = 42, serviceOpts = {}) {
   return [
-    tokenStubs.connectorCreateChargeFromToken({ tokenId: tokenId, gatewayAccountId: gatewayAccountId, used: true, status: status }),
+    tokenStubs.connectorFindChargeByToken({ tokenId: tokenId, gatewayAccountId: gatewayAccountId, used: true, status: status }),
     tokenStubs.connectorMarkTokenAsUsed(tokenId),
     chargeStubs.connectorGetChargeDetails({
       chargeId,
@@ -129,7 +129,7 @@ function buildUsedTokenAndReturnPaymentChargeStubs (tokenId, chargeId, status, g
 
 function buildCreatePaymentChargeWithPrefilledCardholderDeatilsStubs (tokenId, chargeId, gatewayAccountId = 42, chargeOpts = {}, serviceOpts = {}) {
   return [
-    tokenStubs.connectorCreateChargeFromToken({ tokenId, gatewayAccountId }),
+    tokenStubs.connectorFindChargeByToken({ tokenId, gatewayAccountId }),
     tokenStubs.connectorMarkTokenAsUsed(tokenId),
     chargeStubs.connectorGetChargeDetailsWithPrefilledCardholderDetails({
       chargeId,

--- a/test/cypress/utils/stub-builders/token-stubs.js
+++ b/test/cypress/utils/stub-builders/token-stubs.js
@@ -3,10 +3,10 @@
 const { stubBuilder } = require('./stub-builder')
 const paymentFixtures = require('../../../fixtures/payment.fixtures')
 
-function connectorCreateChargeFromToken (opts) {
+function connectorFindChargeByToken (opts) {
   const path = `/v1/frontend/tokens/${opts.tokenId}`
   return stubBuilder('GET', path, 200, {
-    response: paymentFixtures.validChargeCreatedByToken(opts)
+    response: paymentFixtures.validTokenResponse(opts)
   })
 }
 
@@ -21,7 +21,7 @@ function connectorChargeFromTokenNotFound (tokenId) {
 }
 
 module.exports = {
-  connectorCreateChargeFromToken,
+  connectorFindChargeByToken,
   connectorMarkTokenAsUsed,
   connectorChargeFromTokenNotFound
 }

--- a/test/fixtures/payment.fixtures.js
+++ b/test/fixtures/payment.fixtures.js
@@ -255,50 +255,10 @@ const buildChargeDetailsWithPrefilledCardHolderDeatils = (opts) => {
 }
 
 const fixtures = {
-  tokenResponse: (opts = {}) => {
+  validTokenResponse: (opts = {}) => {
     return {
-      used: opts.used,
-      charge: {}
-    }
-  },
-
-  // intitial charge details returned have different API surface than charge others
-  validChargeCreatedByToken: (opts = { used: false }) => {
-    console.log('state passed in: ' + opts.status)
-    return {
-      used: opts.used,
-      charge: {
-        amount: opts.amount || 1000,
-        cardDetails: null,
-        corporateSurcharge: null,
-        delayedCapture: false,
-        description: opts.description || 'Example fixture payment',
-        email: null,
-        externalId: opts.chargeId || 'ub8de8r5mh4pb49rgm1ismaqfv',
-        gatewayAccount: buildGatewayAccount(opts),
-        gatewayTransactionId: null,
-        language: 'ENGLISH',
-        paymentGatewayName: 'SANDBOX',
-        providerSessionId: null,
-        reference: 'my payment reference',
-        refunds: [],
-        returnUrl: '/?confirm',
-        status: opts.status || 'CREATED',
-        version: 1,
-        walletType: null,
-        agreement_id: 'some-agreement-id',
-        agreement: {
-          description: 'A valid description',
-          reference: 'A valid reference'
-        },
-        save_payment_instrument_to_agreement: true,
-        moto: opts.moto || false,
-        events: [{
-          gatewayEventDate: null,
-          status: 'CREATED',
-          version: 1
-        }]
-      }
+      used: opts.used || false,
+      charge: buildChargeDetails(opts)
     }
   },
 

--- a/test/unit/clients/connector-client-token.pact.test.js
+++ b/test/unit/clients/connector-client-token.pact.test.js
@@ -7,7 +7,7 @@ const { expect } = require('chai')
 
 // Local dependencies
 const connectorClient = require('../../../app/services/clients/connector.client')
-const fixtures = require('../../fixtures/payment.fixtures')
+const { validTokenResponse } = require('../../fixtures/payment.fixtures')
 const { PactInteractionBuilder } = require('../../test-helpers/pact/pact-interaction-builder')
 const { pactify } = require('../../test-helpers/pact/pact-base')()
 
@@ -15,6 +15,8 @@ const PORT = Math.floor(Math.random() * 48127) + 1024
 const BASE_URL = `http://localhost:${PORT}`
 const TOKEN = 'testToken'
 const FRONTEND_TOKEN_URL = `/v1/frontend/tokens/${TOKEN}`
+
+const chargeId = 'chargeExternalId'
 
 describe('connector client - tokens', function () {
   const provider = new Pact({
@@ -32,7 +34,11 @@ describe('connector client - tokens', function () {
 
   describe('get charge data for valid token', function () {
     before(() => {
-      const response = fixtures.tokenResponse({ chargeExternalId: 'chargeExternalId', used: false })
+      const response = validTokenResponse({
+        used: false,
+        chargeId,
+        cardTypes: [{}]
+      })
       const builder = new PactInteractionBuilder(FRONTEND_TOKEN_URL)
         .withMethod('GET')
         .withState('an unused token testToken exists with external charge id chargeExternalId associated with it')
@@ -50,7 +56,7 @@ describe('connector client - tokens', function () {
         tokenId: TOKEN
       })
       expect(res.body.used).to.be.equal(false)
-      expect(res.body.charge).to.exist // eslint-disable-line
+      expect(res.body.charge).to.have.property('charge_id').eq(chargeId)
     })
   })
 })


### PR DESCRIPTION
Connector has now been updated so that the GET token response uses the FrontendChargeResponse schema for the embedded charge rather than ChargeEntity.

Remove the handling for the old response.

Update `secure.controller.test.js` for this change, and refactor it slightly to make it easier to understand.

Update the Pact test for the GET token endpoint to validate the embedded charge in the response using the new schema.
