### PR TITLE
PP-11638 Add wallet path param for logging

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/format-card-types.js
+++ b/app/assets/javascripts/browsered/web-payments/format-card-types.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = (allowedCardTypes, provider) => {
+module.exports = (allowedCardTypes, wallet) => {
   if (!allowedCardTypes) {
     return []
   }
@@ -16,11 +16,11 @@ module.exports = (allowedCardTypes, provider) => {
     .filter(brand => brand !== 'diners-club')
     .filter(brand => brand !== 'unionpay')
 
-  if (provider === 'google') {
+  if (wallet === 'google') {
     filteredAvailableNetworks = filteredAvailableNetworks.filter(brand => brand !== 'maestro')
   }
 
-  if (provider === 'apple' && filteredAvailableNetworks.includes('visa')) {
+  if (wallet === 'apple' && filteredAvailableNetworks.includes('visa')) {
     filteredAvailableNetworks.push('electron')
   }
 
@@ -29,6 +29,6 @@ module.exports = (allowedCardTypes, provider) => {
       let formattedBrand = brand
       if (brand === 'master-card') formattedBrand = 'masterCard'
       if (brand === 'american-express') formattedBrand = 'amex'
-      return provider === 'google' ? formattedBrand.toUpperCase() : formattedBrand
+      return wallet === 'google' ? formattedBrand.toUpperCase() : formattedBrand
     })
 }

--- a/app/controllers/web-payments/payment-auth-request.controller.js
+++ b/app/controllers/web-payments/payment-auth-request.controller.js
@@ -14,7 +14,7 @@ const normalise = require('../../services/normalise-charge')
 module.exports = (req, res, next) => {
   const { chargeData, chargeId, params } = req
   const charge = normalise.charge(chargeData, chargeId)
-  const wallet = params.provider
+  const { wallet } = params
   const paymentProvider = charge.paymentProvider
   let payload
 
@@ -49,7 +49,7 @@ module.exports = (req, res, next) => {
 
       // Always return 200 - the redirect checks if there are any errors
       res.status(200)
-      res.send({ url: `/handle-payment-response/${chargeId}` })
+      res.send({ url: `/handle-payment-response/${wallet}/${chargeId}` })
     })
     .catch(err => {
       logger.error(`Error while trying to authorise ${wallet} Pay payment`, {
@@ -58,6 +58,6 @@ module.exports = (req, res, next) => {
       })
       res.status(200)
       // Always return 200 - the redirect handles the error
-      res.send({ url: `/handle-payment-response/${chargeId}` })
+      res.send({ url: `/handle-payment-response/${wallet}/${chargeId}` })
     })
 }

--- a/app/middleware/retrieve-charge.js
+++ b/app/middleware/retrieve-charge.js
@@ -4,8 +4,7 @@
 const {
   GATEWAY_ACCOUNT_ID,
   GATEWAY_ACCOUNT_TYPE,
-  PROVIDER,
-  WALLET
+  PROVIDER
 } = require('@govuk-pay/pay-js-commons').logging.keys
 
 // Local dependencies
@@ -24,9 +23,6 @@ module.exports = (req, res, next) => {
       setLoggingField(req, GATEWAY_ACCOUNT_ID, data.gateway_account.gateway_account_id)
       setLoggingField(req, GATEWAY_ACCOUNT_TYPE, data.gateway_account.type)
       setLoggingField(req, PROVIDER, data.payment_provider)
-      if (data.wallet_type) {
-        setLoggingField(req, WALLET, data.wallet_type)
-      }
       next()
     })
     .catch((err) => {

--- a/app/paths.js
+++ b/app/paths.js
@@ -83,11 +83,15 @@ const paths = {
   },
   webPayments: {
     authRequest: {
-      path: '/web-payments-auth-request/:provider/:chargeId',
+      path: '/web-payments-auth-request/:wallet/:chargeId',
       action: 'post'
     },
     handlePaymentResponse: {
       path: '/handle-payment-response/:chargeId',
+      action: 'get'
+    },
+    handlePaymentResponseNew: {
+      path: '/handle-payment-response/:wallet/:chargeId',
       action: 'get'
     }
   },

--- a/app/routes.js
+++ b/app/routes.js
@@ -85,6 +85,7 @@ exports.bind = function (app) {
   // Generic Web payments endpoint
   app.post(paths.webPayments.authRequest.path, chargeCookieRequiredMiddlewareStack, webPaymentsMakePayment)
   app.get(paths.webPayments.handlePaymentResponse.path, chargeCookieRequiredMiddlewareStack, webPaymentsHandlePaymentResponse)
+  app.get(paths.webPayments.handlePaymentResponseNew.path, chargeCookieRequiredMiddlewareStack, webPaymentsHandlePaymentResponse)
 
   // secure controller
   app.get(paths.secure.get.path, secure.new)

--- a/test/controllers/web-payments/payment-auth-request.controller.test.js
+++ b/test/controllers/web-payments/payment-auth-request.controller.test.js
@@ -15,7 +15,7 @@ const chargeId = 'chargeId'
 
 describe('The web payments auth request controller', () => {
   describe('when processing an Apple Pay payment', () => {
-    const provider = 'apple'
+    const wallet = 'apple'
     const req = {
       headers: {
         'x-request-id': 'aaa'
@@ -23,7 +23,7 @@ describe('The web payments auth request controller', () => {
       chargeId,
       chargeData: paymentFixtures.validChargeDetails({ paymentProvider: 'worldpay' }),
       params: {
-        provider
+        wallet
       },
       body: {}
     }
@@ -49,11 +49,11 @@ describe('The web payments auth request controller', () => {
         statusCode: 200
       }
       nock(process.env.CONNECTOR_HOST)
-        .post(`/v1/frontend/charges/${chargeId}/wallets/${provider}`)
+        .post(`/v1/frontend/charges/${chargeId}/wallets/${wallet}`)
         .reply(200)
       requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
           expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
-          expect(res.send.calledWith({url: `/handle-payment-response/${chargeId}`})).to.be.ok // eslint-disable-line
+          expect(res.send.calledWith({url: `/handle-payment-response/apple/${chargeId}`})).to.be.ok // eslint-disable-line
           expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
         done()
       }
@@ -82,7 +82,7 @@ describe('The web payments auth request controller', () => {
   })
 
   describe('when processing a Google Pay payment', () => {
-    const provider = 'google'
+    const wallet = 'google'
     const req = {
       headers: {
         'x-request-id': 'aaa'
@@ -90,7 +90,7 @@ describe('The web payments auth request controller', () => {
       chargeId,
       chargeData: paymentFixtures.validChargeDetails({ paymentProvider: 'worldpay' }),
       params: {
-        provider
+        wallet
       },
       body: {}
     }
@@ -120,7 +120,7 @@ describe('The web payments auth request controller', () => {
         .reply(200)
       requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
         expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
-        expect(res.send.calledWith({ url: `/handle-payment-response/${chargeId}` })).to.be.ok // eslint-disable-line
+        expect(res.send.calledWith({ url: `/handle-payment-response/google/${chargeId}` })).to.be.ok // eslint-disable-line
         expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
         done()
       }
@@ -146,7 +146,7 @@ describe('The web payments auth request controller', () => {
 
       requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
           expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
-          expect(res.send.calledWith({ url: `/handle-payment-response/${chargeId}` })).to.be.ok // eslint-disable-line
+          expect(res.send.calledWith({ url: `/handle-payment-response/google/${chargeId}` })).to.be.ok // eslint-disable-line
           expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
         done()
       }
@@ -166,7 +166,7 @@ describe('The web payments auth request controller', () => {
         .replyWithError('oops')
       requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
         expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
-        expect(res.send.calledWith({ url: `/handle-payment-response/${chargeId}` })).to.be.ok // eslint-disable-line
+        expect(res.send.calledWith({ url: `/handle-payment-response/google/${chargeId}` })).to.be.ok // eslint-disable-line
         expect(mockCookies.setSessionVariable.called).to.be.false // eslint-disable-line
         done()
       }


### PR DESCRIPTION
Relying on getting the wallet_type from the charge when handling the authorisation result isn't reliable - as connector can return a response before it has completed authorisation, in which case the wallet_type is not present.

So stop logging the `wallet` from the `wallet_type` on the charge from connector, as we can't rely on it consistently being there.

Instead, add the wallet type as a path parameter for the /handle-payment-response/:chargeId path, and pass in this wallet type when passing the redirect URL back to the client-side JS in `payment-auth-request.controller.js`. We will use this for logging in `handle-auth-response.controller.js`.

For now, also support the old URL without the wallet as a path parameter so we don't break in-flight payments. Support for this will be removed as a follow-up commit. We will also the logging of the wallet type in this follow-up commit. We can't add this yet, as the path parameter will not be present for in-flight payments when this change is deployed.

Rename some path params from `provider` -> `wallet` to avoid confusion with payment provider.

## Notes for reviewer

I have manually tested this locally to be sure that an in-flight walley payment that sends the user to the old `/handle-payment-response/:chargeId` route will still work, as well as a payment sending the user to the new `/handle-payment-response/:wallet/:chargeId` route