### PR TITLE
PP-11496 Wallet payments - update error handling and logging of the `handle auth response` controller

### DIFF
--- a/app/controllers/web-payments/handle-auth-response.controller.js
+++ b/app/controllers/web-payments/handle-auth-response.controller.js
@@ -39,6 +39,7 @@ const handleAuthResponse = (req, res, charge) => response => {
         logger.info('Requesting 3DS1 for Google payment, redirect to auth 3ds page', getLoggingFields(req))
         return redirect(res).toAuth3dsRequired(req.chargeId)
       } else {
+        logger.info('Requesting capture for digital wallet payment', getLoggingFields(req))
         Charge(req.headers[CORRELATION_HEADER])
           .capture(req.chargeId, getLoggingFields(req))
           .then(
@@ -70,17 +71,13 @@ const handleAuthResponse = (req, res, charge) => response => {
         { returnUrl: routeFor('return', charge.id) },
         webPaymentsRouteFor('handlePaymentResponse', charge.id))
       )
-    case 402:
-    case 500:
+    default:
       logging.failedChargePost(response.statusCode, getLoggingFields(req))
       responseRouter.systemErrorResponse(req, res, 'Wallet authorisation error response', withAnalytics(
         charge,
         { returnUrl: routeFor('return', charge.id) },
         webPaymentsRouteFor('handlePaymentResponse', charge.id))
       )
-      break
-    default:
-      redirect(res).toNew(req.chargeId)
   }
 }
 

--- a/test/controllers/web-payments/handle-auth-response.controller.test.js
+++ b/test/controllers/web-payments/handle-auth-response.controller.test.js
@@ -297,6 +297,39 @@ describe('The web payments handle auth response controller', () => {
     done()
   })
 
+  it('should show error page and delete connector response if connector response is in the session and status is not recognised', done => {
+    const mockCharge = sinon.spy()
+    const res = {
+      redirect: sinon.spy(),
+      render: sinon.spy(),
+      status: sinon.spy()
+    }
+    const mockCookies = {
+      getSessionVariable: (req, key) => {
+        return {
+          statusCode: 'unknown-status-code'
+        }
+      },
+      deleteSessionVariable: sinon.spy()
+    }
+    const systemErrorObj = {
+      viewName: 'SYSTEM_ERROR',
+      returnUrl: '/return/3',
+      analytics: {
+        analyticsId: 'test-1234',
+        type: 'test',
+        paymentProvider: 'sandbox',
+        path: '/handle-payment-response/3/error',
+        amount: '4.99',
+        testingVariant: 'original'
+      }
+    }
+    requireHandleAuthResponseController(mockCharge, mockNormaliseCharge, mockCookies)(req, res)
+    expect(mockCookies.deleteSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
+    expect(res.render.calledWith('errors/system-error', systemErrorObj)).to.be.true // eslint-disable-line
+    done()
+  })
+
   it('should return error if connector response has not been saved in the session', done => {
     const res = {
       redirect: sinon.spy(),


### PR DESCRIPTION
- During a wallet payment - when calling connector, improve the error handling and logging
  - Add a catch all to pick up any unknown status codes returned from connector.

