### PR TITLE
PP-11032 Remove Humps module

### DIFF
--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -3,7 +3,7 @@
 const logger = require('../../../utils/logger')(__filename)
 const { getLoggingFields } = require('../../../utils/logging-fields-helper')
 const { output, redact } = require('../../../utils/structured-logging-value-helper')
-const keyCamelizer = require('../../../utils/key-camelizer')
+const { keysToSnakeCase } = require('../../../utils/key-camelizer')
 const userIpAddress = require('../../../utils/user-ip-address')
 const lodash = require('lodash')
 
@@ -95,7 +95,7 @@ module.exports = (req, paymentProvider) => {
     ip_address: userIpAddress(req)
   }
 
-  const paymentData = keyCamelizer.decamelize(JSON.parse(payload.paymentResponse.details.paymentMethodData.tokenizationData.token))
+  const paymentData = keysToSnakeCase(JSON.parse(payload.paymentResponse.details.paymentMethodData.tokenizationData.token))
 
   delete payload.paymentResponse.details.paymentMethodData
 

--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -3,8 +3,8 @@
 const logger = require('../../../utils/logger')(__filename)
 const { getLoggingFields } = require('../../../utils/logging-fields-helper')
 const { output, redact } = require('../../../utils/structured-logging-value-helper')
+const keyCamelizer = require('../../../utils/key-camelizer')
 const userIpAddress = require('../../../utils/user-ip-address')
