### PR TITLE
PP-11714 CSP reporting endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -121,15 +121,6 @@
         "line_number": 14
       }
     ],
-    "app/middleware/csp.js": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "app/middleware/csp.js",
-        "hashed_secret": "175847ef942af200ff3d6485225ffa881eb614e1",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
     "test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js": [
       {
         "type": "Private Key",
@@ -398,5 +389,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-06T17:37:23Z"
+  "generated_at": "2023-11-09T18:54:00Z"
 }

--- a/app/middleware/csp.js
+++ b/app/middleware/csp.js
@@ -1,38 +1,40 @@
 const helmet = require('helmet')
+const Sentry = require('../utils/sentry').initialiseSentry()
+const paths = require('../paths')
+const express = require('express')
+const { rateLimit } = require('express-rate-limit')
+const logger = require('../utils/logger')(__filename)
+const hasSubstr = require('../utils/has-substr')
 
 const sendCspHeader = process.env.CSP_SEND_HEADER === 'true'
 const enforceCsp = process.env.CSP_ENFORCE === 'true'
-const cspReportUri = process.env.CSP_REPORT_URI
-const environment = process.env.ENVIRONMENT
 const allowUnsafeEvalScripts = process.env.CSP_ALLOW_UNSAFE_EVAL_SCRIPTS === 'true'
-
-const sentryCspReportUri = `${cspReportUri}&sentry_environment=${environment}`
 
 // Script responsible for setting 'js-enabled' class, extends GOV.UK frontend `layout` which we have no control over
 // and never changes
-const govUkFrontendLayoutJsEnabledScriptHash = "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"
+const govUkFrontendLayoutJsEnabledScriptHash = '\'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=\''
 
-const CSP_NONE = ["'none'"]
-const CSP_SELF = ["'self'"]
+const CSP_NONE = ['\'none\'']
+const CSP_SELF = ['\'self\'']
 
 // Worldpay 3ds flex iframe - frame and child must be kept in sync
-const frameAndChildSourceCardDetails = ["'self'", 'https://secure-test.worldpay.com',
+const frameAndChildSourceCardDetails = ['\'self\'', 'https://secure-test.worldpay.com',
   'https://centinelapi.cardinalcommerce.com']
 
-const imgSourceCardDetails = ["'self'", 'https://www.google-analytics.com', 'https://www.gstatic.com']
+const imgSourceCardDetails = ['\'self\'', 'https://www.google-analytics.com', 'https://www.gstatic.com']
 
-const scriptSourceCardDetails = ["'self'", "'unsafe-inline'", 'https://www.google-analytics.com',
+const scriptSourceCardDetails = ['\'self\'', '\'unsafe-inline\'', 'https://www.google-analytics.com',
   (req, res) => `'nonce-${res.locals && res.locals.nonce}'`, govUkFrontendLayoutJsEnabledScriptHash]
 
-const styleSourceCardDetails = ["'self'", "'unsafe-eval'", "'unsafe-inline'"]
+const styleSourceCardDetails = ['\'self\'', '\'unsafe-eval\'', '\'unsafe-inline\'']
 
-const formActionWP3DS = ["'self'", 'https://centinelapi.cardinalcommerce.com/V1/Cruise/Collect',
+const formActionWP3DS = ['\'self\'', 'https://centinelapi.cardinalcommerce.com/V1/Cruise/Collect',
   'https://secure-test.worldpay.com/shopper/3ds/ddc.html']
 
 // Direct redirect use case lets post to any given site
 const formActionCardDetails = (req, res) => {
   if (res.locals && res.locals.service &&
-      res.locals.service.redirectToServiceImmediatelyOnTerminalState === true) {
+    res.locals.service.redirectToServiceImmediatelyOnTerminalState === true) {
     return '*'
   }
   return CSP_SELF[0]
@@ -40,17 +42,17 @@ const formActionCardDetails = (req, res) => {
 
 // Script that is being used during zap test: https://github.com/alphagov/pay-endtoend/blob/d685d5bc38d639e8adef629673e5577cb923408e/src/test/resources/uk/gov/pay/pen/tests/frontend.feature#L23
 if (allowUnsafeEvalScripts) {
-  scriptSourceCardDetails.push("'unsafe-eval'")
+  scriptSourceCardDetails.push('\'unsafe-eval\'')
 }
 
 // Google Analytics, Google Pay
-const connectSourceCardDetails = ["'self'", 'https://www.google-analytics.com', 'https://google.com/pay', 'https://www.google.com/pay', 'https://pay.google.com']
+const connectSourceCardDetails = ['\'self\'', 'https://www.google-analytics.com', 'https://google.com/pay', 'https://www.google.com/pay', 'https://pay.google.com']
 
 const skipSendingCspHeader = (req, res, next) => { next() }
 
 const cardDetailsCSP = helmet.contentSecurityPolicy({
   directives: {
-    reportUri: sentryCspReportUri,
+    reportUri: paths.csp.path,
     frameSrc: frameAndChildSourceCardDetails,
     childSrc: frameAndChildSourceCardDetails,
     imgSrc: imgSourceCardDetails,
@@ -71,7 +73,7 @@ const cardDetailsCSP = helmet.contentSecurityPolicy({
 
 const worldpayIframeCSP = helmet.contentSecurityPolicy({
   directives: {
-    reportUri: sentryCspReportUri,
+    reportUri: paths.csp.path,
     defaultSrc: CSP_NONE,
     formAction: formActionWP3DS,
     frameAncestors: CSP_SELF,
@@ -81,7 +83,67 @@ const worldpayIframeCSP = helmet.contentSecurityPolicy({
   reportOnly: !enforceCsp
 })
 
+const rateLimitMiddleware = rateLimit({
+  windowMs: 5 * 60 * 1000, // 5 minutes
+  limit: 10, // Limit each IP to 10 requests per window
+  standardHeaders: 'draft-7', // draft-6: `RateLimit-*` headers; draft-7: combined `RateLimit` header
+  legacyHeaders: false // Disable the `X-RateLimit-*` headers.
+})
+
+const requestParseMiddleware = (maxPayloadBytes) => {
+  return (req, res, next) => {
+    if (req.is('application/json') || req.is('application/reports+json') || req.is('application/csp-report')) {
+      express.json({
+        type: ['application/json', 'application/reports+json', 'application/csp-report'],
+        limit: maxPayloadBytes // limit body payload to maxPayloadBytes, validated prior to parsing
+      })(req, res, next)
+    } else {
+      return res.status(400).end()
+    }
+  }
+}
+
+const detectErrorsMiddleware = (err, req, res, next) => {
+  if (err) {
+    if (err.type === 'entity.too.large') logger.info('CSP violation request payload exceeds maximum size')
+    if (err.type === 'entity.parse.failed') logger.info('CSP violation request payload could not be parsed')
+    return res.status(400).end()
+  }
+  next()
+}
+
+const captureEventMiddleware = (ignoredStrings) => {
+  return (req, res) => {
+    const cspReport = req.body['csp-report']
+    const userAgent = req.headers['user-agent']
+    if (cspReport !== undefined) {
+      const blockedUri = cspReport['blocked-uri']
+      const violatedDirective = cspReport['violated-directive']
+      if (violatedDirective === undefined || blockedUri === undefined) {
+        return res.status(400).end()
+      } else {
+        if (hasSubstr(ignoredStrings, blockedUri)) return res.status(204).end()
+        Sentry.captureEvent({
+          message: `Blocked ${violatedDirective} from ${blockedUri}`,
+          level: 'warning',
+          extra: {
+            cspReport: cspReport,
+            userAgent: userAgent
+          }
+        })
+        return res.status(204).end()
+      }
+    } else {
+      return res.status(400).end()
+    }
+  }
+}
+
 module.exports = {
   cardDetails: sendCspHeader ? cardDetailsCSP : skipSendingCspHeader,
-  worldpayIframe: sendCspHeader ? worldpayIframeCSP : skipSendingCspHeader
+  worldpayIframe: sendCspHeader ? worldpayIframeCSP : skipSendingCspHeader,
+  rateLimitMiddleware,
+  captureEventMiddleware,
+  requestParseMiddleware,
+  detectErrorsMiddleware
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -17,6 +17,10 @@ const paths = {
     path: '/log/:chargeId',
     action: 'post'
   },
+  csp: {
+    path: '/csp-report',
+    action: 'post'
+  },
   card: {
     new: {
       path: '/card_details/:chargeId',

--- a/app/utils/has-substr.js
+++ b/app/utils/has-substr.js
@@ -1,0 +1,3 @@
+module.exports = (lookUpStrings, targetString) => {
+  return lookUpStrings.some(str => targetString.toLowerCase().includes(str.toLowerCase()))
+}

--- a/app/utils/sentry.js
+++ b/app/utils/sentry.js
@@ -4,10 +4,6 @@ function initialiseSentry () {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
     environment: process.env.ENVIRONMENT,
-    ignoreErrors: [
-      'www.facebook.com',
-      'spay.samsung.com'
-    ],
     beforeSend (event) {
       if (event.request) {
         delete event.request // This can include sensitive data such as card numbers

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "credit-card-type": "6.3.x",
         "csrf": "3.1.x",
         "express": "4.18.x",
+        "express-rate-limit": "^7.1.4",
         "gaap-analytics": "^3.1.0",
         "govuk-frontend": "^4.7.0",
         "helmet": "3.23.3",
@@ -7044,6 +7045,17 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.1.4.tgz",
+      "integrity": "sha512-mv/6z+EwnWpr+MjGVavMGvM4Tl8S/tHmpl9ZsDfrQeHpYy4Hfr0UYdKEf9OOTe280oIr70yPxLRmQ6MfINfJDw==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/body-parser": {
@@ -22970,6 +22982,12 @@
           }
         }
       }
+    },
+    "express-rate-limit": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.1.4.tgz",
+      "integrity": "sha512-mv/6z+EwnWpr+MjGVavMGvM4Tl8S/tHmpl9ZsDfrQeHpYy4Hfr0UYdKEf9OOTe280oIr70yPxLRmQ6MfINfJDw==",
+      "requires": {}
     },
     "ext": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "credit-card-type": "6.3.x",
     "csrf": "3.1.x",
     "express": "4.18.x",
+    "express-rate-limit": "^7.1.4",
     "gaap-analytics": "^3.1.0",
     "govuk-frontend": "^4.7.0",
     "helmet": "3.23.3",

--- a/server.js
+++ b/server.js
@@ -25,7 +25,6 @@ const Sentry = require('./app/utils/sentry.js').initialiseSentry()
 const { worldpayIframe } = require('./app/middleware/csp')
 const correlationHeader = require('./app/middleware/correlation-header')
 const errorHandlers = require('./app/middleware/error-handlers')
-const paths = require('./app/paths')
 
 // Global constants
 const {

--- a/test/middleware/csp.test.js
+++ b/test/middleware/csp.test.js
@@ -1,6 +1,147 @@
 /* eslint-disable */
+const request = require('supertest')
+const express = require('express')
 const sinon = require('sinon')
 const { expect } = require('chai')
+const proxyquire = require('proxyquire')
+
+const loggingSpy = sinon.spy()
+const sentrySpy = sinon.spy()
+
+const {
+  rateLimitMiddleware,
+  captureEventMiddleware,
+  requestParseMiddleware,
+  detectErrorsMiddleware
+} = proxyquire('../../app/middleware/csp', {
+  '../utils/logger': () => ({
+    info: loggingSpy
+  }),
+  '../utils/sentry': {
+    initialiseSentry: () => ({
+      captureEvent: sentrySpy
+    })
+  }
+})
+
+const cspMiddlewareStack = [
+  rateLimitMiddleware,
+  requestParseMiddleware(2000),
+  detectErrorsMiddleware,
+  captureEventMiddleware([
+    'banned.com' // ignored domain
+  ])
+]
+
+describe('CSP report endpoint', () => {
+  const underTest = express()
+  underTest.enable('trust proxy')
+  underTest.set('trust proxy', 1)
+  underTest.use('/test', cspMiddlewareStack)
+
+  beforeEach(() => {
+    loggingSpy.resetHistory()
+    sentrySpy.resetHistory()
+  })
+
+  const validPayload = {
+    'csp-report': {
+      'blocked-uri': 'https://www.example.com',
+      'violated-directive': 'connect-src'
+    }
+  }
+
+  it('should return 204 and send to sentry if a valid csp report is present', async () => {
+    await request(underTest)
+      .post('/test')
+      .set('user-agent', 'supertest')
+      .send(validPayload)
+      .expect(204)
+
+    expect(sentrySpy.calledOnce).to.be.true
+    expect(sentrySpy.calledWith({
+      message: 'Blocked connect-src from https://www.example.com',
+      level: 'warning',
+      extra: {
+        'cspReport': validPayload['csp-report'],
+        'userAgent': 'supertest'
+      }
+    })).to.be.true
+  })
+
+  it('should return 204 and not send to sentry if a valid csp report is present but the blocked-uri is ignored', async () => {
+    await request(underTest)
+      .post('/test')
+      .set('user-agent', 'supertest')
+      .send({
+        'csp-report': {
+          'blocked-uri': 'https://www.banned.com',
+          'violated-directive': 'connect-src'
+        }
+      })
+      .expect(204)
+
+    expect(sentrySpy.notCalled).to.be.true
+  })
+
+  it('should return 400 if content-type is unexpected', async () => {
+    await request(underTest)
+      .post('/test')
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .send(validPayload)
+      .expect(400)
+  })
+
+  it('should return 400 if payload is too large', async () => {
+
+    const largePayload = {
+      ...validPayload,
+      'large_value': 'some text here x1000'.repeat(1000)
+    }
+
+    await request(underTest)
+      .post('/test')
+      .send(largePayload)
+      .expect(400)
+
+    expect(loggingSpy.calledOnce).to.be.true
+    expect(loggingSpy.calledWith('CSP violation request payload exceeds maximum size')).to.be.true
+  })
+
+  it('should return 400 if request is not JSON', async () => {
+    await request(underTest)
+      .post('/test')
+      .set('content-type', 'application/json')
+      .send('notJSON')
+      .expect(400)
+
+    expect(loggingSpy.calledOnce).to.be.true
+    expect(loggingSpy.calledWith('CSP violation request payload could not be parsed')).to.be.true
+  })
+
+  it('should return 400 if json does not included expected values', async () => {
+    await request(underTest)
+      .post('/test')
+      .send({ key: 'value' })
+      .expect(400)
+  })
+
+  it('should return 429 if too many requests are made', async () => {
+    for (let i = 0; i < 10; i++) {
+      await request(underTest)
+        .post('/test')
+        .set('x-forwarded-for', '9.9.9.9')
+        .send(validPayload)
+        .expect(204)
+    }
+
+    await request(underTest)
+      .post('/test')
+      .set('x-forwarded-for', '9.9.9.9')
+      .send(validPayload)
+      .expect(429)
+  })
+})
 
 const mockRequest = {
   method: 'GET',

--- a/test/utils/has-substr.test.js
+++ b/test/utils/has-substr.test.js
@@ -1,0 +1,30 @@
+const hasSubstr = require('../../app/utils/has-substr')
+const expect = require('chai').expect
+
+const testCase = 'lorem ipsum dolor sit amet'
+
+describe('hasSubstr', () => {
+  it('returns true when substring is detected', () => {
+    const lookupStrings = ['ipsum']
+    const result = hasSubstr(lookupStrings, testCase)
+    expect(result).to.equal(true)
+  })
+
+  it('returns false when substring is not detected', () => {
+    const lookupStrings = ['consectetur']
+    const result = hasSubstr(lookupStrings, testCase)
+    expect(result).to.equal(false)
+  })
+
+  it('ignores case when comparing', () => {
+    const lookupStrings = ['DOLOR']
+    const result = hasSubstr(lookupStrings, testCase)
+    expect(result).to.equal(true)
+  })
+
+  it('handles multiple lookup strings', () => {
+    const lookupStrings = ['consectetur', 'LOREM']
+    const result = hasSubstr(lookupStrings, testCase)
+    expect(result).to.equal(true)
+  })
+})


### PR DESCRIPTION
## WHAT

- added a new endpoint to handle csp violation reports
- updated the `cardDetailsCSP` and `worldpayIframeCSP` helmet configurations to send reports to new endpoint
- added new paramterised middleware functions to handle csp reporting and domain exclusions
  - hardening measures:
    - payload size limit
    - rate limiting
    - payload shape validation
- tests and helper functions


