### PR TITLE
PP-11115 fix frontend layout bug

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -16,6 +16,8 @@
   'data-accept-header': acceptHeader
 } %}
 
+{% set shouldShowEmail = (gatewayAccount.emailCollectionMode === 'MANDATORY') or (gatewayAccount.emailCollectionMode === 'OPTIONAL') %}
+
 {% macro paymentSummary() %}
   <div class="payment-summary-wrap">
     <div class="payment-summary">
@@ -456,7 +458,7 @@
                             value="{{ addressCity }}"
                             autocomplete="billing address-level2"/>
                         </div>
-                        <div class="govuk-form-group{% if highlightErrorFields.addressPostcode %} govuk-form-group--error{% endif %} govuk-!-margin-bottom-0" data-validation="addressPostcode">
+                        <div class="govuk-form-group{% if highlightErrorFields.addressPostcode %} govuk-form-group--error{% endif %} {% if shouldShowEmail %} govuk-!-margin-bottom-0{% endif %}" data-validation="addressPostcode">
                           <label id="address-postcode-lbl" for="address-postcode" class="govuk-label">
                             <span
                               class="address-postcode-label"
@@ -483,7 +485,6 @@
                     </fieldset>
                   </div>
                 {% endif %}
-                {% set shouldShowEmail = (gatewayAccount.emailCollectionMode === 'MANDATORY') or (gatewayAccount.emailCollectionMode === 'OPTIONAL') %}
                 {% if shouldShowEmail %}
                   <div class="govuk-!-width-three-quarters email-container govuk-!-padding-top-4 govuk-!-margin-top-8 pay-!-border-top">
                     <fieldset class="govuk-fieldset" aria-describedby="email-hint">


### PR DESCRIPTION
## WHAT

The continue button was not correctly spaced if a service was configured to collect billing addresses but not email addresses. Conditionally apply margin overrides based on `shouldShowEmail`.

Before:
![before](https://github.com/alphagov/pay-frontend/assets/1949148/5b30684a-f164-4a9b-b6d0-d45684094d41)

After:
![after](https://github.com/alphagov/pay-frontend/assets/1949148/3e6896ae-8cec-4e7a-96f9-94e8017db4dd)

After (all fields enabled):
![after all fields](https://github.com/alphagov/pay-frontend/assets/1949148/d0c02bff-b9ca-41f1-8c03-003e483459ef)


