### PR TITLE
PP-10904 Cypress - Switch to cy.intercept before Cypress 12 upgrade

### DIFF
--- a/test/cypress/integration/card/awaiting-auth.cy.test.js
+++ b/test/cypress/integration/card/awaiting-auth.cy.test.js
@@ -32,8 +32,7 @@ describe('Awaiting auth', () => {
     cy.task('clearStubs')
     cy.task('setupStubs', checkCardDetailsStubs)
 
-    cy.server()
-    cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+    cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
     cy.log('Should enter card details')
 

--- a/test/cypress/integration/card/billing-address-collection.cy.test.js
+++ b/test/cypress/integration/card/billing-address-collection.cy.test.js
@@ -98,8 +98,7 @@ describe('Billing address collection', () => {
       const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter card details')
 
@@ -153,8 +152,8 @@ describe('Billing address collection', () => {
       const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#card-no').type(validPayment.cardNumber)
       cy.get('#card-no').blur()

--- a/test/cypress/integration/card/email-collection.cy.test.js
+++ b/test/cypress/integration/card/email-collection.cy.test.js
@@ -34,8 +34,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter card details')
 
@@ -77,8 +76,8 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter card details')
 
@@ -123,8 +122,8 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#card-no').type(validPayment.cardNumber)
       cy.get('#card-no').blur()

--- a/test/cypress/integration/card/email-typo.cy.test.js
+++ b/test/cypress/integration/card/email-typo.cy.test.js
@@ -81,8 +81,7 @@ describe('Standard card payment flow', () => {
 
       cy.get('#card-no').type(validPayment.cardNumber)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#expiry-month').type(validPayment.expiryMonth)
       cy.get('#expiry-year').type(validPayment.expiryYear)
@@ -160,8 +159,8 @@ describe('Standard card payment flow', () => {
 
       cy.get('#card-no').type(validPayment.cardNumber)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#expiry-month').type(validPayment.expiryMonth)
       cy.get('#expiry-year').type(validPayment.expiryYear)
@@ -241,8 +240,8 @@ describe('Standard card payment flow', () => {
 
       cy.get('#card-no').type(validPayment.cardNumber)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#expiry-month').type(validPayment.expiryMonth)
       cy.get('#expiry-year').type(validPayment.expiryYear)

--- a/test/cypress/integration/card/enforce-views-to-state.cy.test.js
+++ b/test/cypress/integration/card/enforce-views-to-state.cy.test.js
@@ -39,8 +39,7 @@ describe('Enforce views to state', () => {
     cy.task('clearStubs')
     cy.task('setupStubs', checkCardDetailsStubs)
 
-    cy.server()
-    cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+    cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
     cy.log('Should enter card details')
 

--- a/test/cypress/integration/card/moto-mask-payment.cy.test.js
+++ b/test/cypress/integration/card/moto-mask-payment.cy.test.js
@@ -150,8 +150,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should allow a valid card number to be entered and remove existing error messages')
 
@@ -218,8 +217,8 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter and validate a correct card')
 

--- a/test/cypress/integration/card/payment.cy.test.js
+++ b/test/cypress/integration/card/payment.cy.test.js
@@ -123,8 +123,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter and validate a correct card')
 
@@ -190,9 +189,9 @@ describe('Standard card payment flow', () => {
 
       cy.visit(`/secure/${tokenId}`)
       cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-      cy.server()
 
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
       cy.get('#card-no').type('4000160000000004')
       cy.get('#card-no').blur()
       cy.wait('@checkCard')
@@ -205,9 +204,9 @@ describe('Standard card payment flow', () => {
 
       cy.visit(`/secure/${tokenId}`)
       cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-      cy.server()
 
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
       cy.get('#card-no').type('4000160000000004')
       cy.get('#card-no').blur()
       cy.wait('@checkCard')
@@ -231,8 +230,8 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#card-no').type('1234567890')
       cy.get('#card-no').blur()
@@ -256,8 +255,8 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#card-no').type('1234567890')
       cy.get('#card-no').blur()
@@ -296,8 +295,8 @@ describe('Standard card payment flow', () => {
         }
       })
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter and validate a correct card')
 
@@ -345,8 +344,8 @@ describe('Standard card payment flow', () => {
         }
       })
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter and validate a correct card')
 

--- a/test/cypress/integration/card/token-reuse.cy.test.js
+++ b/test/cypress/integration/card/token-reuse.cy.test.js
@@ -65,8 +65,7 @@ describe('Re-use token flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should allow entering payment details')
 

--- a/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js
+++ b/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.cy.test.js
@@ -72,8 +72,7 @@ describe('Worldpay 3ds flex card payment flow', () => {
     cy.task('clearStubs')
     cy.task('setupStubs', checkCardDetailsStubs)
 
-    cy.server()
-    cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+    cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
     cy.get('#card-no').type(validPayment.cardNumber)
     cy.get('#card-no').blur()


### PR DESCRIPTION
- `cy.server` and `cy.route` are deprecated.
- Switched to `cy.intercept` in preparation for Cypress 12 upgrade.


