### PR TITLE
PP-11638 Move client-side logging for wallet available

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/index.js
+++ b/app/assets/javascripts/browsered/web-payments/index.js
@@ -10,20 +10,6 @@ const { sendLogMessage } = require('../helpers')
 const paymentMethodForms = Array.prototype.slice.call(document.getElementsByClassName('web-payments-container'))
 const standardMethodForm = document.getElementById('card-details')
 
-const initApplePayIfAvailable = () => {
-  if (document.body.classList.contains('apple-pay-available')) {
-    ga('send', 'event', 'Apple Pay', 'Enabled', 'Apple pay available on this device')
-    sendLogMessage(window.chargeId, 'ApplePayAvailable')
-  }
-}
-
-const initGooglePayIfAvailable = () => {
-  if (document.body.classList.contains('google-pay-available')) {
-    ga('send', 'event', 'Google Pay', 'Enabled', 'Google pay available on this device')
-    sendLogMessage(window.chargeId, 'GooglePayAvailable')
-  }
-}
-
 const setupEventListener = () => {
   if (window.PaymentRequest || window.ApplePaySession) {
     paymentMethodForms.forEach(form => {
@@ -52,18 +38,6 @@ const setupEventListener = () => {
 }
 
 const init = provider => {
-  switch (provider) {
-    case 'apple':
-      initApplePayIfAvailable()
-      break
-    case 'google':
-      initGooglePayIfAvailable()
-      break
-    default:
-      initApplePayIfAvailable()
-      initGooglePayIfAvailable()
-      break
-  }
   setupEventListener()
 }
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -46,6 +46,9 @@
       {% if allowApplePay %}
         if (window.ApplePaySession && window.ApplePaySession.canMakePayments() && window.ApplePaySession.supportsVersion(4)) {
           document.body.classList.add('apple-pay-available')
+          document.addEventListener('DOMContentLoaded', function (event) {
+            window.payScripts.helpers.sendLogMessage(window.paymentDetails.chargeID, 'ApplePayAvailable')
+          })
         }
       {% endif %}
       {% if allowGooglePay %}
@@ -54,6 +57,13 @@
           googleAvailableRequest.then(function (canMakeGooglePayPayment) {
             if (canMakeGooglePayPayment) {
               document.body.classList.add('google-pay-available')
+              if (document.readyState === "loading") {
+                document.addEventListener('DOMContentLoaded', function (event) {
+                  window.payScripts.helpers.sendLogMessage(window.paymentDetails.chargeID, 'GooglePayAvailable')
+                })
+              } else {
+                window.payScripts.helpers.sendLogMessage(window.paymentDetails.chargeID, 'GooglePayAvailable')
+              }
             }
           })
         }


### PR DESCRIPTION
We were logging that Google Pay is available fewer times than Google Pay was being selected - which obviously shouldn't be possible.

We think this was happening because we were doing the logging in a DOMContentLoaded event listener, based on the presence of the 'google-pay-available' class on the document body.

The 'google-pay-available' class is added in a callback when the Promise to check whether Google Pay payments are available has resolved. It must be possible for this promise to resolve after the code in the DOMContentLoaded event listener that checks for the presence of the class has executed.

To avoid this, add another DOMContentLoaded event listener to the inline script in `charge.njk`, after the Promise to check whether Google Pay is available has resolved, which will log that Google Pay is available. We need to do this in a DOMContentLoaded event listener to ensure the script used to do the logging has loaded.

Move the logging for Apple Pay being available to `charge.njk` to mirror the logging for Google Pay, although the check for Apple Pay isn't asynchronous so we think the previous logging was probably working correctly.

Also, remove the code that sends the Google Analytics events as we do not use Google Analytics currently, and have not for some time.

