### PR TITLE
PP-11638 Log wallet type when handling auth response

### DIFF
--- a/app/controllers/web-payments/handle-auth-response.controller.js
+++ b/app/controllers/web-payments/handle-auth-response.controller.js
@@ -1,6 +1,7 @@
 'use strict'
 
-// NPM dependencies
+const { WALLET } = require('@govuk-pay/pay-js-commons/lib/logging/keys')
+
 const normalise = require('../../services/normalise-charge')
 const logging = require('../../utils/logging')
 const logger = require('../../utils/logger')(__filename)
@@ -15,7 +16,7 @@ const State = require('../../../config/state')
 
 // constants
 const routeFor = (resource, chargeId) => paths.generateRoute(`card.${resource}`, { chargeId })
-const webPaymentsRouteFor = (resource, chargeId) => paths.generateRoute(`webPayments.${resource}`, { chargeId })
+const webPaymentsRouteFor = (resource, wallet, chargeId) => paths.generateRoute(`webPayments.${resource}`, { wallet, chargeId })
 
 const redirect = res => {
   return {
@@ -27,25 +28,28 @@ const redirect = res => {
   }
 }
 
-const handleAuthResponse = (req, res, charge) => response => {
-  logger.info('Handling authorisation response for digital wallet payment', getLoggingFields(req))
+const handleAuthResponse = (req, res, charge, wallet) => response => {
+  const loggingFields = getLoggingFields(req)
+  loggingFields[WALLET] = wallet
+
+  logger.info('Handling authorisation response for digital wallet payment', loggingFields)
   switch (response.statusCode) {
     case 202:
     case 409:
-      logging.failedChargePost(409, getLoggingFields(req))
+      logging.failedChargePost(409, loggingFields)
       redirect(res).toAuthWaiting(req.chargeId)
       break
     case 200:
       if (charge.status === State.AUTH_3DS_REQUIRED) {
-        logger.info('Requesting 3DS1 for Google payment, redirect to auth 3ds page', getLoggingFields(req))
+        logger.info('Requesting 3DS1 for Google payment, redirect to auth 3ds page', loggingFields)
         return redirect(res).toAuth3dsRequired(req.chargeId)
       } else {
-        logger.info('Requesting capture for digital wallet payment', getLoggingFields(req))
+        logger.info('Requesting capture for digital wallet payment', loggingFields)
         Charge(req.headers[CORRELATION_HEADER])
-          .capture(req.chargeId, getLoggingFields(req))
+          .capture(req.chargeId, loggingFields)
           .then(
             () => {
-              logger.info('Successful capture for digital wallet payment.', getLoggingFields(req))
+              logger.info('Successful capture for digital wallet payment.', loggingFields)
               return redirect(res).toReturn(req.chargeId)
             },
             err => {
@@ -53,12 +57,12 @@ const handleAuthResponse = (req, res, charge) => response => {
                 return responseRouter.response(req, res, 'CAPTURE_FAILURE', withAnalytics(
                   charge,
                   {},
-                  webPaymentsRouteFor('handlePaymentResponse', charge.id)))
+                  webPaymentsRouteFor('handlePaymentResponse', wallet, charge.id)))
               } else {
                 responseRouter.systemErrorResponse(req, res, 'Wallet auth response capture payment attempt error', withAnalytics(
                   charge,
                   { returnUrl: routeFor('return', charge.id) },
-                  webPaymentsRouteFor('handlePaymentResponse', charge.id)
+                  webPaymentsRouteFor('handlePaymentResponse', wallet, charge.id)
                 ), err)
               }
             }
@@ -66,32 +70,33 @@ const handleAuthResponse = (req, res, charge) => response => {
       }
       break
     case 400:
-      logging.failedChargePost(response.statusCode, getLoggingFields(req))
+      logging.failedChargePost(response.statusCode, loggingFields)
       if (response.errorIdentifier === 'AUTHORISATION_REJECTED') {
         return responseRouter.response(req, res, 'AUTHORISATION_REJECTED', withAnalytics(
           charge,
           { returnUrl: routeFor('return', charge.id) },
-          webPaymentsRouteFor('handlePaymentResponse', charge.id))
+          webPaymentsRouteFor('handlePaymentResponse', wallet, charge.id))
         )
       } else {
         return responseRouter.errorResponse(req, res, 'Payment authorisation error occurred, ' +
           'but not due to transaction being declined.', withAnalytics(
           charge,
           { returnUrl: routeFor('return', charge.id) },
-          webPaymentsRouteFor('handlePaymentResponse', charge.id))
+          webPaymentsRouteFor('handlePaymentResponse', wallet, charge.id))
         )
       }
     default:
-      logging.failedChargePost(response.statusCode, getLoggingFields(req))
+      logging.failedChargePost(response.statusCode, loggingFields)
       responseRouter.systemErrorResponse(req, res, 'Wallet authorisation error response', withAnalytics(
         charge,
         { returnUrl: routeFor('return', charge.id) },
-        webPaymentsRouteFor('handlePaymentResponse', charge.id))
+        webPaymentsRouteFor('handlePaymentResponse', wallet, charge.id))
       )
   }
 }
 
 module.exports = (req, res) => {
+  const { wallet } = req.params
   const webPaymentAuthResponseSessionKey = `ch_${(req.chargeId)}.webPaymentAuthResponse`
   const charge = normalise.charge(req.chargeData, req.chargeId)
   const connectorResponse = getSessionVariable(req, webPaymentAuthResponseSessionKey)
@@ -99,9 +104,9 @@ module.exports = (req, res) => {
     return responseRouter.systemErrorResponse(req, res, 'Web payment auth error, no connector response', withAnalytics(
       charge,
       { returnUrl: routeFor('return', charge.id) },
-      webPaymentsRouteFor('handlePaymentResponse', charge.id)
+      webPaymentsRouteFor('handlePaymentResponse', wallet, charge.id)
     ))
   }
   deleteSessionVariable(req, webPaymentAuthResponseSessionKey)
-  return handleAuthResponse(req, res, charge)(connectorResponse)
+  return handleAuthResponse(req, res, charge, wallet)(connectorResponse)
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -91,10 +91,6 @@ const paths = {
       action: 'post'
     },
     handlePaymentResponse: {
-      path: '/handle-payment-response/:chargeId',
-      action: 'get'
-    },
-    handlePaymentResponseNew: {
       path: '/handle-payment-response/:wallet/:chargeId',
       action: 'get'
     }

--- a/app/routes.js
+++ b/app/routes.js
@@ -102,7 +102,6 @@ exports.bind = function (app) {
   // Generic Web payments endpoint
   app.post(paths.webPayments.authRequest.path, chargeCookieRequiredMiddlewareStack, webPaymentsMakePayment)
   app.get(paths.webPayments.handlePaymentResponse.path, chargeCookieRequiredMiddlewareStack, webPaymentsHandlePaymentResponse)
-  app.get(paths.webPayments.handlePaymentResponseNew.path, chargeCookieRequiredMiddlewareStack, webPaymentsHandlePaymentResponse)
 
   // secure controller
   app.get(paths.secure.get.path, secure.new)

--- a/test/controllers/web-payments/handle-auth-response.controller.test.js
+++ b/test/controllers/web-payments/handle-auth-response.controller.test.js
@@ -1,11 +1,8 @@
 'use strict'
 
-// NPM dependencies
-const { expect } = require('chai')
-// NPM dependencies
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-// Local dependencies
+
 require('../../test-helpers/html-assertions')
 
 const mockNormaliseCharge = {
@@ -17,6 +14,9 @@ const req = {
     'x-request-id': 'aaa'
   },
   chargeId,
+  params: {
+    wallet: 'google'
+  },
   body: {},
   chargeData: {
     id: 3,
@@ -41,7 +41,13 @@ const requireHandleAuthResponseController = (mockedCharge, mockedNormaliseCharge
 }
 
 describe('The web payments handle auth response controller', () => {
+  let res
   beforeEach(() => {
+    res = {
+      redirect: sinon.spy(),
+      render: sinon.spy(),
+      status: sinon.spy()
+    }
     req.chargeData.status = 'AUTHORISATION SUCCESS'
   })
 
@@ -57,11 +63,6 @@ describe('The web payments handle auth response controller', () => {
         }
       }
     }
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: () => {
         return {
@@ -71,19 +72,14 @@ describe('The web payments handle auth response controller', () => {
       deleteSessionVariable: sinon.spy()
     }
     requireHandleAuthResponseController(mockCharge, mockNormaliseCharge, mockCookies)(req, res)
-    expect(mockCookies.deleteSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
-    expect(res.redirect.calledWith(303, '/return/chargeId')).to.be.ok // eslint-disable-line
+    sinon.assert.calledWith(mockCookies.deleteSessionVariable, req, `ch_${chargeId}.webPaymentAuthResponse`)
+    sinon.assert.calledWith(res.redirect, 303, '/return/chargeId')
     done()
   })
 
   it('redirect to 3ds page if connector response status code is 200 and charge status is 200', done => {
     req.chargeData.status = 'AUTHORISATION 3DS REQUIRED'
     const mockCharge = () => {}
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: () => {
         return {
@@ -93,8 +89,8 @@ describe('The web payments handle auth response controller', () => {
       deleteSessionVariable: sinon.spy()
     }
     requireHandleAuthResponseController(mockCharge, mockNormaliseCharge, mockCookies)(req, res)
-    expect(mockCookies.deleteSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
-    expect(res.redirect.calledWith(303, `/card_details/${chargeId}/3ds_required`)).to.be.ok // eslint-disable-line
+    sinon.assert.calledWith(mockCookies.deleteSessionVariable, req, `ch_${chargeId}.webPaymentAuthResponse`)
+    sinon.assert.calledWith(res.redirect, 303, `/card_details/${chargeId}/3ds_required`)
     done()
   })
 
@@ -110,11 +106,6 @@ describe('The web payments handle auth response controller', () => {
         }
       }
     }
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: () => {
         return {
@@ -124,8 +115,8 @@ describe('The web payments handle auth response controller', () => {
       deleteSessionVariable: sinon.spy()
     }
     requireHandleAuthResponseController(mockCharge, mockNormaliseCharge, mockCookies)(req, res)
-    expect(mockCookies.deleteSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
-    expect(res.redirect.calledWith(303, '/card_details/chargeId/auth_waiting')).to.be.ok // eslint-disable-line
+    sinon.assert.calledWith(mockCookies.deleteSessionVariable, req, `ch_${chargeId}.webPaymentAuthResponse`)
+    sinon.assert.calledWith(res.redirect, 303, '/card_details/chargeId/auth_waiting')
     done()
   })
 
@@ -143,11 +134,6 @@ describe('The web payments handle auth response controller', () => {
         }
       }
     }
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: () => {
         return {
@@ -162,14 +148,14 @@ describe('The web payments handle auth response controller', () => {
         analyticsId: 'test-1234',
         type: 'test',
         paymentProvider: 'sandbox',
-        path: '/handle-payment-response/3/capture_failure',
+        path: '/handle-payment-response/google/3/capture_failure',
         amount: '4.99',
         testingVariant: 'original'
       }
     }
     requireHandleAuthResponseController(mockCharge, mockNormaliseCharge, mockCookies)(req, res)
-    expect(mockCookies.deleteSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
-    expect(res.render.calledWith('errors/incorrect-state/capture-failure', systemErrorObj)).to.be.true // eslint-disable-line
+    sinon.assert.calledWith(mockCookies.deleteSessionVariable, req, `ch_${chargeId}.webPaymentAuthResponse`)
+    sinon.assert.calledWith(res.render, 'errors/incorrect-state/capture-failure', systemErrorObj)
     done()
   })
 
@@ -187,11 +173,6 @@ describe('The web payments handle auth response controller', () => {
         }
       }
     }
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: (req, key) => {
         return {
@@ -207,24 +188,19 @@ describe('The web payments handle auth response controller', () => {
         analyticsId: 'test-1234',
         type: 'test',
         paymentProvider: 'sandbox',
-        path: '/handle-payment-response/3/error',
+        path: '/handle-payment-response/google/3/error',
         amount: '4.99',
         testingVariant: 'original'
       }
     }
     requireHandleAuthResponseController(mockCharge, mockNormaliseCharge, mockCookies)(req, res)
-    expect(mockCookies.deleteSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
-    expect(res.render.calledWith('errors/system-error', systemErrorObj)).to.be.true // eslint-disable-line
+    sinon.assert.calledWith(mockCookies.deleteSessionVariable, req, `ch_${chargeId}.webPaymentAuthResponse`)
+    sinon.assert.calledWith(res.render, 'errors/system-error', systemErrorObj)
     done()
   })
 
   it('should show error page and delete connector response if connector response is in the session and status is 402', done => {
     const mockCharge = sinon.spy()
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: (req, key) => {
         return {
@@ -240,24 +216,19 @@ describe('The web payments handle auth response controller', () => {
         analyticsId: 'test-1234',
         type: 'test',
         paymentProvider: 'sandbox',
-        path: '/handle-payment-response/3/error',
+        path: '/handle-payment-response/google/3/error',
         amount: '4.99',
         testingVariant: 'original'
       }
     }
     requireHandleAuthResponseController(mockCharge, mockNormaliseCharge, mockCookies)(req, res)
-    expect(mockCookies.deleteSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
-    expect(res.render.calledWith('errors/system-error', systemErrorObj)).to.be.true // eslint-disable-line
+    sinon.assert.calledWith(mockCookies.deleteSessionVariable, req, `ch_${chargeId}.webPaymentAuthResponse`)
+    sinon.assert.calledWith(res.render, 'errors/system-error', systemErrorObj)
     done()
   })
 
   it('should render the auth_failure view and delete connector response if connector response is in the session and status code is 400 Authorisation Rejected', done => {
     const mockCharge = sinon.spy()
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: () => {
         return {
@@ -271,7 +242,7 @@ describe('The web payments handle auth response controller', () => {
       viewName: 'AUTHORISATION_REJECTED',
       returnUrl: '/return/3',
       analytics: {
-        path: '/handle-payment-response/3/auth_failure',
+        path: '/handle-payment-response/google/3/auth_failure',
         analyticsId: 'test-1234',
         type: 'test',
         paymentProvider: 'sandbox',
@@ -281,19 +252,14 @@ describe('The web payments handle auth response controller', () => {
     }
 
     requireHandleAuthResponseController(mockCharge, mockNormaliseCharge, mockCookies)(req, res)
-    expect(mockCookies.deleteSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
-    expect(res.render.calledWith('errors/incorrect-state/auth-failure', authErrorObj)).to.be.true // eslint-disable-line
+    sinon.assert.calledWith(mockCookies.deleteSessionVariable, req, `ch_${chargeId}.webPaymentAuthResponse`)
+    sinon.assert.calledWith(res.render, 'errors/incorrect-state/auth-failure', authErrorObj)
     done()
   })
 
   it('should render the error page and delete connector response if connector response is in the session ' +
-      'and status code is 400, but for a Non Authorisation Rejection Error Identifier', done => {
+    'and status code is 400, but for a Non Authorisation Rejection Error Identifier', done => {
     const mockCharge = sinon.spy()
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: () => {
         return {
@@ -306,7 +272,7 @@ describe('The web payments handle auth response controller', () => {
     const authErrorObj = {
       message: 'There is a problem, please try again later',
       analytics: {
-        path: '/handle-payment-response/3',
+        path: '/handle-payment-response/google/3',
         analyticsId: 'test-1234',
         type: 'test',
         paymentProvider: 'sandbox',
@@ -325,11 +291,6 @@ describe('The web payments handle auth response controller', () => {
 
   it('should show error page and delete connector response if connector response is in the session and status is not recognised', done => {
     const mockCharge = sinon.spy()
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: (req, key) => {
         return {
@@ -345,7 +306,7 @@ describe('The web payments handle auth response controller', () => {
         analyticsId: 'test-1234',
         type: 'test',
         paymentProvider: 'sandbox',
-        path: '/handle-payment-response/3/error',
+        path: '/handle-payment-response/google/3/error',
         amount: '4.99',
         testingVariant: 'original'
       }
@@ -359,11 +320,6 @@ describe('The web payments handle auth response controller', () => {
   })
 
   it('should return error if connector response has not been saved in the session', done => {
-    const res = {
-      redirect: sinon.spy(),
-      render: sinon.spy(),
-      status: sinon.spy()
-    }
     const mockCookies = {
       getSessionVariable: sinon.spy(),
       deleteSessionVariable: sinon.spy()
@@ -375,14 +331,14 @@ describe('The web payments handle auth response controller', () => {
         analyticsId: 'test-1234',
         type: 'test',
         paymentProvider: 'sandbox',
-        path: '/handle-payment-response/3/error',
+        path: '/handle-payment-response/google/3/error',
         amount: '4.99',
         testingVariant: 'original'
       }
     }
     requireHandleAuthResponseController(() => { }, mockNormaliseCharge, mockCookies)(req, res)
-    expect(res.render.calledWith('errors/system-error', systemErrorObj)).to.be.true // eslint-disable-line
-    expect(mockCookies.getSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`)).to.be.ok // eslint-disable-line
+    sinon.assert.calledWith(res.render, 'errors/system-error', systemErrorObj)
+    sinon.assert.calledWith(mockCookies.getSessionVariable, req, `ch_${chargeId}.webPaymentAuthResponse`)
     done()
   })
 })


### PR DESCRIPTION
c4ca3a43ec61b017216baa5dc67088e992927c89 added the wallet type as a path parameter to the `/handle-payment-response/:wallet/:chargeId` route. Use this in log lines to log a `wallet` field, which is either "apple" or "google".

Remove the old `/handle-payment-response/:chargeId` route, which was maintained so as not to break in-flight payments when the new route with the path parameter was introduced. New payment journeys will already be directed to the route with the path parameter.

