### PR TITLE
PP-11395 frontend stripe google pay impl

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -352,7 +352,7 @@
         "filename": "test/fixtures/wallet-payment.fixtures.js",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 53
       }
     ],
     "test/middleware/decrypt-card-data.test.js": [
@@ -418,5 +418,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-25T15:23:05Z"
+  "generated_at": "2023-10-03T14:14:52Z"
 }

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -111,7 +111,7 @@ const processPayment = paymentData => {
   showSpinnerAndHideMainContent()
 
   // attempt device data collection for worldpay only
-  if (payment_provider === 'worldpay') {
+  if (payment_provider === 'worldpay') { // eslint-disable-line camelcase
     if (typeof Charge.worldpay_3ds_flex_ddc_jwt !== 'string' || Charge.worldpay_3ds_flex_ddc_jwt === '') {
       submitGooglePayAuthRequest(paymentData)
     }
@@ -138,7 +138,7 @@ const shortenGooglePayDescription = (fullPaymentDescription) => {
 const createGooglePaymentRequest = () => {
   const methodData = [{
     supportedMethods: 'https://google.com/pay',
-    data: getGooglePaymentsConfiguration(payment_provider)
+    data: getGooglePaymentsConfiguration(payment_provider) // eslint-disable-line camelcase
   }]
 
   const shortenedPaymentDescription = shortenGooglePayDescription(window.paymentDetails.description)

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -2,7 +2,7 @@
 
 const { getGooglePaymentsConfiguration, showErrorSummary } = require('./helpers')
 const { toggleSubmitButtons, showSpinnerAndHideMainContent, hideSpinnerAndShowMainContent } = require('../helpers')
-const { email_collection_mode } = window.Charge // eslint-disable-line camelcase
+const { email_collection_mode, payment_provider } = window.Charge // eslint-disable-line camelcase
 
 const submitGooglePayAuthRequest = (paymentResponse) => {
   // eslint-disable-next-line no-var
@@ -110,14 +110,18 @@ const processPayment = paymentData => {
   toggleSubmitButtons()
   showSpinnerAndHideMainContent()
 
-  if (typeof Charge.worldpay_3ds_flex_ddc_jwt !== 'string' || Charge.worldpay_3ds_flex_ddc_jwt === '') {
-    submitGooglePayAuthRequest(paymentData)
-  }
-
-  if (typeof Charge.googlePayWorldpay3dsFlexDeviceDataCollectionStatus === 'string') {
-    submitGooglePayAuthRequest(paymentData)
+  // attempt device data collection for worldpay only
+  if (payment_provider === 'worldpay') {
+    if (typeof Charge.worldpay_3ds_flex_ddc_jwt !== 'string' || Charge.worldpay_3ds_flex_ddc_jwt === '') {
+      submitGooglePayAuthRequest(paymentData)
+    }
+    if (typeof Charge.googlePayWorldpay3dsFlexDeviceDataCollectionStatus === 'string') {
+      submitGooglePayAuthRequest(paymentData)
+    } else {
+      performDeviceDataCollectionForGooglePay(paymentData)
+    }
   } else {
-    performDeviceDataCollectionForGooglePay(paymentData)
+    submitGooglePayAuthRequest(paymentData)
   }
 }
 
@@ -134,7 +138,7 @@ const shortenGooglePayDescription = (fullPaymentDescription) => {
 const createGooglePaymentRequest = () => {
   const methodData = [{
     supportedMethods: 'https://google.com/pay',
-    data: getGooglePaymentsConfiguration()
+    data: getGooglePaymentsConfiguration(payment_provider)
   }]
 
   const shortenedPaymentDescription = shortenGooglePayDescription(window.paymentDetails.description)

--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -71,14 +71,21 @@ const prepareAppleRequestObject = () => {
   }
 }
 
-const getGooglePaymentsConfiguration = () => {
+const getGooglePaymentsConfiguration = (paymentProvider) => {
   const allowedCardNetworks = supportedNetworksFormattedByProvider(allowedCardTypes, 'google')
   const allowedCardAuthMethods = ['PAN_ONLY', 'CRYPTOGRAM_3DS']
   const tokenizationSpecification = {
     type: 'PAYMENT_GATEWAY',
     parameters: {
-      gateway: 'worldpay',
-      gatewayMerchantId: window.googlePayGatewayMerchantID
+      ...(paymentProvider === 'stripe' && {
+        gateway: 'stripe',
+        'stripe:version': '2018-10-31',
+        'stripe:publishableKey': window.stripePublishableKey
+      }),
+      ...(paymentProvider === 'worldpay' && {
+        gateway: 'worldpay',
+        gatewayMerchantId: window.googlePayGatewayMerchantID
+      })
     }
   }
 

--- a/app/controllers/charge.controller.js
+++ b/app/controllers/charge.controller.js
@@ -10,7 +10,9 @@ const {
   WORLDPAY_3DS_FLEX_DDC_LIVE_URL,
   DECRYPT_AND_OMIT_CARD_DATA,
   GOOGLE_PAY_MERCHANT_ID,
-  GOOGLE_PAY_MERCHANT_ID_2
+  GOOGLE_PAY_MERCHANT_ID_2,
+  STRIPE_TEST_PUBLISHABLE_API_KEY,
+  STRIPE_LIVE_PUBLISHABLE_API_KEY
 } = process.env
 const logger = require('../utils/logger')(__filename)
 const logging = require('../utils/logging')
@@ -70,7 +72,14 @@ const appendChargeForNewView = async (charge, req, chargeId) => {
 
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   charge.worldpay3dsFlexDdcJwt = await worlpay3dsFlexService.getDdcJwt(charge, correlationId, getLoggingFields(req))
-  charge.worldpay3dsFlexDdcUrl = charge.gatewayAccount.type !== 'live' ? WORLDPAY_3DS_FLEX_DDC_TEST_URL : WORLDPAY_3DS_FLEX_DDC_LIVE_URL
+  
+  if (charge.gatewayAccount.type !== 'live') {
+    charge.worldpay3dsFlexDdcUrl = WORLDPAY_3DS_FLEX_DDC_TEST_URL
+    charge.stripePublishableKey = STRIPE_TEST_PUBLISHABLE_API_KEY
+  } else {
+    charge.worldpay3dsFlexDdcUrl = WORLDPAY_3DS_FLEX_DDC_LIVE_URL
+    charge.stripePublishableKey = STRIPE_LIVE_PUBLISHABLE_API_KEY
+  }
 
   charge.collectAdditionalBrowserDataForEpdq3ds = charge.paymentProvider === 'epdq' &&
     charge.gatewayAccount.requires3ds && charge.gatewayAccount.integrationVersion3ds === 2

--- a/app/controllers/charge.controller.js
+++ b/app/controllers/charge.controller.js
@@ -72,7 +72,7 @@ const appendChargeForNewView = async (charge, req, chargeId) => {
 
   const correlationId = req.headers[CORRELATION_HEADER] || ''
   charge.worldpay3dsFlexDdcJwt = await worlpay3dsFlexService.getDdcJwt(charge, correlationId, getLoggingFields(req))
-  
+
   if (charge.gatewayAccount.type !== 'live') {
     charge.worldpay3dsFlexDdcUrl = WORLDPAY_3DS_FLEX_DDC_TEST_URL
     charge.stripePublishableKey = STRIPE_TEST_PUBLISHABLE_API_KEY

--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -79,7 +79,7 @@ const nullable = word => {
   return word
 }
 
-module.exports = req => {
+module.exports = (req, paymentProvider) => {
   logSelectedPayloadProperties(req)
 
   const payload = req.body
@@ -98,8 +98,15 @@ module.exports = req => {
   const paymentData = humps.decamelizeKeys(JSON.parse(payload.paymentResponse.details.paymentMethodData.tokenizationData.token))
   delete payload.paymentResponse.details.paymentMethodData
 
-  return {
-    payment_info: paymentInfo,
-    encrypted_payment_data: paymentData
+  if (paymentProvider === 'stripe') {
+    return {
+      payment_info: paymentInfo,
+      token_id: paymentData.id
+    }
+  } else {
+    return {
+      payment_info: paymentInfo,
+      encrypted_payment_data: paymentData
+    }
   }
 }

--- a/app/controllers/web-payments/payment-auth-request.controller.js
+++ b/app/controllers/web-payments/payment-auth-request.controller.js
@@ -15,21 +15,23 @@ module.exports = (req, res) => {
   const { chargeData, chargeId, params } = req
   const charge = normalise.charge(chargeData, chargeId)
   const wallet = params.provider
+  const paymentProvider = charge.paymentProvider
 
   const { worldpay3dsFlexDdcStatus } = req.body
   if (worldpay3dsFlexDdcStatus) {
     logging.worldpay3dsFlexDdcStatus(worldpay3dsFlexDdcStatus, getLoggingFields(req))
   }
 
-  const payload = wallet === 'apple' ? normaliseApplePayPayload(req) : normaliseGooglePayPayload(req)
+  const payload = wallet === 'apple' ? normaliseApplePayPayload(req) : normaliseGooglePayPayload(req, paymentProvider)
 
-  const walletAuthOpts = {
+  const chargeOptions = {
     chargeId,
     wallet,
-    paymentProvider: charge.paymentProvider,
+    paymentProvider,
     payload
   }
-  return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet(walletAuthOpts, getLoggingFields(req))
+
+  return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet(chargeOptions, getLoggingFields(req))
     .then(data => {
       setSessionVariable(req, `ch_${(chargeId)}.webPaymentAuthResponse`, {
         statusCode: data.statusCode

--- a/app/controllers/web-payments/payment-auth-request.controller.js
+++ b/app/controllers/web-payments/payment-auth-request.controller.js
@@ -9,7 +9,7 @@ const normaliseApplePayPayload = require('./apple-pay/normalise-apple-pay-payloa
 const normaliseGooglePayPayload = require('./google-pay/normalise-google-pay-payload')
 const { CORRELATION_HEADER } = require('../../../config/correlation-header')
 const { setSessionVariable } = require('../../utils/cookies')
-const normalise = require("../../services/normalise-charge");
+const normalise = require('../../services/normalise-charge')
 
 module.exports = (req, res) => {
   const { chargeData, chargeId, params } = req

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -7,7 +7,7 @@ const { getCounter } = require('../../metrics/graphite-reporter')
 
 const METRICS_PREFIX = 'internal-rest-call.connector'
 const SERVICE_NAME = 'connector'
-const WALLET_AUTH_PATH = '/v1/frontend/charges/{chargeId}/wallets/{provider}'
+const WALLET_AUTH_PATH = '/v1/frontend/charges/{chargeId}/wallets/{walletType}'
 const CARD_AUTH_PATH = '/v1/frontend/charges/{chargeId}/cards'
 const CARD_3DS_PATH = '/v1/frontend/charges/{chargeId}/3ds'
 const CARD_STATUS_PATH = '/v1/frontend/charges/{chargeId}/status'
@@ -28,10 +28,18 @@ const _getFindChargeUrlFor = chargeId => baseUrl + CARD_CHARGE_PATH.replace('{ch
 const _getAuthUrlFor = chargeId => baseUrl + CARD_AUTH_PATH.replace('{chargeId}', chargeId)
 
 /** @private */
-const _getWalletAuthUrlFor = (chargeId, provider, paymentProvider) => baseUrl + WALLET_AUTH_PATH
-  .replace('{chargeId}', chargeId)
-  .replace('{provider}', provider)
-  .concat((paymentProvider === 'worldpay' && provider === 'google') ? '/worldpay' : '')
+const _getWalletAuthUrlFor = (chargeId, walletType, paymentProvider) => {
+  let walletAuthUrl = baseUrl + WALLET_AUTH_PATH
+    .replace('{chargeId}', chargeId)
+    .replace('{walletType}', walletType)
+
+  if (walletType === 'google') {
+    if (paymentProvider === 'worldpay' || paymentProvider === 'stripe') {
+      walletAuthUrl = walletAuthUrl.concat(`/${paymentProvider}`)
+    }
+  }
+  return walletAuthUrl
+}
 
 /** @private */
 const _getThreeDsFor = chargeId => baseUrl + CARD_3DS_PATH.replace('{chargeId}', chargeId)

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -7,7 +7,7 @@
     description: '{{description}}',
     amount: '{{amount}}',
     chargeID: '{{id}}'
-  };
+  }
 
   window.Card = {
     allowed:
@@ -26,7 +26,7 @@
           prepaidDebit: 0
         }
       {% endif %}
-  };
+  }
   window.Charge = {
     email_collection_mode: '{{ gatewayAccount.emailCollectionMode | safe }}',
     collect_billing_address: {{ "true" if collectBillingAddress else "false" }},
@@ -38,36 +38,37 @@
 
   var mainWrap = document.getElementsByTagName('main')[0]
   document.addEventListener('DOMContentLoaded', function() {
-    window.GOVUKFrontend.initAll();
+    window.GOVUKFrontend.initAll()
     if (mainWrap.classList.contains('charge-new')) {
-      window.payScripts.helpers.setGlobalChargeId();
-      showCardType().init();
+      window.payScripts.helpers.setGlobalChargeId()
+      showCardType().init()
       {% if collectBillingAddress %}
-        window.payScripts.helpers.initialiseAddressCountryAutocomplete();
+        window.payScripts.helpers.initialiseAddressCountryAutocomplete()
       {% endif %}
-      window.payScripts.inputConfirm.init();
-      window.payScripts.formValidation.init();
-      window.payScripts.epdq3ds2.init();
+      window.payScripts.inputConfirm.init()
+      window.payScripts.formValidation.init()
+      window.payScripts.epdq3ds2.init()
     } else if (mainWrap.classList.contains('confirm-page')) {
       var confirmationForm = document.getElementById('confirmation')
       var confirmButton = document.getElementById('confirm')
       confirmationForm.addEventListener('submit', function () {
         confirmButton.setAttribute('disabled', 'disabled')
       })
-      analyticsTrackConfirmClick().init('{{analytics.analyticsId}}', '{{analytics.type}}', '{{analytics.paymentProvider}}', '{{analytics.amount}}', '{{hitPage}}');
+      analyticsTrackConfirmClick().init('{{analytics.analyticsId}}', '{{analytics.type}}', '{{analytics.paymentProvider}}', '{{analytics.amount}}', '{{hitPage}}')
     }
     {% if allowGooglePay%}
-      window.googlePayGatewayMerchantID = '{{ googlePayGatewayMerchantID }}';
-      window.googlePayMerchantID = '{{ googlePayMerchantID }}';
+      window.googlePayGatewayMerchantID = '{{ googlePayGatewayMerchantID }}'
+      window.googlePayMerchantID = '{{ googlePayMerchantID }}'
       window.gatewayAccountType = '{{ gatewayAccount.type }}'
+      window.stripePublishableKey = '{{ stripePublishableKey }}'
     {% endif %}
     {% if allowApplePay and allowGooglePay%}
-      window.payScripts.webPayments.init('all');
+      window.payScripts.webPayments.init('all')
     {% elif allowApplePay %}
-      window.payScripts.webPayments.init('apple');
+      window.payScripts.webPayments.init('apple')
     {% elif allowGooglePay %}
-      window.payScripts.webPayments.init('google');
+      window.payScripts.webPayments.init('google')
     {% endif %}
-  });
+  })
 </script>
 <script src="{{ js_path }}"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-string": "^1.4.0",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^13.3.0",
         "dotenv": "^16.3.1",
         "govuk-country-and-territory-autocomplete": "^1.0.2",

--- a/test/fixtures/wallet-payment.fixtures.js
+++ b/test/fixtures/wallet-payment.fixtures.js
@@ -1,7 +1,7 @@
-const successfulLastDigitsCardNumber = 4242
+const successfulLastDigitsCardNumber = '4242'
 
 const fixtures = {
-  googleAuthRequestDetails: (ops = {}) => {
+  worldpayGoogleAuthRequestDetails: (ops = {}) => {
     const data = {
       payment_info: {
         last_digits_card_number: ops.lastDigitsCardNumber !== undefined ? ops.lastDigitsCardNumber : successfulLastDigitsCardNumber,
@@ -20,6 +20,21 @@ const fixtures = {
       }
     }
     return data
+  },
+  stripeGoogleAuthRequestDetails: (ops = {}) => {
+    return {
+      payment_info: {
+        last_digits_card_number: ops.lastDigitsCardNumber !== undefined ? ops.lastDigitsCardNumber : successfulLastDigitsCardNumber,
+        brand: 'visa',
+        cardholder_name: 'Name',
+        email: 'name@example.com',
+        worldpay_3ds_flex_ddc_result: null,
+        accept_header: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+        user_agent_header: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36',
+        ip_address: '203.0.113.1'
+      },
+      token_id: 'tok_notARealToken123abc'
+    }
   },
   webPaymentSuccessResponse: () => {
     return {

--- a/test/unit/browsered/web-payments/google-pay.test.js
+++ b/test/unit/browsered/web-payments/google-pay.test.js
@@ -25,5 +25,5 @@ describe('Google Pay', () => {
     it('should tuncate the description to 17 characters and add the elipses character when length > 18', () => {
       expect(shortenGooglePayDescription(STRING_19_CHAR_LENGTH)).to.equal('abcdefghijklmnopq…')
     })
-})
+  })
 })

--- a/test/unit/clients/connector-client-stripe-google-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-stripe-google-authentication.pact.test.js
@@ -64,7 +64,7 @@ describe('connectors client - stripe google authentication API', function () {
       it('should return authorisation success', function (done) {
         connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
           ...CHARGE_OPTIONS,
-          payload: successfulGoogleAuthRequest,
+          payload: successfulGoogleAuthRequest
         }).then(res => {
           expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
@@ -94,7 +94,7 @@ describe('connectors client - stripe google authentication API', function () {
       it('should return authorisation success', function (done) {
         connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
           ...CHARGE_OPTIONS,
-          payload: successfulGoogleAuthRequest,
+          payload: successfulGoogleAuthRequest
         }).then(res => {
           expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
           done()

--- a/test/unit/clients/connector-client-stripe-google-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-stripe-google-authentication.pact.test.js
@@ -1,0 +1,161 @@
+'use strict'
+
+// Core dependencies
+const path = require('path')
+
+// NPM dependencies
+const { Pact } = require('@pact-foundation/pact')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+// Constants
+const TEST_CHARGE_ID = 'testChargeId'
+const CHARGE_OPTIONS = {
+  chargeId: TEST_CHARGE_ID,
+  wallet: 'google',
+  paymentProvider: 'stripe'
+}
+const STRIPE_GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google/stripe`
+const PORT = Math.floor(Math.random() * 48127) + 1024
+const BASEURL = `http://127.0.0.1:${PORT}`
+
+// Custom dependencies
+const connectorClient = require('../../../app/services/clients/connector.client')
+const fixtures = require('../../fixtures/wallet-payment.fixtures')
+const { PactInteractionBuilder } = require('../../test-helpers/pact/pact-interaction-builder')
+const { pactify } = require('../../test-helpers/pact/pact-base')()
+
+// Global setup
+const expect = chai.expect
+chai.use(chaiAsPromised)
+
+describe('connectors client - stripe google authentication API', function () {
+  const provider = new Pact({
+    consumer: 'frontend',
+    provider: 'connector',
+    port: PORT,
+    log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
+    dir: path.resolve(process.cwd(), 'pacts'),
+    spec: 2,
+    pactfileWriteMode: 'merge'
+  })
+
+  before(() => provider.setup())
+  after(() => provider.finalize())
+
+  describe('Authenticate Stripe google payment', function () {
+    describe('authorisation success', function () {
+      const successfulGoogleAuthRequest = fixtures.stripeGoogleAuthRequestDetails()
+      const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
+      before(() => {
+        const builder = new PactInteractionBuilder(STRIPE_GOOGLE_AUTH_PATH)
+          .withRequestBody(successfulGoogleAuthRequest)
+          .withMethod('POST')
+          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withUponReceiving('a valid stripe google pay auth request which should be authorised')
+          .withResponseBody(pactify(authorisationSuccessResponse))
+          .withStatusCode(200)
+          .build()
+        return provider.addInteraction(builder)
+      })
+
+      afterEach(() => provider.verify())
+
+      it('should return authorisation success', function (done) {
+        connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
+          ...CHARGE_OPTIONS,
+          payload: successfulGoogleAuthRequest,
+        }).then(res => {
+          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          done()
+        }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
+      })
+    })
+
+    describe('authorisation success with no last card digits', function () {
+      const successfulGoogleAuthRequest = fixtures.stripeGoogleAuthRequestDetails({
+        lastDigitsCardNumber: ''
+      })
+      const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
+      before(() => {
+        const builder = new PactInteractionBuilder(STRIPE_GOOGLE_AUTH_PATH)
+          .withRequestBody(successfulGoogleAuthRequest)
+          .withMethod('POST')
+          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withUponReceiving('a valid stripe google pay auth request with no last card digits which should be authorised')
+          .withResponseBody(pactify(authorisationSuccessResponse))
+          .withStatusCode(200)
+          .build()
+        return provider.addInteraction(builder)
+      })
+
+      afterEach(() => provider.verify())
+
+      it('should return authorisation success', function (done) {
+        connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
+          ...CHARGE_OPTIONS,
+          payload: successfulGoogleAuthRequest,
+        }).then(res => {
+          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          done()
+        }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
+      })
+    })
+
+    describe('authorisation declined', function () {
+      const declinedGoogleAuthRequest = fixtures.stripeGoogleAuthRequestDetails({
+        lastDigitsCardNumber: '0002'
+      })
+
+      before(() => {
+        const builder = new PactInteractionBuilder(STRIPE_GOOGLE_AUTH_PATH)
+          .withRequestBody(declinedGoogleAuthRequest)
+          .withMethod('POST')
+          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withUponReceiving('a valid stripe google pay auth request which should be declined')
+          .withStatusCode(400)
+          .build()
+        return provider.addInteraction(builder)
+      })
+
+      afterEach(() => provider.verify())
+
+      it('should return authorisation declined', function (done) {
+        connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
+          ...CHARGE_OPTIONS,
+          payload: declinedGoogleAuthRequest
+        }).then(() => {
+          done()
+        }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
+      })
+    })
+
+    describe('authorisation error', function () {
+      const errorGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails({
+        lastDigitsCardNumber: '0119'
+      })
+
+      before(() => {
+        const builder = new PactInteractionBuilder(STRIPE_GOOGLE_AUTH_PATH)
+          .withRequestBody(errorGoogleAuthRequest)
+          .withMethod('POST')
+          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withUponReceiving('a valid stripe google pay auth request which should return an error')
+          .withStatusCode(402)
+          .build()
+        return provider.addInteraction(builder)
+      })
+
+      afterEach(() => provider.verify())
+
+      it('should return authorisation declined', function (done) {
+        connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
+          ...CHARGE_OPTIONS,
+          payload: errorGoogleAuthRequest
+        }).then(() => {
+          done()
+        }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
+      })
+    })
+  })
+})

--- a/test/unit/clients/connector-client-stripe-google-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-stripe-google-authentication.pact.test.js
@@ -131,7 +131,7 @@ describe('connectors client - stripe google authentication API', function () {
     })
 
     describe('authorisation error', function () {
-      const errorGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails({
+      const errorGoogleAuthRequest = fixtures.stripeGoogleAuthRequestDetails({
         lastDigitsCardNumber: '0119'
       })
 

--- a/test/unit/clients/connector-client-worldpay-google-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-worldpay-google-authentication.pact.test.js
@@ -10,7 +10,7 @@ const chaiAsPromised = require('chai-as-promised')
 
 // Constants
 const TEST_CHARGE_ID = 'testChargeId'
-const GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google/worldpay`
+const WORLDPAY_GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google/worldpay`
 const PORT = Math.floor(Math.random() * 48127) + 1024
 const BASEURL = `http://127.0.0.1:${PORT}`
 
@@ -26,7 +26,7 @@ chai.use(chaiAsPromised)
 
 const GOOGLE_DDC_RESULT = 'some long opaque string that’s a device data collection result'
 
-describe('connectors client - google authentication API', function () {
+describe('connectors client - worldpay google authentication API', function () {
   const provider = new Pact({
     consumer: 'frontend',
     provider: 'connector',
@@ -40,17 +40,16 @@ describe('connectors client - google authentication API', function () {
   before(() => provider.setup())
   after(() => provider.finalize())
 
-  describe('Authenticate google payment', function () {
+  describe('Authenticate Worldpay google payment', function () {
     describe('authorisation success', function () {
-      const successfulGoogleAuthRequest = fixtures.googleAuthRequestDetails({ worldpay3dsFlexDdcResult: GOOGLE_DDC_RESULT })
+      const successfulGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails({ worldpay3dsFlexDdcResult: GOOGLE_DDC_RESULT })
       const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
-
       before(() => {
-        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
           .withRequestBody(successfulGoogleAuthRequest)
           .withMethod('POST')
           .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid google pay auth request which should be authorised')
+          .withUponReceiving('a valid worldpay google pay auth request which should be authorised')
           .withResponseBody(pactify(authorisationSuccessResponse))
           .withStatusCode(200)
           .build()
@@ -74,18 +73,18 @@ describe('connectors client - google authentication API', function () {
     })
 
     describe('authorisation success with no last card digits', function () {
-      const successfulGoogleAuthRequest = fixtures.googleAuthRequestDetails({
+      const successfulGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails({
         lastDigitsCardNumber: '',
         worldpay3dsFlexDdcResult: GOOGLE_DDC_RESULT
       })
       const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
 
       before(() => {
-        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
           .withRequestBody(successfulGoogleAuthRequest)
           .withMethod('POST')
           .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid google pay auth request with no last card digits which should be authorised')
+          .withUponReceiving('a valid worldpay google pay auth request with no last card digits which should be authorised')
           .withResponseBody(pactify(authorisationSuccessResponse))
           .withStatusCode(200)
           .build()
@@ -109,17 +108,17 @@ describe('connectors client - google authentication API', function () {
     })
 
     describe('authorisation declined', function () {
-      const declinedGoogleAuthRequest = fixtures.googleAuthRequestDetails({
+      const declinedGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails({
         lastDigitsCardNumber: '0002',
         worldpay3dsFlexDdcResult: GOOGLE_DDC_RESULT
       })
 
       before(() => {
-        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
           .withRequestBody(declinedGoogleAuthRequest)
           .withMethod('POST')
           .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid google pay auth request which should be declined')
+          .withUponReceiving('a valid worldpay google pay auth request which should be declined')
           .withStatusCode(400)
           .build()
         return provider.addInteraction(builder)
@@ -140,17 +139,17 @@ describe('connectors client - google authentication API', function () {
     })
 
     describe('authorisation error', function () {
-      const errorGoogleAuthRequest = fixtures.googleAuthRequestDetails({
+      const errorGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails({
         lastDigitsCardNumber: '0119',
         worldpay3dsFlexDdcResult: GOOGLE_DDC_RESULT
       })
 
       before(() => {
-        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
           .withRequestBody(errorGoogleAuthRequest)
           .withMethod('POST')
           .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid google pay auth request which should return an error')
+          .withUponReceiving('a valid worldpay google pay auth request which should return an error')
           .withStatusCode(402)
           .build()
         return provider.addInteraction(builder)
@@ -171,15 +170,15 @@ describe('connectors client - google authentication API', function () {
     })
 
     describe('authorisation success with no ddc result', function () {
-      const successfulGoogleAuthRequest = fixtures.googleAuthRequestDetails()
+      const successfulGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails()
       const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
 
       before(() => {
-        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
           .withRequestBody(successfulGoogleAuthRequest)
           .withMethod('POST')
           .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid google pay auth request with no ddc result which should be authorised')
+          .withUponReceiving('a valid worldpay google pay auth request with no ddc result which should be authorised')
           .withResponseBody(pactify(authorisationSuccessResponse))
           .withStatusCode(200)
           .build()


### PR DESCRIPTION
## WHAT

Implements Google Pay for Stripe accounts:
- `payment_provider` and `stripePublishableKey` are now available in the dom window, we use them in client-side scripts to:
  - prevent device data collection from taking place for Stripe Google payments.
  - enable a Stripe-specific `tokenizationSpecification` structure when interfacing with Google
- the charge controller determines which Stripe publishable key to use based on the gateway account type
- Stripe-specific `connector` request bodies are handled by `normalise-google-pay-payload.js`
- the `connector` client now understands which provider endpoint to call based on the wallet type of the charge
- new pact testing Stripe-specific Google wallet authorisations



