### PR TITLE
PP-11365 Send additional `payment_data` to connector for Apple Pay payments

### DIFF
--- a/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
+++ b/app/controllers/web-payments/apple-pay/normalise-apple-pay-payload.js
@@ -116,6 +116,7 @@ module.exports = req => {
   const paymentData = humps.decamelizeKeys(payload.token.paymentData)
   return {
     payment_info: paymentInfo,
-    encrypted_payment_data: paymentData
+    encrypted_payment_data: paymentData,
+    payment_data: JSON.stringify(payload.token.paymentData)
   }
 }

--- a/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
+++ b/test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js
@@ -63,7 +63,8 @@ describe('normalise apple pay payload', function () {
             public_key_hash: 'Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=',
             transaction_id: '372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9'
           }
-        }
+        },
+        payment_data: '{"version":"EC_v1","data":"MLHhOn2BXhNw9wLLDR48DyeUcuSmRJ6KnAIGTMGqsgiMpc+AoJ…LUQ6UovkfSnW0sFH6NGZ0jhoap6LYnThYb9WT6yKfEm/rDhM=","signature":"MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFAD…ZuQFfsLJ+Nb3+7bpjfBsZAhA1sIT1XmHoGFdoCUT3AAAAAAAA","header":{"ephemeralPublicKey":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5/Qc6z4TY5HQ5n…KC3kJ4DtIWedPQ70N35PBZzJUrFjtvDZFUvs80uo2ynu+lw==","publicKeyHash":"Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=","transactionId":"372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9"}}'
       }
     )
 
@@ -271,7 +272,8 @@ describe('normalise apple pay payload', function () {
             public_key_hash: 'Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=',
             transaction_id: '372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9'
           }
-        }
+        },
+        payment_data: '{"version":"EC_v1","data":"MLHhOn2BXhNw9wLLDR48DyeUcuSmRJ6KnAIGTMGqsgiMpc+AoJ…LUQ6UovkfSnW0sFH6NGZ0jhoap6LYnThYb9WT6yKfEm/rDhM=","signature":"MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFAD…ZuQFfsLJ+Nb3+7bpjfBsZAhA1sIT1XmHoGFdoCUT3AAAAAAAA","header":{"ephemeralPublicKey":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5/Qc6z4TY5HQ5n…KC3kJ4DtIWedPQ70N35PBZzJUrFjtvDZFUvs80uo2ynu+lw==","publicKeyHash":"Xzn7W3vsrlKlb0QvUAviASubdtW4BotWrDo5mGG+UWY=","transactionId":"372c3858122b6bc39c6095eca2f994a8aa012f3b025d0d72ecfd449c2a5877f9"}}'
       }
     )
 


### PR DESCRIPTION
## WHAT

- Currently, we send Apple Pay token.paymentData as JSON to the connector in the field `encrypted_payment_data`. For Stripe payments, we will need to send `paymentData` as is to Stripe. To avoid any issues, when deserialising encrypted_payment_data and then serialising data, we can send paymentData as a String and let connector deserialise payload if required.
- Added a new field payment_data to send token.paymentData as String. Connector doesn't handle the new field yet
