### PR TITLE
PP-11641 Point to generic Google Pay endpoint

### DIFF
--- a/app/controllers/web-payments/payment-auth-request.controller.js
+++ b/app/controllers/web-payments/payment-auth-request.controller.js
@@ -37,7 +37,6 @@ module.exports = (req, res, next) => {
   const chargeOptions = {
     chargeId,
     wallet,
-    paymentProvider,
     payload
   }
 

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -28,16 +28,10 @@ const _getFindChargeUrlFor = chargeId => baseUrl + CARD_CHARGE_PATH.replace('{ch
 const _getAuthUrlFor = chargeId => baseUrl + CARD_AUTH_PATH.replace('{chargeId}', chargeId)
 
 /** @private */
-const _getWalletAuthUrlFor = (chargeId, walletType, paymentProvider) => {
-  let walletAuthUrl = baseUrl + WALLET_AUTH_PATH
+const _getWalletAuthUrlFor = (chargeId, walletType) => {
+  const walletAuthUrl = baseUrl + WALLET_AUTH_PATH
     .replace('{chargeId}', chargeId)
     .replace('{walletType}', walletType)
-
-  if (walletType === 'google') {
-    if (paymentProvider === 'worldpay' || paymentProvider === 'stripe') {
-      walletAuthUrl = walletAuthUrl.concat(`/${paymentProvider}`)
-    }
-  }
   return walletAuthUrl
 }
 
@@ -239,7 +233,7 @@ const chargeAuth = (chargeOptions, loggingFields = {}) => {
 }
 
 const chargeAuthWithWallet = (chargeOptions, loggingFields = {}) => {
-  const authUrl = _getWalletAuthUrlFor(chargeOptions.chargeId, chargeOptions.wallet, chargeOptions.paymentProvider)
+  const authUrl = _getWalletAuthUrlFor(chargeOptions.chargeId, chargeOptions.wallet)
   return _postConnector(authUrl, chargeOptions.payload, 'create charge using e-wallet payment', loggingFields, 'chargeAuthWithWallet')
 }
 

--- a/test/controllers/web-payments/payment-auth-request.controller.test.js
+++ b/test/controllers/web-payments/payment-auth-request.controller.test.js
@@ -116,7 +116,7 @@ describe('The web payments auth request controller', () => {
         statusCode: 200
       }
       nock(process.env.CONNECTOR_HOST)
-        .post(`/v1/frontend/charges/${chargeId}/wallets/google/worldpay`)
+        .post(`/v1/frontend/charges/${chargeId}/wallets/google`)
         .reply(200)
       requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
         expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
@@ -141,7 +141,7 @@ describe('The web payments auth request controller', () => {
         errorIdentifier: 'AUTHORISATION_REJECTED'
       }
       nock(process.env.CONNECTOR_HOST)
-        .post(`/v1/frontend/charges/${chargeId}/wallets/google/worldpay`)
+        .post(`/v1/frontend/charges/${chargeId}/wallets/google`)
         .reply(200, { error_identifier: 'AUTHORISATION_REJECTED' })
 
       requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {

--- a/test/unit/clients/connector-client-stripe-google-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-stripe-google-authentication.pact.test.js
@@ -15,7 +15,7 @@ const CHARGE_OPTIONS = {
   wallet: 'google',
   paymentProvider: 'stripe'
 }
-const STRIPE_GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google/stripe`
+const GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google`
 const PORT = Math.floor(Math.random() * 48127) + 1024
 const BASEURL = `http://127.0.0.1:${PORT}`
 
@@ -48,10 +48,10 @@ describe('connectors client - stripe google authentication API', function () {
       const successfulGoogleAuthRequest = fixtures.stripeGoogleAuthRequestDetails()
       const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
       before(() => {
-        const builder = new PactInteractionBuilder(STRIPE_GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
           .withRequestBody(successfulGoogleAuthRequest)
           .withMethod('POST')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withState('a Stripe account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
           .withUponReceiving('a valid stripe google pay auth request which should be authorised')
           .withResponseBody(pactify(authorisationSuccessResponse))
           .withStatusCode(200)
@@ -78,10 +78,10 @@ describe('connectors client - stripe google authentication API', function () {
       })
       const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
       before(() => {
-        const builder = new PactInteractionBuilder(STRIPE_GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
           .withRequestBody(successfulGoogleAuthRequest)
           .withMethod('POST')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withState('a Stripe account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
           .withUponReceiving('a valid stripe google pay auth request with no last card digits which should be authorised')
           .withResponseBody(pactify(authorisationSuccessResponse))
           .withStatusCode(200)
@@ -97,62 +97,6 @@ describe('connectors client - stripe google authentication API', function () {
           payload: successfulGoogleAuthRequest
         }).then(res => {
           expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
-          done()
-        }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
-      })
-    })
-
-    describe('authorisation declined', function () {
-      const declinedGoogleAuthRequest = fixtures.stripeGoogleAuthRequestDetails({
-        lastDigitsCardNumber: '0002'
-      })
-
-      before(() => {
-        const builder = new PactInteractionBuilder(STRIPE_GOOGLE_AUTH_PATH)
-          .withRequestBody(declinedGoogleAuthRequest)
-          .withMethod('POST')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid stripe google pay auth request which should be declined')
-          .withStatusCode(400)
-          .build()
-        return provider.addInteraction(builder)
-      })
-
-      afterEach(() => provider.verify())
-
-      it('should return authorisation declined', function (done) {
-        connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
-          ...CHARGE_OPTIONS,
-          payload: declinedGoogleAuthRequest
-        }).then(() => {
-          done()
-        }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
-      })
-    })
-
-    describe('authorisation error', function () {
-      const errorGoogleAuthRequest = fixtures.stripeGoogleAuthRequestDetails({
-        lastDigitsCardNumber: '0119'
-      })
-
-      before(() => {
-        const builder = new PactInteractionBuilder(STRIPE_GOOGLE_AUTH_PATH)
-          .withRequestBody(errorGoogleAuthRequest)
-          .withMethod('POST')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid stripe google pay auth request which should return an error')
-          .withStatusCode(402)
-          .build()
-        return provider.addInteraction(builder)
-      })
-
-      afterEach(() => provider.verify())
-
-      it('should return authorisation declined', function (done) {
-        connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
-          ...CHARGE_OPTIONS,
-          payload: errorGoogleAuthRequest
-        }).then(() => {
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })

--- a/test/unit/clients/connector-client-worldpay-google-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-worldpay-google-authentication.pact.test.js
@@ -10,7 +10,7 @@ const chaiAsPromised = require('chai-as-promised')
 
 // Constants
 const TEST_CHARGE_ID = 'testChargeId'
-const WORLDPAY_GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google/worldpay`
+const GOOGLE_AUTH_PATH = `/v1/frontend/charges/${TEST_CHARGE_ID}/wallets/google`
 const PORT = Math.floor(Math.random() * 48127) + 1024
 const BASEURL = `http://127.0.0.1:${PORT}`
 
@@ -45,10 +45,10 @@ describe('connectors client - worldpay google authentication API', function () {
       const successfulGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails({ worldpay3dsFlexDdcResult: GOOGLE_DDC_RESULT })
       const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
       before(() => {
-        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
           .withRequestBody(successfulGoogleAuthRequest)
           .withMethod('POST')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withState('a Worldpay account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
           .withUponReceiving('a valid worldpay google pay auth request which should be authorised')
           .withResponseBody(pactify(authorisationSuccessResponse))
           .withStatusCode(200)
@@ -80,10 +80,10 @@ describe('connectors client - worldpay google authentication API', function () {
       const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
 
       before(() => {
-        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
           .withRequestBody(successfulGoogleAuthRequest)
           .withMethod('POST')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withState('a Worldpay account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
           .withUponReceiving('a valid worldpay google pay auth request with no last card digits which should be authorised')
           .withResponseBody(pactify(authorisationSuccessResponse))
           .withStatusCode(200)
@@ -107,77 +107,15 @@ describe('connectors client - worldpay google authentication API', function () {
       })
     })
 
-    describe('authorisation declined', function () {
-      const declinedGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails({
-        lastDigitsCardNumber: '0002',
-        worldpay3dsFlexDdcResult: GOOGLE_DDC_RESULT
-      })
-
-      before(() => {
-        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
-          .withRequestBody(declinedGoogleAuthRequest)
-          .withMethod('POST')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid worldpay google pay auth request which should be declined')
-          .withStatusCode(400)
-          .build()
-        return provider.addInteraction(builder)
-      })
-
-      afterEach(() => provider.verify())
-
-      it('should return authorisation declined', function (done) {
-        connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
-          chargeId: TEST_CHARGE_ID,
-          wallet: 'google',
-          payload: declinedGoogleAuthRequest,
-          paymentProvider: 'worldpay'
-        }).then(() => {
-          done()
-        }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
-      })
-    })
-
-    describe('authorisation error', function () {
-      const errorGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails({
-        lastDigitsCardNumber: '0119',
-        worldpay3dsFlexDdcResult: GOOGLE_DDC_RESULT
-      })
-
-      before(() => {
-        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
-          .withRequestBody(errorGoogleAuthRequest)
-          .withMethod('POST')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
-          .withUponReceiving('a valid worldpay google pay auth request which should return an error')
-          .withStatusCode(402)
-          .build()
-        return provider.addInteraction(builder)
-      })
-
-      afterEach(() => provider.verify())
-
-      it('should return authorisation declined', function (done) {
-        connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
-          chargeId: TEST_CHARGE_ID,
-          wallet: 'google',
-          payload: errorGoogleAuthRequest,
-          paymentProvider: 'worldpay'
-        }).then(() => {
-          done()
-        }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
-      })
-    })
-
     describe('authorisation success with no ddc result', function () {
       const successfulGoogleAuthRequest = fixtures.worldpayGoogleAuthRequestDetails()
       const authorisationSuccessResponse = fixtures.webPaymentSuccessResponse()
 
       before(() => {
-        const builder = new PactInteractionBuilder(WORLDPAY_GOOGLE_AUTH_PATH)
+        const builder = new PactInteractionBuilder(GOOGLE_AUTH_PATH)
           .withRequestBody(successfulGoogleAuthRequest)
           .withMethod('POST')
-          .withState('a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
+          .withState('a Worldpay account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.')
           .withUponReceiving('a valid worldpay google pay auth request with no ddc result which should be authorised')
           .withResponseBody(pactify(authorisationSuccessResponse))
           .withStatusCode(200)


### PR DESCRIPTION
Context: connector's google/worlpay and google/stripe endpoints are being merged into a single endpoint for Google Pay authorisations

- point frontend wallet authorisation requests to the new wallets/google endpoint
- point consumer tests to new connector provider states that include stubbing for Worldpay and Stripe
- remove the decline and error consumer tests, to be reintroduced when sandbox authorisations are enabled.