### PR TITLE
PP-11638 Add endpoint for client-side logging

### DIFF
--- a/app/assets/javascripts/browsered/helpers.js
+++ b/app/assets/javascripts/browsered/helpers.js
@@ -59,10 +59,24 @@ const hideSpinnerAndShowMainContent = () => {
   document.getElementById('spinner').classList.add('hidden')
 }
 
+const sendLogMessage = (chargeId, logCode) => {
+  return fetch(`/log/${chargeId}`, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      code: logCode
+    })
+  })
+}
+
 module.exports = {
   setGlobalChargeId,
   toggleSubmitButtons,
   showSpinnerAndHideMainContent,
   hideSpinnerAndShowMainContent,
-  initialiseAddressCountryAutocomplete
+  initialiseAddressCountryAutocomplete,
+  sendLogMessage
 }

--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -1,7 +1,12 @@
 'use strict'
 
 const { prepareAppleRequestObject, showErrorSummary } = require('./helpers')
-const { toggleSubmitButtons, showSpinnerAndHideMainContent, hideSpinnerAndShowMainContent } = require('../helpers')
+const {
+  toggleSubmitButtons,
+  showSpinnerAndHideMainContent,
+  hideSpinnerAndShowMainContent,
+  sendLogMessage
+} = require('../helpers')
 const { validateEmail } = require('../../../../utils/email-validation')
 const { email_collection_mode } = window.Charge || {} // eslint-disable-line camelcase
 
@@ -26,7 +31,8 @@ module.exports = () => {
         })
       } else {
         ga('send', 'event', 'Apple Pay', 'Error', 'Merchant ID not valid')
-        return session.abort()
+        return sendLogMessage(window.chargeId, 'ApplePayMerchantIdNotValid')
+          .finally(() => (session.abort()))
       }
     })
   }
@@ -38,7 +44,8 @@ module.exports = () => {
       }).catch(err => {
         showErrorSummary(i18n.fieldErrors.webPayments.apple)
         ga('send', 'event', 'Apple Pay', 'Error', 'Error completing Merchant validation')
-        return err
+        return sendLogMessage(window.chargeId, 'ApplePayMerchantValidationError')
+          .finally(() => (err))
       })
   }
 
@@ -49,7 +56,7 @@ module.exports = () => {
 
     if (email_collection_mode !== 'OFF') { // eslint-disable-line camelcase
       if (!payment.shippingContact || typeof payment.shippingContact.emailAddress !== 'string' ||
-          !validateEmail(payment.shippingContact.emailAddress).valid) {
+        !validateEmail(payment.shippingContact.emailAddress).valid) {
         hideSpinnerAndShowMainContent()
         toggleSubmitButtons()
         showErrorSummary(i18n.fieldErrors.summary, i18n.fieldErrors.fields.email.message)

--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -31,8 +31,8 @@ module.exports = () => {
         })
       } else {
         ga('send', 'event', 'Apple Pay', 'Error', 'Merchant ID not valid')
-        return sendLogMessage(window.chargeId, 'ApplePayMerchantIdNotValid')
-          .finally(() => (session.abort()))
+        sendLogMessage(window.chargeId, 'ApplePayMerchantIdNotValid')
+        return session.abort()
       }
     })
   }
@@ -44,8 +44,8 @@ module.exports = () => {
       }).catch(err => {
         showErrorSummary(i18n.fieldErrors.webPayments.apple)
         ga('send', 'event', 'Apple Pay', 'Error', 'Error completing Merchant validation')
-        return sendLogMessage(window.chargeId, 'ApplePayMerchantValidationError')
-          .finally(() => (err))
+        sendLogMessage(window.chargeId, 'ApplePayMerchantValidationError')
+        return err
       })
   }
 

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { getGooglePaymentsConfiguration, showErrorSummary } = require('./helpers')
-const { toggleSubmitButtons, showSpinnerAndHideMainContent, hideSpinnerAndShowMainContent } = require('../helpers')
+const { toggleSubmitButtons, showSpinnerAndHideMainContent, hideSpinnerAndShowMainContent, sendLogMessage } = require('../helpers')
 const { email_collection_mode, payment_provider } = window.Charge // eslint-disable-line camelcase
 
 const submitGooglePayAuthRequest = (paymentResponse) => {
@@ -170,6 +170,7 @@ const googlePayNow = () => {
     })
     .catch(dismissed => {
       ga('send', 'event', 'Google Pay', 'Aborted', 'by user')
+      sendLogMessage(window.chargeId, 'GooglePayAborted')
     })
 }
 

