### PR TITLE
PP-11638 Add additional client-side logging

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -79,6 +79,7 @@ module.exports = () => {
     }).then(response => {
       if (response.status >= 200 && response.status < 300) {
         ga('send', 'event', 'Apple Pay', 'Successful', 'auth/capture request')
+        sendLogMessage(window.paymentDetails.chargeID, 'ApplePayAuthResponseProcessed')
         return response.json().then(data => {
           session.completePayment(ApplePaySession.STATUS_SUCCESS)
           window.location.href = data.url
@@ -89,6 +90,7 @@ module.exports = () => {
         toggleSubmitButtons()
         showErrorSummary(i18n.fieldErrors.webPayments.apple)
         ga('send', 'event', 'Apple Pay', 'Error', 'During authorisation/capture')
+        sendLogMessage(window.paymentDetails.chargeID, 'ApplePayServerError')
       }
     }).catch(err => {
       session.abort()
@@ -96,6 +98,7 @@ module.exports = () => {
       toggleSubmitButtons()
       showErrorSummary(i18n.fieldErrors.webPayments.apple)
       ga('send', 'event', 'Apple Pay', 'Error', 'Couldn’t post to /web-payments-auth-request/apple/{chargeId}')
+      sendLogMessage(window.paymentDetails.chargeID, 'ApplePayErrorMakingRequestToAuthorise')
       return err
     })
   }

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -29,6 +29,7 @@ const submitGooglePayAuthRequest = (paymentResponse) => {
   })
     .then(response => {
       ga('send', 'event', 'Google Pay', 'Successful', 'auth/capture request')
+      sendLogMessage(window.paymentDetails.chargeID, 'GooglePayAuthResponseProcessed')
       if (response.status >= 200 && response.status < 300) {
         return response.json().then(data => {
           window.location.href = data.url
@@ -38,6 +39,7 @@ const submitGooglePayAuthRequest = (paymentResponse) => {
         toggleSubmitButtons()
         showErrorSummary(i18n.fieldErrors.webPayments.failureTitle, i18n.fieldErrors.webPayments.failureBody)
         ga('send', 'event', 'Google Pay', 'Error', 'During authorisation/capture')
+        sendLogMessage(window.paymentDetails.chargeID, 'GooglePayServerError')
       }
     })
     .catch(err => {
@@ -45,6 +47,7 @@ const submitGooglePayAuthRequest = (paymentResponse) => {
       toggleSubmitButtons()
       showErrorSummary(i18n.fieldErrors.webPayments.failureTitle, i18n.fieldErrors.webPayments.failureBody)
       ga('send', 'event', 'Google Pay', 'Error', 'During authorisation/capture')
+      sendLogMessage(window.paymentDetails.chargeID, 'GooglePayErrorMakingRequestToAuthorise')
       return err
     })
 }

--- a/app/controllers/client-side-logging.controller.js
+++ b/app/controllers/client-side-logging.controller.js
@@ -9,9 +9,15 @@ const LOG_CODES = {
   ApplePayAborted: 'Apple Pay attempt aborted by user',
   ApplePayMerchantIdNotValid: 'Apple Pay Merchant ID not valid',
   ApplePayMerchantValidationError: 'Error completing Apple Pay merchant validation',
+  ApplePayErrorMakingRequestToAuthorise: 'There was an error making a request to the server to authorise an Apple Pay payment',
+  ApplePayAuthResponseProcessed: 'Processed Apple Pay authorisation response',
+  ApplePayServerError: 'The server returned a non-success response for request to authorise an Apple Pay Payment',
   GooglePayAvailable: 'Google Pay is available on this device',
   GooglePayStarted: 'User chose Google Pay method',
-  GooglePayAborted: 'Google Pay attempt aborted by user'
+  GooglePayAborted: 'Google Pay attempt aborted by user',
+  GooglePayErrorMakingRequestToAuthorise: 'There was an error making a request to the server to authorise a Google Pay payment',
+  GooglePayAuthResponseProcessed: 'Processed Google Pay authorisation response',
+  GooglePayServerError: 'The server returned a non-success response for request to authorise a Google Pay Payment'
 }
 
 function log (req, res) {


### PR DESCRIPTION
Add additional client-side logging in places where we were previously sending events to Google Analytics.

This is just logging the response the client receives from the server so we can identify whether there was an error making the request to the server to authorise the payment. If the request was made successfully, regardless of the outcome (authorisation success, authorisation rejected or authorisation error), the server will return a 200 status code to the client. In this case log that the response has been successfully processed - but the client does not know the outcome of the authorisation request at this point, but we can look at the server logs to find that out.

