### PR TITLE
PP-10904 Cypress 12 upgrade prep - replace `cy.server`, `cy.route` with `cy.intercept`

### DIFF
--- a/test/cypress/integration/card/awaiting-auth.test.cy.js
+++ b/test/cypress/integration/card/awaiting-auth.test.cy.js
@@ -32,8 +32,7 @@ describe('Awaiting auth', () => {
     cy.task('clearStubs')
     cy.task('setupStubs', checkCardDetailsStubs)
 
-    cy.server()
-    cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+    cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
     cy.log('Should enter card details')
 

--- a/test/cypress/integration/card/billing-address-collection.test.cy.js
+++ b/test/cypress/integration/card/billing-address-collection.test.cy.js
@@ -98,8 +98,7 @@ describe('Billing address collection', () => {
       const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter card details')
 
@@ -153,8 +152,7 @@ describe('Billing address collection', () => {
       const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#card-no').type(validPayment.cardNumber)
       cy.get('#card-no').blur()

--- a/test/cypress/integration/card/email-collection.test.cy.js
+++ b/test/cypress/integration/card/email-collection.test.cy.js
@@ -34,8 +34,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter card details')
 
@@ -77,8 +76,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter card details')
 
@@ -123,8 +121,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#card-no').type(validPayment.cardNumber)
       cy.get('#card-no').blur()

--- a/test/cypress/integration/card/email-typo.test.cy.js
+++ b/test/cypress/integration/card/email-typo.test.cy.js
@@ -81,8 +81,7 @@ describe('Standard card payment flow', () => {
 
       cy.get('#card-no').type(validPayment.cardNumber)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#expiry-month').type(validPayment.expiryMonth)
       cy.get('#expiry-year').type(validPayment.expiryYear)
@@ -160,8 +159,7 @@ describe('Standard card payment flow', () => {
 
       cy.get('#card-no').type(validPayment.cardNumber)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#expiry-month').type(validPayment.expiryMonth)
       cy.get('#expiry-year').type(validPayment.expiryYear)
@@ -241,8 +239,7 @@ describe('Standard card payment flow', () => {
 
       cy.get('#card-no').type(validPayment.cardNumber)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#expiry-month').type(validPayment.expiryMonth)
       cy.get('#expiry-year').type(validPayment.expiryYear)

--- a/test/cypress/integration/card/enforce-views-to-state.test.cy.js
+++ b/test/cypress/integration/card/enforce-views-to-state.test.cy.js
@@ -39,8 +39,7 @@ describe('Enforce views to state', () => {
     cy.task('clearStubs')
     cy.task('setupStubs', checkCardDetailsStubs)
 
-    cy.server()
-    cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+    cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
     cy.log('Should enter card details')
 

--- a/test/cypress/integration/card/moto-mask-payment.test.cy.js
+++ b/test/cypress/integration/card/moto-mask-payment.test.cy.js
@@ -150,8 +150,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should allow a valid card number to be entered and remove existing error messages')
 
@@ -218,8 +217,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter and validate a correct card')
 

--- a/test/cypress/integration/card/payment.test.cy.js
+++ b/test/cypress/integration/card/payment.test.cy.js
@@ -123,8 +123,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter and validate a correct card')
 
@@ -190,9 +189,8 @@ describe('Standard card payment flow', () => {
 
       cy.visit(`/secure/${tokenId}`)
       cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-      cy.server()
 
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
       cy.get('#card-no').type('4000160000000004')
       cy.get('#card-no').blur()
       cy.wait('@checkCard')
@@ -205,9 +203,8 @@ describe('Standard card payment flow', () => {
 
       cy.visit(`/secure/${tokenId}`)
       cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-      cy.server()
 
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
       cy.get('#card-no').type('4000160000000004')
       cy.get('#card-no').blur()
       cy.wait('@checkCard')
@@ -231,8 +228,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#card-no').type('1234567890')
       cy.get('#card-no').blur()
@@ -256,8 +252,7 @@ describe('Standard card payment flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.get('#card-no').type('1234567890')
       cy.get('#card-no').blur()
@@ -296,8 +291,7 @@ describe('Standard card payment flow', () => {
         }
       })
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter and validate a correct card')
 
@@ -345,8 +339,7 @@ describe('Standard card payment flow', () => {
         }
       })
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should enter and validate a correct card')
 

--- a/test/cypress/integration/card/token-reuse.test.cy.js
+++ b/test/cypress/integration/card/token-reuse.test.cy.js
@@ -65,8 +65,7 @@ describe('Re-use token flow', () => {
       cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubs)
 
-      cy.server()
-      cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+      cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
       cy.log('Should allow entering payment details')
 

--- a/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.test.cy.js
+++ b/test/cypress/integration/worldpay-3ds-flex-ddc/payment-with-session-id.test.cy.js
@@ -72,8 +72,7 @@ describe('Worldpay 3ds flex card payment flow', () => {
     cy.task('clearStubs')
     cy.task('setupStubs', checkCardDetailsStubs)
 
-    cy.server()
-    cy.route('POST', `/check_card/${chargeId}`).as('checkCard')
+    cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
 
     cy.get('#card-no').type(validPayment.cardNumber)
     cy.get('#card-no').blur()


### PR DESCRIPTION
- `cy.server` and `cy.route` are removed in Cypress 12.
- Replace with `cy.intercept` in preparation for the Cypress 12 upgrade.


