### PR TITLE
PP-11638 Improve logging for handling wallet auth response

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/apple-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/apple-pay.js
@@ -79,7 +79,6 @@ module.exports = () => {
     }).then(response => {
       if (response.status >= 200 && response.status < 300) {
         ga('send', 'event', 'Apple Pay', 'Successful', 'auth/capture request')
-        sendLogMessage(window.paymentDetails.chargeID, 'ApplePayAuthResponseProcessed')
         return response.json().then(data => {
           session.completePayment(ApplePaySession.STATUS_SUCCESS)
           window.location.href = data.url

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -29,7 +29,6 @@ const submitGooglePayAuthRequest = (paymentResponse) => {
   })
     .then(response => {
       ga('send', 'event', 'Google Pay', 'Successful', 'auth/capture request')
-      sendLogMessage(window.paymentDetails.chargeID, 'GooglePayAuthResponseProcessed')
       if (response.status >= 200 && response.status < 300) {
         return response.json().then(data => {
           window.location.href = data.url

--- a/app/assets/javascripts/browsered/web-payments/index.js
+++ b/app/assets/javascripts/browsered/web-payments/index.js
@@ -37,7 +37,7 @@ const setupEventListener = () => {
   }
 }
 
-const init = provider => {
+const init = () => {
   setupEventListener()
 }
 

--- a/app/controllers/client-side-logging.controller.js
+++ b/app/controllers/client-side-logging.controller.js
@@ -10,13 +10,11 @@ const LOG_CODES = {
   ApplePayMerchantIdNotValid: 'Apple Pay Merchant ID not valid',
   ApplePayMerchantValidationError: 'Error completing Apple Pay merchant validation',
   ApplePayErrorMakingRequestToAuthorise: 'There was an error making a request to the server to authorise an Apple Pay payment',
-  ApplePayAuthResponseProcessed: 'Processed Apple Pay authorisation response',
   ApplePayServerError: 'The server returned a non-success response for request to authorise an Apple Pay Payment',
   GooglePayAvailable: 'Google Pay is available on this device',
   GooglePayStarted: 'User chose Google Pay method',
   GooglePayAborted: 'Google Pay attempt aborted by user',
   GooglePayErrorMakingRequestToAuthorise: 'There was an error making a request to the server to authorise a Google Pay payment',
-  GooglePayAuthResponseProcessed: 'Processed Google Pay authorisation response',
   GooglePayServerError: 'The server returned a non-success response for request to authorise a Google Pay Payment'
 }
 

--- a/app/controllers/web-payments/handle-auth-response.controller.js
+++ b/app/controllers/web-payments/handle-auth-response.controller.js
@@ -28,6 +28,7 @@ const redirect = res => {
 }
 
 const handleAuthResponse = (req, res, charge) => response => {
+  logger.info('Handling authorisation response for digital wallet payment', getLoggingFields(req))
   switch (response.statusCode) {
     case 202:
     case 409:

--- a/app/middleware/retrieve-charge.js
+++ b/app/middleware/retrieve-charge.js
@@ -4,7 +4,8 @@
 const {
   GATEWAY_ACCOUNT_ID,
   GATEWAY_ACCOUNT_TYPE,
-  PROVIDER
+  PROVIDER,
+  WALLET
 } = require('@govuk-pay/pay-js-commons').logging.keys
 
 // Local dependencies
@@ -23,6 +24,9 @@ module.exports = (req, res, next) => {
       setLoggingField(req, GATEWAY_ACCOUNT_ID, data.gateway_account.gateway_account_id)
       setLoggingField(req, GATEWAY_ACCOUNT_TYPE, data.gateway_account.type)
       setLoggingField(req, PROVIDER, data.payment_provider)
+      if (data.wallet_type) {
+        setLoggingField(req, WALLET, data.wallet_type)
+      }
       next()
     })
     .catch((err) => {

--- a/app/views/includes/scripts.njk
+++ b/app/views/includes/scripts.njk
@@ -62,12 +62,8 @@
       window.gatewayAccountType = '{{ gatewayAccount.type }}'
       window.stripePublishableKey = '{{ stripePublishableKey }}'
     {% endif %}
-    {% if allowApplePay and allowGooglePay%}
-      window.payScripts.webPayments.init('all')
-    {% elif allowApplePay %}
-      window.payScripts.webPayments.init('apple')
-    {% elif allowGooglePay %}
-      window.payScripts.webPayments.init('google')
+    {% if allowApplePay or allowGooglePay %}
+      window.payScripts.webPayments.init()
     {% endif %}
   })
 </script>


### PR DESCRIPTION
Log the "wallet" on log lines if it is available on the charge. This will only be present post-authorisation.

Log a line when we are handling the authorisation response from connector. This is so we can easily validate that the redirect occurs in the client-side JavaScript after the authorisation is completed.

Stop trying to send a log to the server from the client-side  JavaScript when the authorisation has been processed. There is no guarantee this will complete before the page redirects meaning we were dropping some log lines. We could move the redirect to a `then` clause to execute after the promise to send the log message has resolved, but this would slow down the page redirect, which is undesirable.

Tidy up some of the client-side JavaScript slightly. The `init` function in `web-payments/index.js` no longer takes any parameters.