### PR TITLE
PP-11323 hide wallet options for recurring payments

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block pageTitle %}
-  {% if allowApplePay or allowGooglePay %}
+  {% if (allowApplePay or allowGooglePay) and not savePaymentInstrumentToAgreement %}
     {{ __p("cardDetails.enterPaymentDetails") }}
   {% else %}
     {{ __p("cardDetails.enterCardDetails") }}
@@ -39,7 +39,7 @@
 
 
 {% block bodyStart %}
-  {% if allowApplePay or allowGooglePay %}
+  {% if (allowApplePay or allowGooglePay) and not savePaymentInstrumentToAgreement %}
     <script nonce="{{ nonce }}">
       {% if allowApplePay %}
         if (window.ApplePaySession && window.ApplePaySession.canMakePayments() && window.ApplePaySession.supportsVersion(4)) {
@@ -88,13 +88,13 @@
                 </ul>
               </div>
             </div>
-            {% if allowApplePay or allowGooglePay %}
+            {% if (allowApplePay or allowGooglePay) and not savePaymentInstrumentToAgreement %}
               <div class="web-payment-button-section govuk-!-margin-bottom-7">
                 <h1 class="govuk-heading-l">{{ __p("cardDetails.enterPaymentDetails") }}</h1>
                 {{ paymentSummary() }}
               </div>
             {% endif %}
-            {% if allowApplePay %}
+            {% if allowApplePay and not savePaymentInstrumentToAgreement%}
               <div class="apple-pay-container">
                 <h2 class="govuk-heading-m">{{ __p("cardDetails.webPayments.payWithApplePay") }}</h2>
 
@@ -118,7 +118,7 @@
                 </form>
               </div>
             {% endif %}
-            {% if allowGooglePay %}
+            {% if allowGooglePay and not savePaymentInstrumentToAgreement %}
               <div class="google-pay-container">
                 <h2 class="govuk-heading-m">{{ __p("cardDetails.webPayments.payWithGooglePay") }}</h2>
 
@@ -145,7 +145,7 @@
             <div id="spinner" class="hidden"><img src="/images/spinner.gif" alt="{{ __p("authorisation.spinnerAltText") }}"/></div>
 
             <div id="card-details-wrap">
-              {% if allowApplePay or allowGooglePay %}
+              {% if (allowApplePay or allowGooglePay) and not savePaymentInstrumentToAgreement %}
                 <h2 class="govuk-heading-m web-payment-button-section">{{ __p("cardDetails.enterCardDetails") }}</h2>
               {% endif %}
               <div class="non-web-payment-button-section govuk-!-margin-bottom-5">
@@ -361,7 +361,7 @@
                   <div class="govuk-!-width-three-quarters govuk-!-padding-top-4 govuk-!-margin-top-8 pay-!-border-top">
                       <fieldset class="govuk-fieldset" aria-describedby="address-hint">
                         <legend>
-                          {% if allowApplePay or allowGooglePay %}
+                          {% if (allowApplePay or allowGooglePay) and not savePaymentInstrumentToAgreement %}
                             <h3 class="govuk-heading-m govuk-!-margin-bottom-1 web-payment-button-section">{{ __p("cardDetails.billingAddress") }}</h3>
                           {% endif %}
                           <h2 class="govuk-heading-m govuk-!-margin-bottom-1 non-web-payment-button-section">{{ __p("cardDetails.billingAddress") }}</h2>
@@ -487,7 +487,7 @@
                     <fieldset class="govuk-fieldset" aria-describedby="email-hint">
                       <div>
                         <legend for="email" class="govuk-!-margin-bottom-6">
-                          {% if allowApplePay or allowGooglePay %}
+                          {% if (allowApplePay or allowGooglePay) and not savePaymentInstrumentToAgreement %}
                             <h3 class="govuk-heading-m govuk-!-margin-bottom-1 web-payment-button-section">{{ __p("cardDetails.contactDetails") }}</h3>
                           {% endif %}
                           <h2 class="govuk-heading-m govuk-!-margin-bottom-1 non-web-payment-button-section">{{ __p("cardDetails.contactDetails") }}</h2>
@@ -592,7 +592,7 @@
           </div>
           {% if worldpay3dsFlexDdcJwt %}
             <iframe id="worldpay3dsFlexDdcIframe" src="/public/worldpay/worldpay-3ds-flex-ddc.html" class="govuk-!-display-none"></iframe>
-            {% if allowGooglePay %}
+            {% if allowGooglePay and not savePaymentInstrumentToAgreement %}
               <iframe id="googlePayWorldpay3dsFlexDdcIframe" src="/public/worldpay/worldpay-3ds-flex-ddc.html" class="govuk-!-display-none"></iframe>
             {% endif %}
           {% endif %}


### PR DESCRIPTION
## WHAT

We currently only offer wallet payments for one-off payments. Although it is possible to use recurring payments (payments taken when setting up agreements), it needs additional backend integration which is not in place for both Stripe/Worldpay.

So we should hide wallet options even if allow_apple_pay / allow_google_pay is true for the gateway account

- do not render wallet payments if the payment is a recurring one (savePaymentInstrumentToAgreement is present)
- add Cypress tests
