### PR TITLE
PP-11638 Add logging when Apple Pay session is aborted

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -100,5 +100,9 @@ module.exports = () => {
     })
   }
 
+  session.oncancel = event => {
+    sendLogMessage(window.chargeId, 'ApplePayAborted')
+  }
+
   session.begin()
 }

--- a/app/controllers/client-side-logging.controller.js
+++ b/app/controllers/client-side-logging.controller.js
@@ -6,6 +6,7 @@ const logger = require('../utils/logger')(__filename)
 const LOG_CODES = {
   ApplePayAvailable: 'Apple Pay is available on this device',
   ApplePayStarted: 'User chose Apple Pay method',
+  ApplePayAborted: 'Apple Pay attempt aborted by user',
   ApplePayMerchantIdNotValid: 'Apple Pay Merchant ID not valid',
   ApplePayMerchantValidationError: 'Error completing Apple Pay merchant validation',
   GooglePayAvailable: 'Google Pay is available on this device',


### PR DESCRIPTION
We log when a Google Pay session is aborted, for completeness also log when an Apple Pay session is aborted.