--- a/app/assets/javascripts/browsered/web-payments/index.js
+++ b/app/assets/javascripts/browsered/web-payments/index.js
@@ -4,6 +4,7 @@
 const { clearErrorSummary } = require('./helpers')
 const makeApplePayRequest = require('./apple-pay')
 const { googlePayNow } = require('./google-pay')
+const { sendLogMessage } = require('../helpers')
 
 // Browser elements
 const paymentMethodForms = Array.prototype.slice.call(document.getElementsByClassName('web-payments-container'))
@@ -12,12 +13,14 @@ const standardMethodForm = document.getElementById('card-details')
 const initApplePayIfAvailable = () => {
   if (document.body.classList.contains('apple-pay-available')) {
     ga('send', 'event', 'Apple Pay', 'Enabled', 'Apple pay available on this device')
+    sendLogMessage(window.chargeId, 'ApplePayAvailable')
   }
 }
 
 const initGooglePayIfAvailable = () => {
   if (document.body.classList.contains('google-pay-available')) {
     ga('send', 'event', 'Google Pay', 'Enabled', 'Google pay available on this device')
+    sendLogMessage(window.chargeId, 'GooglePayAvailable')
   }
 }
 
@@ -33,8 +36,10 @@ const setupEventListener = () => {
 
         switch (webPaymentMethod) {
           case 'Apple Pay':
+            sendLogMessage(window.chargeId, 'ApplePayStarted')
             return makeApplePayRequest()
           case 'Google Pay':
+            sendLogMessage(window.chargeId, 'GooglePayStarted')
             return googlePayNow()
         }
       }, false)

--- a/app/controllers/client-side-logging.controller.js
+++ b/app/controllers/client-side-logging.controller.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { getLoggingFields } = require('../utils/logging-fields-helper')
+const logger = require('../utils/logger')(__filename)
+
+const LOG_CODES = {
+  ApplePayAvailable: 'Apple Pay is available on this device',
+  ApplePayStarted: 'User chose Apple Pay method',
+  ApplePayMerchantIdNotValid: 'Apple Pay Merchant ID not valid',
+  ApplePayMerchantValidationError: 'Error completing Apple Pay merchant validation',
+  GooglePayAvailable: 'Google Pay is available on this device',
+  GooglePayStarted: 'User chose Google Pay method',
+  GooglePayAborted: 'Google Pay attempt aborted by user'
+}
+
+function log (req, res) {
+  const code = req.body && req.body.code
+  if (LOG_CODES.hasOwnProperty(code)) { // eslint-disable-line
+    logger.info(LOG_CODES[code], getLoggingFields(req))
+  } else {
+    logger.info('Client side logging endpoint called with invalid log code')
+  }
+  res.sendStatus(200)
+}
+
+module.exports = {
+  log
+}

--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -70,7 +70,7 @@ module.exports = (req, res) => {
         response: response,
         body: body
       })
-      res.status(500).send(body)
+      return res.status(500).send(body)
     }
     res.status(200).send(body)
   })

