### PR TITLE
PP-11638 Send client-side errors to Sentry

### DIFF
--- a/app/assets/javascripts/browsered/sentry.js
+++ b/app/assets/javascripts/browsered/sentry.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const Sentry = require('@sentry/browser')
+
+function initialiseSentry () {
+  Sentry.init({
+    dsn: window.sentryDSN,
+    environment: window.environment
+  })
+}
+
+module.exports = {
+  initialiseSentry
+}

--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -3,6 +3,7 @@
 const { prepareAppleRequestObject, showErrorSummary } = require('./helpers')
 const { toggleSubmitButtons, showSpinnerAndHideMainContent, hideSpinnerAndShowMainContent } = require('../helpers')
 const { validateEmail } = require('../../../../utils/email-validation')
+const Sentry = require('@sentry/browser')
 const { email_collection_mode } = window.Charge || {} // eslint-disable-line camelcase
 
 module.exports = () => {
@@ -25,6 +26,7 @@ module.exports = () => {
           return data
         })
       } else {
+        Sentry.captureMessage('Apple Pay Merchant ID not valid');
         ga('send', 'event', 'Apple Pay', 'Error', 'Merchant ID not valid')
         return session.abort()
       }

--- a/app/browsered.js
+++ b/app/browsered.js
@@ -4,6 +4,7 @@ const analytics = require('gaap-analytics')
 const formValidation = require('./assets/javascripts/browsered/form-validation')
 const epdq3ds2 = require('./assets/javascripts/browsered/epdq-3ds2')
 const helpers = require('./assets/javascripts/browsered/helpers')
+const sentry = require('./assets/javascripts/browsered/sentry')
 
 exports.chargeValidation = require('./utils/charge-validation')
 analytics.eventTracking.init()
@@ -14,7 +15,8 @@ window.payScripts = { // eslint-disable-line no-unused-vars
   inputConfirm,
   webPayments,
   formValidation,
-  epdq3ds2
+  epdq3ds2,
+  sentry
 }
 
 // GA tracking if an email typo is spotted

