### PR TITLE
PP-11714 exclude common `connect-src` csp violations

### DIFF
--- a/app/utils/sentry.js
+++ b/app/utils/sentry.js
@@ -4,6 +4,10 @@ function initialiseSentry () {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.ENVIRONMENT,
+    ignoreErrors: [
+      'www.facebook.com',
+      'spay.samsung.com'
+    ],
     beforeSend (event) {
       if (event.request) {
         delete event.request // This can include sensitive data such as card numbers


### PR DESCRIPTION
## WHAT

Prevent Sentry sending error reports for common `connect-src` csp violations.

[ignoreErrors](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-platformidentifier-nameignore-errors-) takes an array of strings which are used to detect partial matches in the error message, the following URLs appear only in the csp errors we want to block:
- 'www.facebook.com'
- 'spay.samsung.com'

Example events (requires Sentry login):
- https://govuk-pay.sentry.io/issues/4013720616/?environment=production-2&project=5494573&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=5
- https://govuk-pay.sentry.io/issues/4013720595/?environment=production-2&project=5494573&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=0