-const humps = require('humps')
 const lodash = require('lodash')
 
 const logSelectedPayloadProperties = req => {
@@ -95,7 +95,8 @@ module.exports = (req, paymentProvider) => {
     ip_address: userIpAddress(req)
   }
 
-  const paymentData = humps.decamelizeKeys(JSON.parse(payload.paymentResponse.details.paymentMethodData.tokenizationData.token))
+  const paymentData = keyCamelizer.decamelize(JSON.parse(payload.paymentResponse.details.paymentMethodData.tokenizationData.token))
+
   delete payload.paymentResponse.details.paymentMethodData
 
   if (paymentProvider === 'stripe') {

--- a/app/services/normalise-charge.js
+++ b/app/services/normalise-charge.js
@@ -1,13 +1,13 @@
 'use strict'
 
 // NPM dependencies
-const humps = require('humps')
 const lodash = require('lodash')
 
 // Local dependencies
 const countries = require('../services/countries')
 const normaliseCards = require('../services/normalise-cards')
 const userIpAddress = require('../utils/user-ip-address')
+const keyCamelizer = require('../utils/key-camelizer')
 
 module.exports = (function () {
   const charge = function (charge, chargeId) {
@@ -92,7 +92,7 @@ module.exports = (function () {
 
   const _normaliseConfirmationDetails = function (cardDetails) {
     cardDetails.cardNumber = '●●●●●●●●●●●●' + cardDetails.last_digits_card_number
-    const normalisedDetails = humps.camelizeKeys(cardDetails)
+    const normalisedDetails = keyCamelizer.camelize(cardDetails)
     delete normalisedDetails.lastDigitsCardNumber
     if (cardDetails.billing_address) {
       normalisedDetails.billingAddress = _normaliseAddress(cardDetails.billing_address)
@@ -124,7 +124,7 @@ module.exports = (function () {
   }
 
   const _normaliseGatewayAccountDetails = function (accountDetails) {
-    const gatewayAccountDetails = humps.camelizeKeys(accountDetails)
+    const gatewayAccountDetails = keyCamelizer.camelize(accountDetails)
     gatewayAccountDetails.cardTypes = normaliseCards(gatewayAccountDetails.cardTypes)
     return gatewayAccountDetails
   }

--- a/app/services/normalise-charge.js
+++ b/app/services/normalise-charge.js
@@ -7,7 +7,7 @@ const lodash = require('lodash')
 const countries = require('../services/countries')
 const normaliseCards = require('../services/normalise-cards')
 const userIpAddress = require('../utils/user-ip-address')
-const keyCamelizer = require('../utils/key-camelizer')
+const { keysToCamelCase } = require('../utils/key-camelizer')
 
 module.exports = (function () {
   const charge = function (charge, chargeId) {
@@ -92,7 +92,7 @@ module.exports = (function () {
 
   const _normaliseConfirmationDetails = function (cardDetails) {
     cardDetails.cardNumber = '●●●●●●●●●●●●' + cardDetails.last_digits_card_number
-    const normalisedDetails = keyCamelizer.camelize(cardDetails)
+    const normalisedDetails = keysToCamelCase(cardDetails)
     delete normalisedDetails.lastDigitsCardNumber
     if (cardDetails.billing_address) {
       normalisedDetails.billingAddress = _normaliseAddress(cardDetails.billing_address)
@@ -124,7 +124,7 @@ module.exports = (function () {
   }
 
   const _normaliseGatewayAccountDetails = function (accountDetails) {
-    const gatewayAccountDetails = keyCamelizer.camelize(accountDetails)
+    const gatewayAccountDetails = keysToCamelCase(accountDetails)
     gatewayAccountDetails.cardTypes = normaliseCards(gatewayAccountDetails.cardTypes)
     return gatewayAccountDetails
   }

--- a/app/utils/key-camelizer.js
+++ b/app/utils/key-camelizer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function convertToCamelCase (objectKey) {
-  const camelizedString = objectKey.replace(/[\-_\s]+(.)?/g, (match, chr) => chr ? chr.toUpperCase() : '')
+  const camelizedString = objectKey.replace(/[-_\s]+(.)?/g, (match, chr) => chr ? chr.toUpperCase() : '')
   return camelizedString.substr(0, 1).toLowerCase() + camelizedString.substr(1)
 }
 

--- a/app/utils/key-camelizer.js
+++ b/app/utils/key-camelizer.js
@@ -5,8 +5,8 @@ function convertToCamelCase (objectKey) {
   return camelizedString.substr(0, 1).toLowerCase() + camelizedString.substr(1)
 }
 
-function convertToSnakeCase(objectKey, separator = '_', split = /(?=[A-Z])/) {
-  return objectKey.split(split).join(separator).toLowerCase();
+function convertToSnakeCase (objectKey, separator = '_', split = /(?=[A-Z])/) {
+  return objectKey.split(split).join(separator).toLowerCase()
 }
 
 function keysToCamelCase (obj) {

--- a/app/utils/key-camelizer.js
+++ b/app/utils/key-camelizer.js
@@ -1,0 +1,56 @@
+'use strict'
+
+function convertToCamelCase (objectKey) {
+  const camelizedString = objectKey.replace(/[\-_\s]+(.)?/g, (match, chr) => chr ? chr.toUpperCase() : '')
+  return camelizedString.substr(0, 1).toLowerCase() + camelizedString.substr(1)
+}
+
+function separateWords (objectKey) {
+  const options = {}
+  const separator = options.separator || '_'
+  const split = options.split || /(?=[A-Z])/
+  return objectKey.split(split).join(separator).toLowerCase()
+};
+
+function camelize (obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(item => camelize(item))
+  } else if (typeof obj === 'object') {
+    return Object.keys(obj).reduce((result, key) => {
+      if (obj[key] === null) {
+        result[convertToCamelCase(key)] = null
+      } else if (typeof obj[key] === 'object') {
+        result[convertToCamelCase(key)] = camelize(obj[key])
+      } else {
+        result[convertToCamelCase(key)] = obj[key]
+      }
+      return result
+    }, {})
+  } else {
+    return obj
+  }
+}
+
+function decamelize (obj) {
+  if (Array.isArray(obj)) {
+    return obj.map(item => decamelize(item))
+  } else if (typeof obj === 'object') {
+    return Object.keys(obj).reduce((result, key) => {
+      if (obj[key] === null) {
+        result[separateWords(key)] = null
+      } else if (typeof obj[key] === 'object') {
+        result[separateWords(key)] = decamelize(obj[key])
+      } else {
+        result[separateWords(key)] = obj[key]
+      }
+      return result
+    }, {})
+  } else {
+    return obj
+  }
+};
+
+module.exports = {
+  camelize,
+  decamelize
+}

--- a/app/utils/key-camelizer.js
+++ b/app/utils/key-camelizer.js
@@ -5,22 +5,19 @@ function convertToCamelCase (objectKey) {
   return camelizedString.substr(0, 1).toLowerCase() + camelizedString.substr(1)
 }
 
-function separateWords (objectKey) {
-  const options = {}
-  const separator = options.separator || '_'
-  const split = options.split || /(?=[A-Z])/
-  return objectKey.split(split).join(separator).toLowerCase()
-};
+function convertToSnakeCase(objectKey, separator = '_', split = /(?=[A-Z])/) {
+  return objectKey.split(split).join(separator).toLowerCase();
+}
 
-function camelize (obj) {
+function keysToCamelCase (obj) {
   if (Array.isArray(obj)) {
-    return obj.map(item => camelize(item))
+    return obj.map(item => keysToCamelCase(item))
   } else if (typeof obj === 'object') {
     return Object.keys(obj).reduce((result, key) => {
       if (obj[key] === null) {
         result[convertToCamelCase(key)] = null
       } else if (typeof obj[key] === 'object') {
-        result[convertToCamelCase(key)] = camelize(obj[key])
+        result[convertToCamelCase(key)] = keysToCamelCase(obj[key])
       } else {
         result[convertToCamelCase(key)] = obj[key]
       }
@@ -31,17 +28,17 @@ function camelize (obj) {
   }
 }
 
-function decamelize (obj) {
+function keysToSnakeCase (obj) {
   if (Array.isArray(obj)) {
-    return obj.map(item => decamelize(item))
+    return obj.map(item => keysToSnakeCase(item))
   } else if (typeof obj === 'object') {
     return Object.keys(obj).reduce((result, key) => {
       if (obj[key] === null) {
-        result[separateWords(key)] = null
+        result[convertToSnakeCase(key)] = null
       } else if (typeof obj[key] === 'object') {
-        result[separateWords(key)] = decamelize(obj[key])
+        result[convertToSnakeCase(key)] = keysToSnakeCase(obj[key])
       } else {
-        result[separateWords(key)] = obj[key]
+        result[convertToSnakeCase(key)] = obj[key]
       }
       return result
     }, {})
@@ -51,6 +48,6 @@ function decamelize (obj) {
 };
 
 module.exports = {
-  camelize,
-  decamelize
+  keysToCamelCase,
+  keysToSnakeCase
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "gaap-analytics": "^3.1.0",
         "govuk-frontend": "^4.7.0",
         "helmet": "3.23.3",
-        "humps": "^2.0.1",
         "i18n": "0.15.x",
         "lodash": "4.17.x",
         "mailcheck": "^1.1.1",
@@ -9286,11 +9285,6 @@
       "engines": {
         "node": ">=8.12.0"
       }
-    },
-    "node_modules/humps": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-      "integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g=="
     },
     "node_modules/i18n": {
       "version": "0.15.1",
@@ -24645,11 +24639,6 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
-    },
-    "humps": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-      "integrity": "sha512-E0eIbrFWUhwfXJmsbdjRQFQPrl5pTEoKlz163j1mTqqUnU9PgR4AgB8AIITzuB3vLBdxZXyZ9TDIrwB2OASz4g=="
     },
     "i18n": {
       "version": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "gaap-analytics": "^3.1.0",
     "govuk-frontend": "^4.7.0",
     "helmet": "3.23.3",
-    "humps": "^2.0.1",
     "i18n": "0.15.x",
     "lodash": "4.17.x",
     "mailcheck": "^1.1.1",

--- a/test/utils/key-camelizer.test.js
+++ b/test/utils/key-camelizer.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const expect = require('chai').expect
-const { camelize, decamelize } = require('../../app/utils/key-camelizer')
+const { keysToCamelCase, keysToSnakeCase } = require('../../app/utils/key-camelizer')
 
 const simpleSnakeObj = {
   attr_one: 'foo',
@@ -127,31 +127,31 @@ describe('camelize', () => {
   objectTests.forEach( test => {
     const {nonCamelCase, camelizedCase, objectName} = test
     it(`converts a ${objectName} to camel case`, () => {
-      const result = camelize(nonCamelCase)
+      const result = keysToCamelCase(nonCamelCase)
       expect(result).to.deep.equal(camelizedCase)
     })
   })
   primitiveTypeTests.forEach( test => {
     const {primitiveType, objectName} = test
     it(`does not convert a ${objectName} to camel case and returns an unchanged argument`, () => {
-      const result = camelize(primitiveType)
+      const result = keysToCamelCase(primitiveType)
       expect(result).to.deep.equal(primitiveType)
     })
   })
 })
 
-describe('decamelize', () => {
+describe('camelCaseToSnakeCase', () => {
   objectsForDecamelizingTests.forEach( test => {
     const {nonCamelCase, camelizedCase, objectName} = test
     it(`converts a ${objectName} to snake case`, () => {
-      const result = decamelize(camelizedCase)
+      const result = keysToSnakeCase(camelizedCase)
       expect(result).to.deep.equal(nonCamelCase)
     })
   })
   primitiveTypeTests.forEach( test => {
     const {primitiveType, objectName} = test
     it(`does not convert a ${objectName} to camel case and returns and returns an unchanged argument`, () => {
-      const result = decamelize(primitiveType)
+      const result = keysToSnakeCase(primitiveType)
       expect(result).to.deep.equal(primitiveType)
     })
   })

--- a/test/utils/key-camelizer.test.js
+++ b/test/utils/key-camelizer.test.js
@@ -123,7 +123,7 @@ const primitiveTypeTests = [
 
 const objectsForDecamelizingTests = objectTests.filter(obj => obj.objectName.includes('snake'))
 
-describe('camelize', () => {
+describe('keysToCamelCase', () => {
   objectTests.forEach(test => {
     const { nonCamelCase, camelizedCase, objectName } = test
     it(`converts a ${objectName} to camel case`, () => {
@@ -140,7 +140,7 @@ describe('camelize', () => {
   })
 })
 
-describe('camelCaseToSnakeCase', () => {
+describe('keysToSnakeCase', () => {
   objectsForDecamelizingTests.forEach(test => {
     const { nonCamelCase, camelizedCase, objectName } = test
     it(`converts a ${objectName} to snake case`, () => {

--- a/test/utils/key-camelizer.test.js
+++ b/test/utils/key-camelizer.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const expect = require('chai').expect
-const { result } = require('lodash')
 const { camelize, decamelize } = require('../../app/utils/key-camelizer')
 
 const simpleSnakeObj = {

--- a/test/utils/key-camelizer.test.js
+++ b/test/utils/key-camelizer.test.js
@@ -107,32 +107,32 @@ const camelizedNestedNullObj = {
 }
 
 const objectTests = [
-  {nonCamelCase: simpleSnakeObj, camelizedCase: simpleCamelObj, objectName: 'simple snake object keys'},
-  {nonCamelCase: simplePascalObj, camelizedCase: simpleCamelObj, objectName: 'simple pascal object keys'},
-  {nonCamelCase: complexSnakeObj, camelizedCase: complexCamelObj, objectName: 'complex snake object keys'},
-  {nonCamelCase: complexPascalObj, camelizedCase: complexCamelObj, objectName: 'complex pascal object keys'},
-  {nonCamelCase: complexCustomObj, camelizedCase: complexCamelObj, objectName: 'complex custom object keys'},
-  {nonCamelCase: nestedNullObj, camelizedCase: camelizedNestedNullObj, objectName: 'simple snake object with nested null property'},
+  { nonCamelCase: simpleSnakeObj, camelizedCase: simpleCamelObj, objectName: 'simple snake object keys' },
+  { nonCamelCase: simplePascalObj, camelizedCase: simpleCamelObj, objectName: 'simple pascal object keys' },
+  { nonCamelCase: complexSnakeObj, camelizedCase: complexCamelObj, objectName: 'complex snake object keys' },
+  { nonCamelCase: complexPascalObj, camelizedCase: complexCamelObj, objectName: 'complex pascal object keys' },
+  { nonCamelCase: complexCustomObj, camelizedCase: complexCamelObj, objectName: 'complex custom object keys' },
+  { nonCamelCase: nestedNullObj, camelizedCase: camelizedNestedNullObj, objectName: 'simple snake object with nested null property' }
 ]
 
 const primitiveTypeTests = [
-  {primitiveType: 34, objectName: 'number'},
-  {primitiveType: 'Test string', objectName: 'string'},
-  {primitiveType: true, objectName: 'boolean'}
+  { primitiveType: 34, objectName: 'number' },
+  { primitiveType: 'Test string', objectName: 'string' },
+  { primitiveType: true, objectName: 'boolean' }
 ]
 
-const objectsForDecamelizingTests = objectTests.filter(obj => obj.objectName.includes('snake'));
+const objectsForDecamelizingTests = objectTests.filter(obj => obj.objectName.includes('snake'))
 
 describe('camelize', () => {
-  objectTests.forEach( test => {
-    const {nonCamelCase, camelizedCase, objectName} = test
+  objectTests.forEach(test => {
+    const { nonCamelCase, camelizedCase, objectName } = test
     it(`converts a ${objectName} to camel case`, () => {
       const result = keysToCamelCase(nonCamelCase)
       expect(result).to.deep.equal(camelizedCase)
     })
   })
-  primitiveTypeTests.forEach( test => {
-    const {primitiveType, objectName} = test
+  primitiveTypeTests.forEach(test => {
+    const { primitiveType, objectName } = test
     it(`does not convert a ${objectName} to camel case and returns an unchanged argument`, () => {
       const result = keysToCamelCase(primitiveType)
       expect(result).to.deep.equal(primitiveType)
@@ -141,15 +141,15 @@ describe('camelize', () => {
 })
 
 describe('camelCaseToSnakeCase', () => {
-  objectsForDecamelizingTests.forEach( test => {
-    const {nonCamelCase, camelizedCase, objectName} = test
+  objectsForDecamelizingTests.forEach(test => {
+    const { nonCamelCase, camelizedCase, objectName } = test
     it(`converts a ${objectName} to snake case`, () => {
       const result = keysToSnakeCase(camelizedCase)
       expect(result).to.deep.equal(nonCamelCase)
     })
   })
-  primitiveTypeTests.forEach( test => {
-    const {primitiveType, objectName} = test
+  primitiveTypeTests.forEach(test => {
+    const { primitiveType, objectName } = test
     it(`does not convert a ${objectName} to camel case and returns and returns an unchanged argument`, () => {
       const result = keysToSnakeCase(primitiveType)
       expect(result).to.deep.equal(primitiveType)

--- a/test/utils/key-camelizer.test.js
+++ b/test/utils/key-camelizer.test.js
@@ -1,0 +1,165 @@
+'use strict'
+
+const expect = require('chai').expect
+const { camelize, decamelize } = require('../../app/utils/key-camelizer')
+
+const simpleSnakeObj = {
+  attr_one: 'foo',
+  attr_two: 'bar'
+}
+
+const simpleCamelObj = {
+  attrOne: 'foo',
+  attrTwo: 'bar'
+}
+
+const simplePascalObj = {
+  AttrOne: 'foo',
+  AttrTwo: 'bar'
+}
+
+const complexSnakeObj = {
+  attr_one: 'foo',
+  attr_two: {
+    nested_attr1: 'bar'
+  },
+  attr_three: {
+    nested_attr2: {
+      nested_attr3: [{
+        nested_in_array1: 'baz'
+      }, {
+        nested_in_array2: 'hello'
+      }, {
+        nested_in_array3: ['world', 'boo']
+      }]
+    }
+  }
+}
+
+const complexCamelObj = {
+  attrOne: 'foo',
+  attrTwo: {
+    nestedAttr1: 'bar'
+  },
+  attrThree: {
+    nestedAttr2: {
+      nestedAttr3: [{
+        nestedInArray1: 'baz'
+      }, {
+        nestedInArray2: 'hello'
+      }, {
+        nestedInArray3: ['world', 'boo']
+      }]
+    }
+  }
+}
+
+const complexPascalObj = {
+  AttrOne: 'foo',
+  AttrTwo: {
+    NestedAttr1: 'bar'
+  },
+  AttrThree: {
+    NestedAttr2: {
+      NestedAttr3: [{
+        NestedInArray1: 'baz'
+      }, {
+        NestedInArray2: 'hello'
+      }, {
+        NestedInArray3: ['world', 'boo']
+      }]
+    }
+  }
+}
+
+const complexCustomObj = {
+  'attr-one': 'foo',
+  'attr-two': {
+    'nested-attr1': 'bar'
+  },
+  'attr-three': {
+    'nested-attr2': {
+      'nested-attr3': [{
+        'nested-in-array1': 'baz'
+      }, {
+        'nested-in-array2': 'hello'
+      }, {
+        'nested-in-array3': ['world', 'boo']
+      }]
+    }
+  }
+}
+
+const nestedNullObj = {
+  attr_one: 'foo',
+  attr_two: 'bar',
+  attr_three: {
+    nested_obj: null
+  }
+}
+
+const camelizedNestedNullObj = {
+  attrOne: 'foo',
+  attrTwo: 'bar',
+  attrThree: {
+    nestedObj: null
+  }
+}
+
+describe('camelize', () => {
+  it('converts a simple snake case object keys to camel case', () => {
+    const result = camelize(simpleSnakeObj)
+    expect(result).to.deep.equal(simpleCamelObj)
+  })
+  it('converts a simple pascal case object to camel case', () => {
+    const result = camelize(simplePascalObj)
+    expect(result).to.deep.equal(simpleCamelObj)
+  })
+  it('converts a complex snake case object to camel case', () => {
+    const result = camelize(complexSnakeObj)
+    expect(result).to.deep.equal(complexCamelObj)
+  })
+  it('converts a complex pascal case object to camel case', () => {
+    const result = camelize(complexPascalObj)
+    expect(result).to.deep.equal(complexCamelObj)
+  })
+  it('converts a complex custom object to camel case', () => {
+    const result = camelize(complexCustomObj)
+    expect(result).to.deep.equal(complexCamelObj)
+  })
+  it('converts an object which has a property value of null', () => {
+    const result = camelize(nestedNullObj)
+    expect(result).to.deep.equal(camelizedNestedNullObj)
+  })
+  it('does not convert anything if a number is passed to it', () => {
+    const result = camelize(34)
+    expect(result).to.deep.equal(34)
+  })
+  it('does not convert anything if a string is passed to it', () => {
+    const result = camelize('Test string')
+    expect(result).to.deep.equal('Test string')
+  })
+})
+
+describe('decamelize', () => {
+  it('converts a simple camel case object keys to snake case', () => {
+    const result = decamelize(simpleCamelObj)
+    expect(result).to.deep.equal(simpleSnakeObj)
+  })
+  it('converst a complex camel cased object to snake case', () => {
+    const result = decamelize(complexCamelObj)
+    expect(result).to.deep.equal(complexSnakeObj)
+  })
+  it('converts an object which has a property value of null', () => {
+    const result = decamelize(camelizedNestedNullObj)
+    expect(result).to.deep.equal(nestedNullObj)
+  })
+  it('does not convert anything if a number is passed to it', () => {
+    const result = decamelize(34)
+    expect(result).to.deep.equal(34)
+  })
+  it('does not convert anything if a string is passed to it', () => {
+    const result = decamelize('Test string')
+    expect(result).to.deep.equal('Test string')
+  })
+})

--- a/test/utils/key-camelizer.test.js
+++ b/test/utils/key-camelizer.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const expect = require('chai').expect
+const { result } = require('lodash')
 const { camelize, decamelize } = require('../../app/utils/key-camelizer')
 
 const simpleSnakeObj = {
@@ -106,60 +107,53 @@ const camelizedNestedNullObj = {
   }
 }
 
+const objectTests = [
+  {nonCamelCase: simpleSnakeObj, camelizedCase: simpleCamelObj, objectName: 'simple snake object keys'},
+  {nonCamelCase: simplePascalObj, camelizedCase: simpleCamelObj, objectName: 'simple pascal object keys'},
+  {nonCamelCase: complexSnakeObj, camelizedCase: complexCamelObj, objectName: 'complex snake object keys'},
+  {nonCamelCase: complexPascalObj, camelizedCase: complexCamelObj, objectName: 'complex pascal object keys'},
+  {nonCamelCase: complexCustomObj, camelizedCase: complexCamelObj, objectName: 'complex custom object keys'},
+  {nonCamelCase: nestedNullObj, camelizedCase: camelizedNestedNullObj, objectName: 'simple snake object with nested null property'},
+]
+
+const primitiveTypeTests = [
+  {primitiveType: 34, objectName: 'number'},
+  {primitiveType: 'Test string', objectName: 'string'},
+  {primitiveType: true, objectName: 'boolean'}
+]
+
+const objectsForDecamelizingTests = objectTests.filter(obj => obj.objectName.includes('snake'));
+
 describe('camelize', () => {
-  it('converts a simple snake case object keys to camel case', () => {
-    const result = camelize(simpleSnakeObj)
-    expect(result).to.deep.equal(simpleCamelObj)
+  objectTests.forEach( test => {
+    const {nonCamelCase, camelizedCase, objectName} = test
+    it(`converts a ${objectName} to camel case`, () => {
+      const result = camelize(nonCamelCase)
+      expect(result).to.deep.equal(camelizedCase)
+    })
   })
-  it('converts a simple pascal case object to camel case', () => {
-    const result = camelize(simplePascalObj)
-    expect(result).to.deep.equal(simpleCamelObj)
-  })
-  it('converts a complex snake case object to camel case', () => {
-    const result = camelize(complexSnakeObj)
-    expect(result).to.deep.equal(complexCamelObj)
-  })
-  it('converts a complex pascal case object to camel case', () => {
-    const result = camelize(complexPascalObj)
-    expect(result).to.deep.equal(complexCamelObj)
-  })
-  it('converts a complex custom object to camel case', () => {
-    const result = camelize(complexCustomObj)
-    expect(result).to.deep.equal(complexCamelObj)
-  })
-  it('converts an object which has a property value of null', () => {
-    const result = camelize(nestedNullObj)
-    expect(result).to.deep.equal(camelizedNestedNullObj)
-  })
-  it('does not convert anything if a number is passed to it', () => {
-    const result = camelize(34)
-    expect(result).to.deep.equal(34)
-  })
-  it('does not convert anything if a string is passed to it', () => {
-    const result = camelize('Test string')
-    expect(result).to.deep.equal('Test string')
+  primitiveTypeTests.forEach( test => {
+    const {primitiveType, objectName} = test
+    it(`does not convert a ${objectName} to camel case and returns an unchanged argument`, () => {
+      const result = camelize(primitiveType)
+      expect(result).to.deep.equal(primitiveType)
+    })
   })
 })
 
 describe('decamelize', () => {
-  it('converts a simple camel case object keys to snake case', () => {
-    const result = decamelize(simpleCamelObj)
-    expect(result).to.deep.equal(simpleSnakeObj)
+  objectsForDecamelizingTests.forEach( test => {
+    const {nonCamelCase, camelizedCase, objectName} = test
+    it(`converts a ${objectName} to snake case`, () => {
+      const result = decamelize(camelizedCase)
+      expect(result).to.deep.equal(nonCamelCase)
+    })
   })
-  it('converst a complex camel cased object to snake case', () => {
-    const result = decamelize(complexCamelObj)
-    expect(result).to.deep.equal(complexSnakeObj)
-  })
-  it('converts an object which has a property value of null', () => {
-    const result = decamelize(camelizedNestedNullObj)
-    expect(result).to.deep.equal(nestedNullObj)
-  })
-  it('does not convert anything if a number is passed to it', () => {
-    const result = decamelize(34)
-    expect(result).to.deep.equal(34)
-  })
-  it('does not convert anything if a string is passed to it', () => {
-    const result = decamelize('Test string')
-    expect(result).to.deep.equal('Test string')
+  primitiveTypeTests.forEach( test => {
+    const {primitiveType, objectName} = test
+    it(`does not convert a ${objectName} to camel case and returns and returns an unchanged argument`, () => {
+      const result = decamelize(primitiveType)
+      expect(result).to.deep.equal(primitiveType)
+    })
   })
 })


### PR DESCRIPTION
## WHAT

- Removed the `humps` npm module by running `npm uninstall humps` which was being used to either change card detail JSON keys from snake-case to camel-case, or vice versa.
- Added a custom utility which provides the same functionality, albeit without the extra methods in `humps` which we weren't using. This utility changes the keys (including nested keys) using either the `camelize` or `decamelize` methods.
- Added a key-camelizer test.

## HOW 

- Should not encounter any errors when paying using a valid card.


