### PR TITLE
PP-11577 implement apple pay for sandbox accounts

### DIFF
--- a/app/assets/sass/modules/_web-payments.scss
+++ b/app/assets/sass/modules/_web-payments.scss
@@ -44,6 +44,7 @@
   //https://developer.apple.com/documentation/apple_pay_on_the_web/displaying_apple_pay_buttons
   &--apple-pay{
     @supports (-webkit-appearance: -apple-pay-button) {
+      border-radius: 4px;
       min-width: 200px;
       width: 100%;
       min-height: 32px;

--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -17,7 +17,7 @@ ${key}
 }
 
 function getApplePayMerchantIdentityVariables (paymentProvider) {
-  if (paymentProvider === 'worldpay') {
+  if (paymentProvider === 'worldpay' || paymentProvider === 'sandbox') {
     return {
       merchantIdentifier: process.env.WORLDPAY_APPLE_PAY_MERCHANT_ID,
       cert: getCertificateMultiline(process.env.WORLDPAY_APPLE_PAY_MERCHANT_ID_CERTIFICATE),

--- a/app/utils/wallet-utils.js
+++ b/app/utils/wallet-utils.js
@@ -6,7 +6,7 @@ function applePayEnabled (charge) {
   const applePayEnabledForWorldpay = (process.env.WORLDPAY_APPLE_PAY_ENABLED || 'true') === 'true'
   const applePayEnabledForStripe = (process.env.STRIPE_APPLE_PAY_ENABLED || 'true') === 'true'
 
-  const globallyEnabledForProvider = (charge.paymentProvider === 'worldpay' && applePayEnabledForWorldpay) ||
+  const globallyEnabledForProvider = ((charge.paymentProvider === 'worldpay' || charge.paymentProvider === 'sandbox') && applePayEnabledForWorldpay) ||
     (charge.paymentProvider === 'stripe' && applePayEnabledForStripe)
 
   return (globallyEnabledForProvider || shouldOverrideGlobalWalletFlagForGatewayAccount(charge)) &&

--- a/test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js
+++ b/test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js
@@ -119,7 +119,7 @@ ${stripeKey}
     sinon.assert.calledWith(res.sendStatus, 400)
   })
 
-  it('should return 400 for unexpected payment provider', async () => {
+  it('should return a payload for a Sandbox payment if Merchant is valid', async () => {
     const mockRequest = sinon.stub().yields(null, appleResponse, appleResponseBody)
     const controller = getControllerWithMocks(mockRequest)
 
@@ -127,6 +127,39 @@ ${stripeKey}
       body: {
         url,
         paymentProvider: 'sandbox'
+      }
+    }
+    await controller(req, res)
+
+    sinon.assert.calledWith(mockRequest, {
+      url,
+      body: {
+        merchantIdentifier: worldpayMerchantId,
+        displayName: 'GOV.UK Pay',
+        initiative: 'web',
+        initiativeContext: merchantDomain
+      },
+      method: 'post',
+      json: true,
+      cert: `-----BEGIN CERTIFICATE-----
+${worldpayCertificate}
+-----END CERTIFICATE-----`,
+      key: `-----BEGIN PRIVATE KEY-----
+${worldpayKey}
+-----END PRIVATE KEY-----`
+    })
+    sinon.assert.calledWith(res.status, 200)
+    sinon.assert.calledWith(sendSpy, appleResponseBody)
+  })
+
+  it('should return 400 for unexpected payment provider', async () => {
+    const mockRequest = sinon.stub().yields(null, appleResponse, appleResponseBody)
+    const controller = getControllerWithMocks(mockRequest)
+
+    const req = {
+      body: {
+        url,
+        paymentProvider: 'mystery'
       }
     }
     await controller(req, res)

--- a/test/unit/clients/connector-client-apple-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-apple-authentication.pact.test.js
@@ -133,58 +133,57 @@ describe('connectors client - apple authentication API', function () {
     })
   })
 
-  // TODO: re-enable these pact tests with new state providers once https://github.com/alphagov/pay-connector/pull/4754 is merged
-  // describe('authorisation declined', function () {
-  //   const appleAuthRequest = fixtures.appleAuthRequestDetails({ email: 'name@email.test', lastDigitsCardNumber: '0002' })
-  //
-  //   before(() => {
-  //     const builder = new PactInteractionBuilder(APPLE_AUTH_PATH)
-  //       .withRequestBody(appleAuthRequest)
-  //       .withMethod('POST')
-  //       .withState('a sandbox account exists with a charge with id testChargeId and description DECLINED that is in state ENTERING_CARD_DETAILS.')
-  //       .withUponReceiving('a valid apple pay auth request which should be declined')
-  //       .withStatusCode(400)
-  //       .build()
-  //     return provider.addInteraction(builder)
-  //   })
-  //
-  //   afterEach(() => provider.verify())
-  //
-  //   it('should return authorisation declined', function (done) {
-  //     connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
-  //       chargeId: TEST_CHARGE_ID,
-  //       wallet: 'apple',
-  //       payload: appleAuthRequest
-  //     }).then(() => {
-  //       done()
-  //     }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
-  //   })
-  // })
-  //
-  // describe('authorisation error', function () {
-  //   const appleAuthRequest = fixtures.appleAuthRequestDetails({ email: 'name@email.test', lastDigitsCardNumber: '0119' })
-  //
-  //   before(() => {
-  //     const builder = new PactInteractionBuilder(APPLE_AUTH_PATH)
-  //       .withRequestBody(appleAuthRequest)
-  //       .withMethod('POST')
-  //       .withState('a sandbox account exists with a charge with id testChargeId and description ERROR that is in state ENTERING_CARD_DETAILS.')
-  //       .withUponReceiving('a valid apple pay auth request which should return an error')
-  //       .withStatusCode(402)
-  //       .build()
-  //     return provider.addInteraction(builder)
-  //   })
-  //
-  //   afterEach(() => provider.verify())
-  //
-  //   it('should return authorisation declined', function (done) {
-  //     connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
-  //       chargeId: TEST_CHARGE_ID,
-  //       wallet: 'apple',
-  //       payload: appleAuthRequest
-  //     }).then(() => {
-  //       done()
-  //     }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
-  //   })
-  // })
+  describe('authorisation declined', function () {
+    const appleAuthRequest = fixtures.appleAuthRequestDetails({ email: 'name@email.test', lastDigitsCardNumber: '0002' })
+
+    before(() => {
+      const builder = new PactInteractionBuilder(APPLE_AUTH_PATH)
+        .withRequestBody(appleAuthRequest)
+        .withMethod('POST')
+        .withState('a sandbox account exists with a charge with id testChargeId and description DECLINED that is in state ENTERING_CARD_DETAILS.')
+        .withUponReceiving('a valid apple pay auth request which should be declined')
+        .withStatusCode(400)
+        .build()
+      return provider.addInteraction(builder)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should return authorisation declined', function (done) {
+      connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
+        chargeId: TEST_CHARGE_ID,
+        wallet: 'apple',
+        payload: appleAuthRequest
+      }).then(() => {
+        done()
+      }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
+    })
+  })
+
+  describe('authorisation error', function () {
+    const appleAuthRequest = fixtures.appleAuthRequestDetails({ email: 'name@email.test', lastDigitsCardNumber: '0119' })
+
+    before(() => {
+      const builder = new PactInteractionBuilder(APPLE_AUTH_PATH)
+        .withRequestBody(appleAuthRequest)
+        .withMethod('POST')
+        .withState('a sandbox account exists with a charge with id testChargeId and description ERROR that is in state ENTERING_CARD_DETAILS.')
+        .withUponReceiving('a valid apple pay auth request which should return an error')
+        .withStatusCode(402)
+        .build()
+      return provider.addInteraction(builder)
+    })
+
+    afterEach(() => provider.verify())
+
+    it('should return authorisation declined', function (done) {
+      connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
+        chargeId: TEST_CHARGE_ID,
+        wallet: 'apple',
+        payload: appleAuthRequest
+      }).then(() => {
+        done()
+      }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
+    })
+  })
 })


### PR DESCRIPTION
## WHAT

- fix apple pay button styling
- enable sandbox apple pay payments via worldplay
- switch on pact tests for sandbox wallet payments, see https://github.com/alphagov/pay-connector/pull/4754 

<img width="970" alt="Screenshot 2023-10-24 at 17 52 20" src="https://github.com/alphagov/pay-frontend/assets/1949148/4d10e09c-6a6e-4231-a9d9-c143b83d68b6">

![Screenshot 2023-10-24 at 17 52 23](https://github.com/alphagov/pay-frontend/assets/1949148/33212188-ddd9-4e53-a52b-600d3cf2c8df)

![Screenshot 2023-10-24 at 17 52 31](https://github.com/alphagov/pay-frontend/assets/1949148/2d4ea449-24cb-4ffc-b681-f2ba8985a656)

![Screenshot 2023-10-24 at 17 52 41](https://github.com/alphagov/pay-frontend/assets/1949148/43f24938-1ae7-4bc7-b73d-aa42e2faf4fb)

![Screenshot 2023-10-24 at 17 53 06](https://github.com/alphagov/pay-frontend/assets/1949148/ab54d4d6-6997-4f6e-984b-abc1da29af92)

![Screenshot 2023-10-24 at 17 53 21](https://github.com/alphagov/pay-frontend/assets/1949148/6c2ed6ad-d297-417f-b49e-ab56343a3c69)

![Screenshot 2023-10-24 at 17 53 28](https://github.com/alphagov/pay-frontend/assets/1949148/e59ae5c9-4a14-402d-9d3b-a0eee68dc491)

