### PR TITLE
PP-11582 Fix Google Pay repeated error message bug

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -10,6 +10,7 @@ const showErrorSummary = (title, body) => {
   errorSummary.classList.remove('hidden')
   errorSummary.querySelectorAll('h2')[0].innerText = title
   if (body) {
+    errorSummary.querySelectorAll('ul')[0].innerHTML = ''
     const error = document.createElement('li')
     error.innerText = body
     errorSummary.querySelectorAll('ul')[0].appendChild(error)

--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -7,10 +7,10 @@ const { email_collection_mode } = window.Charge || {} // eslint-disable-line cam
 
 const showErrorSummary = (title, body) => {
   const errorSummary = document.getElementById('error-summary')
+  errorSummary.querySelectorAll('ul')[0].innerHTML = ''
   errorSummary.classList.remove('hidden')
   errorSummary.querySelectorAll('h2')[0].innerText = title
   if (body) {
-    errorSummary.querySelectorAll('ul')[0].innerHTML = ''
     const error = document.createElement('li')
     error.innerText = body
     errorSummary.querySelectorAll('ul')[0].appendChild(error)

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -76,7 +76,7 @@
     <div class="govuk-grid-row govuk-!-margin-bottom-9">
       <main class="charge-new govuk-grid-column-two-thirds" id="main-content" role="main">
           <div class="charge-new__content">
-            <div id="error-summary" class="govuk-error-summary {% if not hasError %}hidden{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+            <div id="error-summary" data-cy="error-summary" class="govuk-error-summary {% if not hasError %}hidden{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
               <h2 class="govuk-error-summary__title" id="error-summary-title">
                 {{ __p("fieldErrors.summary") }}
               </h2>


### PR DESCRIPTION
Context: Bug - if a Google Pay payment fails multiple times, the same error message is shown multiple times
- Clear existing error messages before displaying the new error message