--- a/app/paths.js
+++ b/app/paths.js
@@ -13,6 +13,10 @@ if (process.env.CONNECTOR_HOST === undefined) throw new Error('CONNECTOR_HOST en
 // routes when we have duplicate paths on different actions
 
 const paths = {
+  log: {
+    path: '/log/:chargeId',
+    action: 'post'
+  },
   card: {
     new: {
       path: '/card_details/:chargeId',

--- a/app/routes.js
+++ b/app/routes.js
@@ -10,6 +10,7 @@ const webPaymentsMakePayment = require('./controllers/web-payments/payment-auth-
 const webPaymentsHandlePaymentResponse = require('./controllers/web-payments/handle-auth-response.controller')
 const returnCont = require('./controllers/return.controller.js')
 const { healthcheck } = require('./controllers/healthcheck.controller.js')
+const { log } = require('./controllers/client-side-logging.controller')
 const paths = require('./paths.js')
 
 // Express middleware
@@ -57,6 +58,8 @@ exports.bind = function (app) {
     retrieveCharge,
     resolveLanguage
   ]
+
+  app.post(paths.log.path, chargeCookieRequiredMiddlewareStack, log)
 
   app.get(card.new.path, standardMiddlewareStack, csp.cardDetails, charge.new)
   app.get(card.authWaiting.path, standardMiddlewareStack, charge.authWaiting)

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-string": "^1.4.0",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^13.3.1",
         "dotenv": "^16.3.1",
         "govuk-country-and-territory-autocomplete": "^1.0.2",

--- a/test/controllers/client-side-logging.controller.test.js
+++ b/test/controllers/client-side-logging.controller.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+const loggingSpy = sinon.spy()
+const res = {
+  sendStatus: sinon.spy()
+}
+
+const clientSideLoggingController = proxyquire('../../app/controllers/client-side-logging.controller', {
+  '../utils/logger': () => ({
+    info: loggingSpy
+  })
+})
+
+describe('The client-side logging controller', () => {
+  beforeEach(() => {
+    loggingSpy.resetHistory()
+  })
+
+  it('Should log expected message and return 200 for valid code', () => {
+    const req = {
+      body: {
+        code: 'ApplePayAvailable'
+      }
+    }
+    clientSideLoggingController.log(req, res)
+    sinon.assert.calledWith(loggingSpy, 'Apple Pay is available on this device')
+    sinon.assert.calledWith(res.sendStatus, 200)
+  })
+
+  it('Should log error message and return 200 for invalid code', () => {
+    const req = {
+      body: {
+        code: 'FOO'
+      }
+    }
+    clientSideLoggingController.log(req, res)
+    sinon.assert.calledWith(loggingSpy, 'Client side logging endpoint called with invalid log code')
+    sinon.assert.calledWith(res.sendStatus, 200)
+  })
+
+  it('Should log error message and return 200 for no code', () => {
+    const req = {
+      body: {
+      }
+    }
+    clientSideLoggingController.log(req, res)
+    sinon.assert.calledWith(loggingSpy, 'Client side logging endpoint called with invalid log code')
+    sinon.assert.calledWith(res.sendStatus, 200)
+  })
+})

--- a/test/integration/client-side-logging.ft.test.js
+++ b/test/integration/client-side-logging.ft.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const supertest = require('supertest')
+const nock = require('nock')
+const proxyquire = require('proxyquire')
+
+const cookie = require('../test-helpers/session')
+const paymentFixtures = require('../fixtures/payment.fixtures')
+
+const app = proxyquire('../../server.js',
+  {
+    'memory-cache': {
+      get: function () {
+        return false
+      },
+      '@global': true
+    }
+  }).getApp()
+
+describe('Client side logging tests', () => {
+  const chargeId = '23144323'
+
+  it('should return a 200 status code when cookie is present', (done) => {
+    const cookieValue = cookie.create(chargeId)
+    nock(process.env.CONNECTOR_HOST)
+      .get('/v1/frontend/charges/' + chargeId).reply(200, paymentFixtures.validChargeDetails())
+    supertest(app)
+      .post('/log/' + chargeId)
+      .set('Content-Type', 'application/json')
+      .set('Cookie', ['frontend_state=' + cookieValue])
+      .send({
+        code: 'foo'
+      })
+      .expect(200)
+      .end(done)
+  })
+
+  it('should return a 403 status code when cookie is not present', (done) => {
+    supertest(app)
+      .post('/log/' + chargeId)
+      .set('Content-Type', 'application/json')
+      .send({
+        code: 'foo'
+      })
+      .expect(403)
+      .end(done)
+  })
+})


### PR DESCRIPTION
Add a `/log/:chargeId` POST route. This can be called by the client-side JavaScript to do logging.

This accepts a POST request with a body containing a `code`, which maps to a message to be logged. We want to do this rather than accepting any string to be logged to avoid log injection.

This endpoint always returns a 200, even if we do not log due to the `code` being invalid or missing. This is because we do not want to interrupt client-side JavaScript running if this fails.

In the client-side JavaScript call this endpoint to log steps in the wallet payment journeys, such as when the button is clicked to start an Apple Pay or Google Pay payment, and also to log when certain errors are caught. When we call the loggng endpoint, we do not handle the Promise resolving/rejecting as we don't need to handle the response in any way.

