### PR TITLE
PP-11601 Improve how we handle rejected authorisation for wallets.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -118,8 +114,7 @@
         "filename": "app/controllers/web-payments/apple-pay/merchant-validation.controller.js",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 14,
-        "is_secret": false
+        "line_number": 14
       }
     ],
     "app/middleware/csp.js": [
@@ -128,8 +123,7 @@
         "filename": "app/middleware/csp.js",
         "hashed_secret": "175847ef942af200ff3d6485225ffa881eb614e1",
         "is_verified": false,
-        "line_number": 13,
-        "is_secret": false
+        "line_number": 13
       }
     ],
     "test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js": [
@@ -147,24 +141,21 @@
         "filename": "test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js",
         "hashed_secret": "321f58f0cffa4caf8de5176503e82691f0f4f092",
         "is_verified": false,
-        "line_number": 35,
-        "is_secret": false
+        "line_number": 35
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js",
         "hashed_secret": "f6a72b11f4038f37c4c436084d974f38b829ae96",
         "is_verified": false,
-        "line_number": 36,
-        "is_secret": false
+        "line_number": 36
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 44,
-        "is_secret": false
+        "line_number": 44
       }
     ],
     "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js": [
@@ -173,64 +164,56 @@
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
         "is_verified": false,
-        "line_number": 39,
-        "is_secret": false
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
         "is_verified": false,
-        "line_number": 39,
-        "is_secret": false
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
         "is_verified": false,
-        "line_number": 39,
-        "is_secret": false
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
         "is_verified": false,
-        "line_number": 39,
-        "is_secret": false
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 65,
-        "is_secret": false
+        "line_number": 65
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1ee4b74cf4b89c3cd9792a34a1fdfed2c8d4b71d",
         "is_verified": false,
-        "line_number": 67,
-        "is_secret": false
+        "line_number": 67
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "29537aaf22996353c2fe981aaa72e960b2ed2d70",
         "is_verified": false,
-        "line_number": 67,
-        "is_secret": false
+        "line_number": 67
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "6464ec4579ee376ccaa76867f536aa1061bc89bf",
         "is_verified": false,
-        "line_number": 67,
-        "is_secret": false
+        "line_number": 67
       }
     ],
     "test/cypress/integration/card/payment.test.cy.js": [
@@ -361,40 +344,35 @@
         "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "063166341af85659c0b5226ef0987932d7380c27",
         "is_verified": false,
-        "line_number": 27,
-        "is_secret": false
+        "line_number": 27
       },
       {
         "type": "Private Key",
         "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 126,
-        "is_secret": false
+        "line_number": 126
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "2600a4bbca0e75c7fd331333413040209e97bccf",
         "is_verified": false,
-        "line_number": 167,
-        "is_secret": false
+        "line_number": 167
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "528ecf3b9ac1e9846921e29b32d2c04354b6bfe7",
         "is_verified": false,
-        "line_number": 171,
-        "is_secret": false
+        "line_number": 171
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/middleware/decrypt-card-data.test.js",
         "hashed_secret": "5c03e44c937badf76e28e556d38a5768cf7bc7e7",
         "is_verified": false,
-        "line_number": 175,
-        "is_secret": false
+        "line_number": 175
       }
     ],
     "test/unit/cookies.test.js": [
@@ -403,8 +381,7 @@
         "filename": "test/unit/cookies.test.js",
         "hashed_secret": "ef5c25da3f68da43b33a9bc96de633756beb2d88",
         "is_verified": false,
-        "line_number": 35,
-        "is_secret": false
+        "line_number": 35
       }
     ],
     "test/utils/normalise.test.js": [
@@ -413,10 +390,9 @@
         "filename": "test/utils/normalise.test.js",
         "hashed_secret": "4d69da42017d038f2129de83cda1feb3911f8cd3",
         "is_verified": false,
-        "line_number": 108,
-        "is_secret": false
+        "line_number": 108
       }
     ]
   },
-  "generated_at": "2023-10-03T14:14:52Z"
+  "generated_at": "2023-11-06T14:40:29Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -335,7 +339,7 @@
         "filename": "test/fixtures/wallet-payment.fixtures.js",
         "hashed_secret": "690d31e7e1b8e4a3c8f5e160d55c3ca4bf8c8ef8",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 58
       }
     ],
     "test/middleware/decrypt-card-data.test.js": [
@@ -394,5 +398,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-06T14:40:29Z"
+  "generated_at": "2023-11-06T17:37:23Z"
 }

--- a/test/fixtures/wallet-payment.fixtures.js
+++ b/test/fixtures/wallet-payment.fixtures.js
@@ -41,6 +41,11 @@ const fixtures = {
       status: 'AUTHORISATION SUCCESS'
     }
   },
+  webPaymentDeclinedResponse: () => {
+    return {
+      error_identifier: 'AUTHORISATION_REJECTED'
+    }
+  },
   appleAuthRequestDetails: (ops = {}) => {
     const lastDigitsCardNumber = ops.lastDigitsCardNumber !== undefined ? ops.lastDigitsCardNumber : successfulLastDigitsCardNumber
     const data = {

--- a/test/unit/clients/connector-client-apple-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-apple-authentication.pact.test.js
@@ -135,6 +135,7 @@ describe('connectors client - apple authentication API', function () {
 
   describe('authorisation declined', function () {
     const appleAuthRequest = fixtures.appleAuthRequestDetails({ email: 'name@email.test', lastDigitsCardNumber: '0002' })
+    const authorisationDeclinedResponse = fixtures.webPaymentDeclinedResponse()
 
     before(() => {
       const builder = new PactInteractionBuilder(APPLE_AUTH_PATH)
@@ -142,6 +143,7 @@ describe('connectors client - apple authentication API', function () {
         .withMethod('POST')
         .withState('a sandbox account exists with a charge with id testChargeId and description DECLINED that is in state ENTERING_CARD_DETAILS.')
         .withUponReceiving('a valid apple pay auth request which should be declined')
+        .withResponseBody(pactify(authorisationDeclinedResponse))
         .withStatusCode(400)
         .build()
       return provider.addInteraction(builder)
@@ -154,7 +156,8 @@ describe('connectors client - apple authentication API', function () {
         chargeId: TEST_CHARGE_ID,
         wallet: 'apple',
         payload: appleAuthRequest
-      }).then(() => {
+      }).then(res => {
+        expect(res.body.error_identifier).to.be.equal('AUTHORISATION_REJECTED')
         done()
       }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
     })

--- a/test/unit/clients/connector-client-apple-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-apple-authentication.pact.test.js
@@ -151,7 +151,7 @@ describe('connectors client - apple authentication API', function () {
 
     afterEach(() => provider.verify())
 
-    it('should return authorisation declined', function (done) {
+    it('should return authorisation declined with error identifier in response payload', function (done) {
       connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
         chargeId: TEST_CHARGE_ID,
         wallet: 'apple',


### PR DESCRIPTION
As part of the review, a Pact test update was requested as per AC.

## WHAT
We recently looked at this in PP-11470: We show a technical problems page when Google Pay payments are declined.
 
However, we are expecting a 400 to always mean the authorisation was rejected - however, it could also mean that the request to connector has an invalid payload which we should handle by showing an error page.

The original change involves the pay-connector service returning an “error_identifier":"AUTHORISATION_REJECTED" in the error response for declined payments for the authorise wallet payment endpoints so we can be sure the 400 means the payment has been declined.

This change involved updating the Pact test to cover this error handling implementation

## HOW 
Review and run Pact test `connector-client-apple-authentication.pact.test.js` and associated stub.

