### PR TITLE
PP-11496 Wallet payments - add exception handling to `payment auth request` controller

### DIFF
--- a/app/controllers/web-payments/payment-auth-request.controller.js
+++ b/app/controllers/web-payments/payment-auth-request.controller.js
@@ -11,18 +11,28 @@ const { CORRELATION_HEADER } = require('../../../config/correlation-header')
 const { setSessionVariable } = require('../../utils/cookies')
 const normalise = require('../../services/normalise-charge')
 
-module.exports = (req, res) => {
+module.exports = (req, res, next) => {
   const { chargeData, chargeId, params } = req
   const charge = normalise.charge(chargeData, chargeId)
   const wallet = params.provider
   const paymentProvider = charge.paymentProvider
+  let payload
 
   const { worldpay3dsFlexDdcStatus } = req.body
   if (worldpay3dsFlexDdcStatus) {
     logging.worldpay3dsFlexDdcStatus(worldpay3dsFlexDdcStatus, getLoggingFields(req))
   }
-
-  const payload = wallet === 'apple' ? normaliseApplePayPayload(req) : normaliseGooglePayPayload(req, paymentProvider)
+  try {
+    payload = wallet === 'apple' ? normaliseApplePayPayload(req) : normaliseGooglePayPayload(req, paymentProvider)
+  } catch (error) {
+    logger.error('Exception normalising Wallet payload', {
+      ...getLoggingFields(req),
+      charge_status: charge.status,
+      error,
+      wallet
+    })
+    return next(error)
+  }
 
   const chargeOptions = {
     chargeId,
@@ -36,7 +46,8 @@ module.exports = (req, res) => {
       setSessionVariable(req, `ch_${(chargeId)}.webPaymentAuthResponse`, {
         statusCode: data.statusCode
       })
-      logger.info(`Successful auth for ${wallet} Pay payment. ChargeID: ${chargeId}`, getLoggingFields(req))
+
+      // Always return 200 - the redirect checks if there are any errors
       res.status(200)
       res.send({ url: `/handle-payment-response/${chargeId}` })
     })
@@ -46,6 +57,7 @@ module.exports = (req, res) => {
         error: err
       })
       res.status(200)
+      // Always return 200 - the redirect handles the error
       res.send({ url: `/handle-payment-response/${chargeId}` })
     })
 }

--- a/test/controllers/web-payments/payment-auth-request.controller.test.js
+++ b/test/controllers/web-payments/payment-auth-request.controller.test.js
@@ -60,24 +60,24 @@ describe('The web payments auth request controller', () => {
       )
     })
 
-    it('should not set payload in the session and return handle payment url if error', done => {
+    it('should call the `next` function when the Apple Pay normalise function throws an error', done => {
       const res = {
         status: sinon.spy(),
         send: sinon.spy()
       }
-      const mockCookies = {
-        setSessionVariable: sinon.spy()
+
+      const mockCookies = () => {}
+      const error = new Error('Error normalising Apple Pay payload')
+      const next = sinon.spy()
+
+      const mockNormaliseThrowException = function (object) {
+        throw error
       }
-      nock(process.env.CONNECTOR_HOST)
-        .post(`/v1/frontend/charges/${chargeId}/wallets/apple`)
-        .replyWithError('oops')
-      requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
-          expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
-          expect(res.send.calledWith({url: `/handle-payment-response/${chargeId}`})).to.be.ok // eslint-disable-line
-          expect(mockCookies.setSessionVariable.called).to.be.false // eslint-disable-line
-        done()
-      }
-      )
+
+      requirePaymentAuthRequestController(mockNormaliseThrowException, mockCookies)(req, res, next)
+      sinon.assert.calledWith(next, error)
+
+      done()
     })
   })
 
@@ -145,6 +145,26 @@ describe('The web payments auth request controller', () => {
         done()
       }
       )
+    })
+
+    it('should call the `next` function when the Google Pay normalise function throws an error', done => {
+      const res = {
+        status: sinon.spy(),
+        send: sinon.spy()
+      }
+
+      const mockCookies = () => {}
+      const error = new Error('Error normalising Google Pay payload')
+      const next = sinon.spy()
+
+      const mockNormaliseThrowException = function (object) {
+        throw error
+      }
+
+      requirePaymentAuthRequestController(mockNormaliseThrowException, mockCookies)(req, res, next)
+      sinon.assert.calledWith(next, error)
+
+      done()
     })
   })
 })


### PR DESCRIPTION
- When a wallet payment is made, it gets sent to the `payment auth request` controller.
- This controller will normalise the payload before submitting a request to connector to authorise the payment.
- This PR adds exception handling code for any exceptions that occur while normalising the payload.



