### PR TITLE
PP-11674 fix broken links

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -70,12 +70,12 @@
           <ul class="govuk-footer__inline-list govuk-!-margin-bottom-6">
             <li class="govuk-footer__inline-list-item">
               Read our updated
-              <a class="govuk-footer__link" href="/privacy">
+              <a class="govuk-footer__link" href="https://www.payments.service.gov.uk/privacy">
                 privacy notice
               </a>
             </li>
             <li class="govuk-footer__inline-list-item">
-              <a class="govuk-footer__link" href="/accessibility-statement">
+              <a class="govuk-footer__link" href="https://www.payments.service.gov.uk/accessibility-statement">
                 Accessibility Statement
               </a>
             </li>


### PR DESCRIPTION
## WHAT

Pay privacy and accessibility statements are no longer hosted on `frontend`, update links to the new location


