### PR TITLE
PP-10904 Make payment Cypress test standalone.

### DIFF
--- a/test/cypress/integration/card/payment.test.cy.js
+++ b/test/cypress/integration/card/payment.test.cy.js
@@ -80,12 +80,6 @@ describe('Standard card payment flow', () => {
     connectorPostValidCaptureCharge(chargeId)
   ]
 
-  beforeEach(() => {
-    // this test is for the full process, the session should be maintained
-    // as it would for an actual payment flow
-    Cypress.Cookies.preserveOnce('frontend_state')
-  })
-
   describe('Secure card payment page', () => {
     it('Should show a paying user disclaimer that details will be saved when an agreement is being configured', () => {
       cy.task('setupStubs', createPaymentChargeStubsEnglish)


### PR DESCRIPTION
- In previous PR https://github.com/alphagov/pay-frontend/pull/3533, the payment Cypress test was updated so that it was not dependent on the `preserveOnce` method.
- However, forgot to remove the actual `preserveOnce` method.
- This PR removes this method - which is required before upgrading to Cypress 12.


