### PR TITLE
PP-11394 rename google pay endpoint

### DIFF
--- a/app/controllers/web-payments/payment-auth-request.controller.js
+++ b/app/controllers/web-payments/payment-auth-request.controller.js
@@ -11,7 +11,7 @@ const { CORRELATION_HEADER } = require('../../../config/correlation-header')
 const { setSessionVariable } = require('../../utils/cookies')
 
 module.exports = (req, res) => {
-  const { chargeId, params } = req
+  const { chargeId, params, paymentProvider } = req
   const { provider } = params
 
   const { worldpay3dsFlexDdcStatus } = req.body
@@ -21,7 +21,7 @@ module.exports = (req, res) => {
 
   const payload = provider === 'apple' ? normaliseApplePayPayload(req) : normaliseGooglePayPayload(req)
 
-  return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet({ chargeId, provider, payload }, getLoggingFields(req))
+  return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet({ chargeId, provider, paymentProvider, payload }, getLoggingFields(req))
     .then(data => {
       setSessionVariable(req, `ch_${(chargeId)}.webPaymentAuthResponse`, {
         statusCode: data.statusCode

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -28,7 +28,10 @@ const _getFindChargeUrlFor = chargeId => baseUrl + CARD_CHARGE_PATH.replace('{ch
 const _getAuthUrlFor = chargeId => baseUrl + CARD_AUTH_PATH.replace('{chargeId}', chargeId)
 
 /** @private */
-const _getWalletAuthUrlFor = (chargeId, provider) => baseUrl + WALLET_AUTH_PATH.replace('{chargeId}', chargeId).replace('{provider}', provider)
+const _getWalletAuthUrlFor = (chargeId, provider, paymentProvider) => baseUrl + WALLET_AUTH_PATH
+  .replace('{chargeId}', chargeId)
+  .replace('{provider}', provider)
+  .concat((paymentProvider === 'worldpay' && provider === 'google') ? '/worldpay' : '')
 
 /** @private */
 const _getThreeDsFor = chargeId => baseUrl + CARD_3DS_PATH.replace('{chargeId}', chargeId)
@@ -228,7 +231,7 @@ const chargeAuth = (chargeOptions, loggingFields = {}) => {
 }
 
 const chargeAuthWithWallet = (chargeOptions, loggingFields = {}) => {
-  const authUrl = _getWalletAuthUrlFor(chargeOptions.chargeId, chargeOptions.provider)
+  const authUrl = _getWalletAuthUrlFor(chargeOptions.chargeId, chargeOptions.provider, chargeOptions.paymentProvider)
   return _postConnector(authUrl, chargeOptions.payload, 'create charge using e-wallet payment', loggingFields, 'chargeAuthWithWallet')
 }
 

--- a/test/controllers/web-payments/payment-auth-request.controller.test.js
+++ b/test/controllers/web-payments/payment-auth-request.controller.test.js
@@ -20,6 +20,7 @@ describe('The web payments auth request controller', () => {
         'x-request-id': 'aaa'
       },
       chargeId,
+      paymentProvider: 'worldpay',
       params: {
         provider
       },
@@ -86,6 +87,7 @@ describe('The web payments auth request controller', () => {
         'x-request-id': 'aaa'
       },
       chargeId,
+      paymentProvider: 'worldpay',
       params: {
         provider
       },
@@ -113,7 +115,7 @@ describe('The web payments auth request controller', () => {
         statusCode: 200
       }
       nock(process.env.CONNECTOR_HOST)
-        .post(`/v1/frontend/charges/${chargeId}/wallets/${provider}`)
+        .post(`/v1/frontend/charges/${chargeId}/wallets/${provider}/worldpay`)
         .reply(200)
       requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
         expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line

--- a/test/unit/clients/connector-client-google-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-google-authentication.pact.test.js
@@ -10,7 +10,7 @@ const chaiAsPromised = require('chai-as-promised')
 
 // Constants
 const TEST_CHARGE_ID = 'testChargeId'
-const GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google`
+const GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google/worldpay`
 const PORT = Math.floor(Math.random() * 48127) + 1024
 const BASEURL = `http://localhost:${PORT}`
 
@@ -64,7 +64,8 @@ describe('connectors client - google authentication API', function () {
         connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
           chargeId: TEST_CHARGE_ID,
           provider: 'google',
-          payload: payload
+          payload: payload,
+          paymentProvider: 'worldpay'
         }).then(res => {
           expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
@@ -98,7 +99,8 @@ describe('connectors client - google authentication API', function () {
         connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
           chargeId: TEST_CHARGE_ID,
           provider: 'google',
-          payload: payload
+          payload: payload,
+          paymentProvider: 'worldpay'
         }).then(res => {
           expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
@@ -129,7 +131,8 @@ describe('connectors client - google authentication API', function () {
         connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
           chargeId: TEST_CHARGE_ID,
           provider: 'google',
-          payload: declinedGoogleAuthRequest
+          payload: declinedGoogleAuthRequest,
+          paymentProvider: 'worldpay'
         }).then(() => {
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
@@ -159,7 +162,8 @@ describe('connectors client - google authentication API', function () {
         connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
           chargeId: TEST_CHARGE_ID,
           provider: 'google',
-          payload: errorGoogleAuthRequest
+          payload: errorGoogleAuthRequest,
+          paymentProvider: 'worldpay'
         }).then(() => {
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
@@ -189,7 +193,8 @@ describe('connectors client - google authentication API', function () {
         connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
           chargeId: TEST_CHARGE_ID,
           provider: 'google',
-          payload: payload
+          payload: payload,
+          paymentProvider: 'worldpay'
         }).then(res => {
           expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
           done()


### PR DESCRIPTION
## WHAT

PP-11393 adds a separate endpoint for authorising Stripe goole pay payments. Rename the existing endpoint to make it clear it is for Worldpay.

- rename calling google pay authorisation URL
- update tests

