### PR TITLE
PP-11394 Point to new worldpay-specific endpoint for google pay

### DIFF
--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -28,7 +28,12 @@ const _getFindChargeUrlFor = chargeId => baseUrl + CARD_CHARGE_PATH.replace('{ch
 const _getAuthUrlFor = chargeId => baseUrl + CARD_AUTH_PATH.replace('{chargeId}', chargeId)
 
 /** @private */
-const _getWalletAuthUrlFor = (chargeId, provider) => baseUrl + WALLET_AUTH_PATH.replace('{chargeId}', chargeId).replace('{provider}', provider)
+const _getWalletAuthUrlFor = (chargeId, provider) => {
+  if (provider === 'google') {
+    return baseUrl + WALLET_AUTH_PATH.replace('{chargeId}', chargeId).replace('{provider}', 'google/worldpay')
+  }
+  return baseUrl + WALLET_AUTH_PATH.replace('{chargeId}', chargeId).replace('{provider}', provider)
+}
 
 /** @private */
 const _getThreeDsFor = chargeId => baseUrl + CARD_3DS_PATH.replace('{chargeId}', chargeId)

--- a/test/controllers/web-payments/payment-auth-request.controller.test.js
+++ b/test/controllers/web-payments/payment-auth-request.controller.test.js
@@ -113,7 +113,7 @@ describe('The web payments auth request controller', () => {
         statusCode: 200
       }
       nock(process.env.CONNECTOR_HOST)
-        .post(`/v1/frontend/charges/${chargeId}/wallets/${provider}`)
+        .post(`/v1/frontend/charges/${chargeId}/wallets/google/worldpay`)
         .reply(200)
       requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
         expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line

--- a/test/unit/clients/connector-client-google-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-google-authentication.pact.test.js
@@ -10,7 +10,7 @@ const chaiAsPromised = require('chai-as-promised')
 
 // Constants
 const TEST_CHARGE_ID = 'testChargeId'
-const GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google`
+const GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google/worldpay`
 const PORT = Math.floor(Math.random() * 48127) + 1024
 const BASEURL = `http://localhost:${PORT}`
 


### PR DESCRIPTION
Context - Implementing Google Pay payments for Stripe will require separate endpoints for Stripe and Worldpay.
- Point to new connector endpoint for Google Pay authorisations via Worldpay
- Update tests