--- a/app/utils/response-router.js
+++ b/app/utils/response-router.js
@@ -293,7 +293,12 @@ function shouldRedirect (req, res, action) {
 }
 
 function render (res, action, options) {
-  options = (action.locals) ? lodash.merge({}, action.locals, options) : options
+  options = {
+    ...options,
+    ...action.locals,
+    sentryDSN: process.env.SENTRY_DSN,
+    environment: process.env.ENVIRONMENT
+  }
   if (lodash.get(options, 'analytics.path')) {
     options.analytics.path = options.analytics.path + lodash.get(action, 'analyticsPage', '')
   }

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -3,6 +3,9 @@
   var i18n = {{ translationStrings | safe }}
   {% endif %}
 
+  window.sentryDSN = '{{ sentryDSN }}'
+  window.environment = '{{ environment }}'
+
   window.paymentDetails = {
     description: '{{description}}',
     amount: '{{amount}}',
@@ -38,6 +41,8 @@
 
   var mainWrap = document.getElementsByTagName('main')[0]
   document.addEventListener('DOMContentLoaded', function() {
+    window.payScripts.sentry.initialiseSentry()
+    myUndefinedFunction();
     window.GOVUKFrontend.initAll()
     if (mainWrap.classList.contains('charge-new')) {
       window.payScripts.helpers.setGlobalChargeId()

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
         "@govuk-pay/pay-js-commons": "^4.0.5",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
+        "@sentry/browser": "^7.75.0",
         "@sentry/node": "7.74.0",
         "cert-info": "^1.5.1",
         "change-case": "2.3.x",
@@ -58,7 +59,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-string": "^1.4.0",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^13.3.1",
         "dotenv": "^16.3.1",
         "govuk-country-and-territory-autocomplete": "^1.0.2",
@@ -2453,6 +2454,65 @@
         "node": ">=8"
       }
     },
+    "node_modules/@sentry/browser": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.75.0.tgz",
+      "integrity": "sha512-DXH/69vzp2j8xjydX+lrUYasrk7a1mpbXFGA9GtnII7shMCy55+QkVxpa6cLojYUaG2K/8yFDMcrP9N395LnWg==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.75.0",
+        "@sentry/core": "7.75.0",
+        "@sentry/replay": "7.75.0",
+        "@sentry/types": "7.75.0",
+        "@sentry/utils": "7.75.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry-internal/tracing": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.75.0.tgz",
+      "integrity": "sha512-/j4opF/jB9j8qnSiQK75/lFLtkfqXS5/MoOKc2KWK/pOaf15W+6uJzGQ8jRBHLYd9dDg6AyqsF48Wqy561/mNg==",
+      "dependencies": {
+        "@sentry/core": "7.75.0",
+        "@sentry/types": "7.75.0",
+        "@sentry/utils": "7.75.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/core": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.75.0.tgz",
+      "integrity": "sha512-vXg3cdJgwzP24oTS9zFCgLW4MgTkMZqXx+ESRq7gTD9qJTpcmAmYT+Ckmvebg8K6DBThV6+0v61r50na2+XdrA==",
+      "dependencies": {
+        "@sentry/types": "7.75.0",
+        "@sentry/utils": "7.75.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/types": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.75.0.tgz",
+      "integrity": "sha512-xG8OLADxG7HpGhMxrF4v4tKq/v/gqmLsTZ858R51pz0xCWM8SK6ZSWOKudkAGBIpRjI6RUHMnkBtRAN2aKDOkQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/utils": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.75.0.tgz",
+      "integrity": "sha512-UHWKeevhUNRp+mAWDbMVFOMgseoq8t/xFgdUywO/2PC14qZKRBH+0k1BKoNkp5sOzDT06ETj2w6wYoYhy6i+dA==",
+      "dependencies": {
+        "@sentry/types": "7.75.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sentry/core": {
       "version": "7.74.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.74.0.tgz",
@@ -2479,6 +2539,64 @@
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.75.0.tgz",
+      "integrity": "sha512-TAAlj7JCMF6hFFL71RmPzVX89ltyPYFWR+t4SuWaBmU6HmTliI2eJvK+M36oE+N7s3CkyRVTaXXRe0YMwRMuZQ==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.75.0",
+        "@sentry/core": "7.75.0",
+        "@sentry/types": "7.75.0",
+        "@sentry/utils": "7.75.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry-internal/tracing": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.75.0.tgz",
+      "integrity": "sha512-/j4opF/jB9j8qnSiQK75/lFLtkfqXS5/MoOKc2KWK/pOaf15W+6uJzGQ8jRBHLYd9dDg6AyqsF48Wqy561/mNg==",
+      "dependencies": {
+        "@sentry/core": "7.75.0",
+        "@sentry/types": "7.75.0",
+        "@sentry/utils": "7.75.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/core": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.75.0.tgz",
+      "integrity": "sha512-vXg3cdJgwzP24oTS9zFCgLW4MgTkMZqXx+ESRq7gTD9qJTpcmAmYT+Ckmvebg8K6DBThV6+0v61r50na2+XdrA==",
+      "dependencies": {
+        "@sentry/types": "7.75.0",
+        "@sentry/utils": "7.75.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/types": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.75.0.tgz",
+      "integrity": "sha512-xG8OLADxG7HpGhMxrF4v4tKq/v/gqmLsTZ858R51pz0xCWM8SK6ZSWOKudkAGBIpRjI6RUHMnkBtRAN2aKDOkQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/replay/node_modules/@sentry/utils": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.75.0.tgz",
+      "integrity": "sha512-UHWKeevhUNRp+mAWDbMVFOMgseoq8t/xFgdUywO/2PC14qZKRBH+0k1BKoNkp5sOzDT06ETj2w6wYoYhy6i+dA==",
+      "dependencies": {
+        "@sentry/types": "7.75.0"
       },
       "engines": {
         "node": ">=8"
@@ -19254,6 +19372,52 @@
         "tslib": "^2.4.1 || ^1.9.3"
       }
     },
+    "@sentry/browser": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.75.0.tgz",
+      "integrity": "sha512-DXH/69vzp2j8xjydX+lrUYasrk7a1mpbXFGA9GtnII7shMCy55+QkVxpa6cLojYUaG2K/8yFDMcrP9N395LnWg==",
+      "requires": {
+        "@sentry-internal/tracing": "7.75.0",
+        "@sentry/core": "7.75.0",
+        "@sentry/replay": "7.75.0",
+        "@sentry/types": "7.75.0",
+        "@sentry/utils": "7.75.0"
+      },
+      "dependencies": {
+        "@sentry-internal/tracing": {
+          "version": "7.75.0",
+          "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.75.0.tgz",
+          "integrity": "sha512-/j4opF/jB9j8qnSiQK75/lFLtkfqXS5/MoOKc2KWK/pOaf15W+6uJzGQ8jRBHLYd9dDg6AyqsF48Wqy561/mNg==",
+          "requires": {
+            "@sentry/core": "7.75.0",
+            "@sentry/types": "7.75.0",
+            "@sentry/utils": "7.75.0"
+          }
+        },
+        "@sentry/core": {
+          "version": "7.75.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.75.0.tgz",
+          "integrity": "sha512-vXg3cdJgwzP24oTS9zFCgLW4MgTkMZqXx+ESRq7gTD9qJTpcmAmYT+Ckmvebg8K6DBThV6+0v61r50na2+XdrA==",
+          "requires": {
+            "@sentry/types": "7.75.0",
+            "@sentry/utils": "7.75.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.75.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.75.0.tgz",
+          "integrity": "sha512-xG8OLADxG7HpGhMxrF4v4tKq/v/gqmLsTZ858R51pz0xCWM8SK6ZSWOKudkAGBIpRjI6RUHMnkBtRAN2aKDOkQ=="
+        },
+        "@sentry/utils": {
+          "version": "7.75.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.75.0.tgz",
+          "integrity": "sha512-UHWKeevhUNRp+mAWDbMVFOMgseoq8t/xFgdUywO/2PC14qZKRBH+0k1BKoNkp5sOzDT06ETj2w6wYoYhy6i+dA==",
+          "requires": {
+            "@sentry/types": "7.75.0"
+          }
+        }
+      }
+    },
     "@sentry/core": {
       "version": "7.74.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.74.0.tgz",
@@ -19277,6 +19441,51 @@
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^2.4.1 || ^1.9.3"
+      }
+    },
+    "@sentry/replay": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.75.0.tgz",
+      "integrity": "sha512-TAAlj7JCMF6hFFL71RmPzVX89ltyPYFWR+t4SuWaBmU6HmTliI2eJvK+M36oE+N7s3CkyRVTaXXRe0YMwRMuZQ==",
+      "requires": {
+        "@sentry-internal/tracing": "7.75.0",
+        "@sentry/core": "7.75.0",
+        "@sentry/types": "7.75.0",
+        "@sentry/utils": "7.75.0"
+      },
+      "dependencies": {
+        "@sentry-internal/tracing": {
+          "version": "7.75.0",
+          "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.75.0.tgz",
+          "integrity": "sha512-/j4opF/jB9j8qnSiQK75/lFLtkfqXS5/MoOKc2KWK/pOaf15W+6uJzGQ8jRBHLYd9dDg6AyqsF48Wqy561/mNg==",
+          "requires": {
+            "@sentry/core": "7.75.0",
+            "@sentry/types": "7.75.0",
+            "@sentry/utils": "7.75.0"
+          }
+        },
+        "@sentry/core": {
+          "version": "7.75.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.75.0.tgz",
+          "integrity": "sha512-vXg3cdJgwzP24oTS9zFCgLW4MgTkMZqXx+ESRq7gTD9qJTpcmAmYT+Ckmvebg8K6DBThV6+0v61r50na2+XdrA==",
+          "requires": {
+            "@sentry/types": "7.75.0",
+            "@sentry/utils": "7.75.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.75.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.75.0.tgz",
+          "integrity": "sha512-xG8OLADxG7HpGhMxrF4v4tKq/v/gqmLsTZ858R51pz0xCWM8SK6ZSWOKudkAGBIpRjI6RUHMnkBtRAN2aKDOkQ=="
+        },
+        "@sentry/utils": {
+          "version": "7.75.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.75.0.tgz",
+          "integrity": "sha512-UHWKeevhUNRp+mAWDbMVFOMgseoq8t/xFgdUywO/2PC14qZKRBH+0k1BKoNkp5sOzDT06ETj2w6wYoYhy6i+dA==",
+          "requires": {
+            "@sentry/types": "7.75.0"
+          }
+        }
       }
     },
     "@sentry/types": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
     "@govuk-pay/pay-js-commons": "^4.0.5",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
+    "@sentry/browser": "^7.75.0",
     "@sentry/node": "7.74.0",
     "cert-info": "^1.5.1",
     "change-case": "2.3.x",


### PR DESCRIPTION
A proof of concept for sending client-side errors to Sentry. This will send all unhandled errors from our client.

Things to consider before we turn this on:

- What are the privacy considerations? Could there be sensistive data in JS exceptions? Can we prevent against this in a reliable way?
- Do we need to update our privacy notice if we are including Sentry JS?
- Will we run into high costs from enabling this? Are there lots of exceptions that will be logged, or is there a potential for abuse?
