### PR TITLE
PP-11468 Update Apple Pay Cypress tests to test the Node endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -247,21 +247,21 @@
         "filename": "test/cypress/integration/web-payments/apple-pay.test.cy.js",
         "hashed_secret": "321f58f0cffa4caf8de5176503e82691f0f4f092",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 34
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/web-payments/apple-pay.test.cy.js",
         "hashed_secret": "f6a72b11f4038f37c4c436084d974f38b829ae96",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 35
       },
       {
         "type": "Hex High Entropy String",
         "filename": "test/cypress/integration/web-payments/apple-pay.test.cy.js",
         "hashed_secret": "a269701da90143c626af966dfdaa775d848858b1",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 43
       }
     ],
     "test/cypress/integration/web-payments/google-pay.test.cy.js": [
@@ -389,5 +389,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-09T18:54:00Z"
+  "generated_at": "2023-11-14T11:55:43Z"
 }

--- a/test/cypress/integration/web-payments/apple-pay.test.cy.js
+++ b/test/cypress/integration/web-payments/apple-pay.test.cy.js
@@ -1,7 +1,9 @@
 const { getMockApplePayClass, MockApplePayError } = require('../../utils/apple-pay-js-api-stubs')
 const {
-  connectorGetChargeDetails,
-  connectorUpdateChargeStatus
+  connectorMultipleSubsequentChargeDetails,
+  connectorUpdateChargeStatus,
+  connectorAuthWalletCharge,
+  connectorPostValidCaptureCharge
 } = require('../../utils/stub-builders/charge-stubs')
 const {
   connectorFindChargeByToken,
@@ -13,7 +15,6 @@ const { cardIdValidCardDetails } = require('../../utils/stub-builders/card-id-st
 describe('Apple Pay payment flow', () => {
   const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
   const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
-  const returnURL = 'humans.txt?success'
 
   const validPaymentRequestResponse = email => {
     const response = {
@@ -48,37 +49,10 @@ describe('Apple Pay payment flow', () => {
     return response
   }
 
-  const createPaymentChargeStubs = [
-    connectorFindChargeByToken({ tokenId }),
-    connectorMarkTokenAsUsed(tokenId),
-    connectorGetChargeDetails({
-      chargeId,
-      status: 'CREATED',
-      state: { finished: false, status: 'created' },
-      paymentProvider: 'worldpay'
-    }),
-    connectorUpdateChargeStatus(chargeId),
-    adminUsersGetService()
-  ]
-
-  const createPaymentChargeStubsWithAgreement = [
-    connectorFindChargeByToken({ tokenId }),
-    connectorMarkTokenAsUsed(tokenId),
-    connectorGetChargeDetails({
-      chargeId,
-      status: 'CREATED',
-      state: { finished: false, status: 'created' },
-      agreement: { agreement_id: 'an-agreement-id' },
-      paymentProvider: 'worldpay'
-    }),
-    connectorUpdateChargeStatus(chargeId),
-    adminUsersGetService()
-  ]
-
   const checkCardDetailsStubsWithApplePayorGooglePay = (applePayEnabled, googlePayEnabled, emailCollectionMode = 'MANDATORY', agreement) => {
-    const chargeDetails = {
+    const createdCharge = {
       chargeId,
-      status: 'ENTERING CARD DETAILS',
+      status: 'CREATED',
       state: { finished: false, status: 'started' },
       allowApplePay: applePayEnabled,
       allowGooglePay: googlePayEnabled,
@@ -88,271 +62,180 @@ describe('Apple Pay payment flow', () => {
     }
 
     if (agreement) {
-      chargeDetails.agreement = { agreement_id: 'an-agreement-id' }
+      createdCharge.agreement = { agreement_id: 'an-agreement-id' }
+    }
+
+    const enteringCardDetailsCharge = {
+      chargeId,
+      status: 'CAPTURE APPROVED',
+      state: { finished: true, status: 'success' },
+      allowApplePay: applePayEnabled,
+      allowGooglePay: googlePayEnabled,
+      gatewayMerchantId: 'SMTHG12345UP',
+      requires3ds: true,
+      integrationVersion3ds: 2,
+      paymentProvider: 'worldpay'
+    }
+
+    if (agreement) {
+      enteringCardDetailsCharge.agreement = { agreement_id: 'an-agreement-id' }
     }
 
     return [
-      connectorGetChargeDetails(chargeDetails),
-      cardIdValidCardDetails()
+      connectorFindChargeByToken({ tokenId }),
+      connectorMultipleSubsequentChargeDetails([
+        createdCharge,
+        enteringCardDetailsCharge]),
+      cardIdValidCardDetails(),
+      connectorMarkTokenAsUsed(tokenId),
+      connectorUpdateChargeStatus(chargeId),
+      adminUsersGetService(),
+      connectorAuthWalletCharge(chargeId, 'apple'),
+      connectorPostValidCaptureCharge(chargeId)
     ]
-  }
-  const mockFetchAPI = path => {
-    // Mock merchant validation controller response
-    if (path === '/apple-pay-merchant-validation') {
-      return new Promise(resolve => resolve({
-        status: 200,
-        json: () => new Promise(resolve => resolve({ signature: 'legit' }))
-      }))
-    }
-    // Mock payment auth response
-    return new Promise(resolve => resolve({
-      status: 200,
-      json: () => new Promise(resolve => resolve({ url: `/${returnURL}` }))
-    }))
   }
 
   describe('Secure card payment page', () => {
     it('Should show Apple Pay as a payment option and allow user to choose Apple Pay', () => {
-      cy.task('setupStubs', createPaymentChargeStubs)
-      cy.visit(`/secure/${tokenId}`)
-
-      // 1. Charge will be created using this id as a token (GET)
-      // 2. Token will be marked as used (POST)
-      // 3. Charge will be fetched (GET)
-      // 4. Service related to charge will be fetched (GET)
-      // 5. Charge status will be updated (PUT)
-      // 6. Client will be redirected to /card_details/:chargeId (304)
-      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-
-      cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubsWithApplePayorGooglePay(true, false))
-
-      cy.visit(`/card_details/${chargeId}`, {
+      cy.visit(`/secure/${tokenId}`, {
         onBeforeLoad: win => {
-          // Stub Apple Pay API (which only exists within Safari)
           win.ApplePaySession = getMockApplePayClass(validPaymentRequestResponse, 'jonheslop@bla.test')
-          // Stub fetch so we can simulate
-          // 1. The merchant validation call to Apple
-          // 2. The auth call to connector
-          cy.stub(win, 'fetch', mockFetchAPI)
         }
       })
 
-      // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Apple Pay
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+
+      cy.intercept('/apple-pay-merchant-validation', { method: 'POST', times: 1 }, 'test').as('apple-pay-merchant-validation-request')
+
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').should('be.visible')
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').click()
 
-      // 8. User clicks though the native payment UI and passes their tokenised card data to the auth request handler
-      // 9. The auth response comes back from connector and frontend sends capture request and redirects the user the success page
+      cy.wait('@apple-pay-merchant-validation-request')
+
       cy.location().should((loc) => {
         expect(loc.pathname).to.eq('/humans.txt')
-        expect(loc.search).to.eq('?success')
+        expect(loc.search).to.eq('?confirm')
       })
     })
 
     it('Should show Apple Pay as a payment option with email address collection disabled and allow user to choose Apple Pay', () => {
-      cy.task('setupStubs', createPaymentChargeStubs)
-      cy.visit(`/secure/${tokenId}`)
-
-      // 1. Charge will be created using this id as a token (GET)
-      // 2. Token will be marked as used (POST)
-      // 3. Charge will be fetched (GET)
-      // 4. Service related to charge will be fetched (GET)
-      // 5. Charge status will be updated (PUT)
-      // 6. Client will be redirected to /card_details/:chargeId (304)
-      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-
-      cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubsWithApplePayorGooglePay(true, false, 'OFF'))
 
-      cy.visit(`/card_details/${chargeId}`, {
+      cy.visit(`/secure/${tokenId}`, {
         onBeforeLoad: win => {
-          // Stub Apple Pay API (which only exists within Safari)
-          win.ApplePaySession = getMockApplePayClass(validPaymentRequestResponse, null)
-          // Stub fetch so we can simulate
-          // 1. The merchant validation call to Apple
-          // 2. The auth call to connector
-          cy.stub(win, 'fetch', mockFetchAPI)
+          win.ApplePaySession = getMockApplePayClass(validPaymentRequestResponse, 'jonheslop@bla.test')
         }
       })
 
-      // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Apple Pay
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+
+      cy.intercept('/apple-pay-merchant-validation', { method: 'POST', times: 1 }, 'test').as('apple-pay-merchant-validation-request')
+
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').should('be.visible')
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').click()
 
-      // 8. User clicks though the native payment UI and passes their tokenised card data to the auth request handler
-      // 9. The auth response comes back from connector and frontend sends capture request and redirects the user the success page
+      cy.wait('@apple-pay-merchant-validation-request')
+
       cy.location().should((loc) => {
         expect(loc.pathname).to.eq('/humans.txt')
-        expect(loc.search).to.eq('?success')
+        expect(loc.search).to.eq('?confirm')
       })
     })
 
     it('Should show Apple Pay as a payment option but allow user to pay with a card', () => {
-      cy.task('setupStubs', createPaymentChargeStubs)
-      cy.visit(`/secure/${tokenId}`)
-
-      // 1. Charge will be created using this id as a token (GET)
-      // 2. Token will be marked as used (POST)
-      // 3. Charge will be fetched (GET)
-      // 4. Service related to charge will be fetched (GET)
-      // 5. Charge status will be updated (PUT)
-      // 6. Client will be redirected to /card_details/:chargeId (304)
-      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-
-      cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubsWithApplePayorGooglePay(true, false))
-
-      cy.visit(`/card_details/${chargeId}`, {
+      cy.visit(`/secure/${tokenId}`, {
         onBeforeLoad: win => {
-          // Stub Apple Pay API (which only exists within Safari)
           win.ApplePaySession = getMockApplePayClass(validPaymentRequestResponse, 'jonheslop@bla.test')
-          // Stub fetch so we can simulate
-          // 1. The merchant validation call to Apple
-          // 2. The auth call to connector
-          cy.stub(win, 'fetch', mockFetchAPI)
         }
       })
 
-      // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Apple Pay
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').should('be.visible')
 
-      // 8. User should see normal payment form
       cy.get('#card-no').should('be.visible')
     })
 
     it('Should show Apple Pay but error because a bad email was entered', () => {
-      cy.task('setupStubs', createPaymentChargeStubs)
-      cy.visit(`/secure/${tokenId}`)
+      cy.task('setupStubs', checkCardDetailsStubsWithApplePayorGooglePay(true, false))
+      cy.visit(`/secure/${tokenId}`, {
+        onBeforeLoad: win => {
+          win.ApplePaySession = getMockApplePayClass(validPaymentRequestResponse, 'bad-email')
+          win.ApplePayError = MockApplePayError
+        }
+      })
 
-      // 1. Charge will be created using this id as a token (GET)
-      // 2. Token will be marked as used (POST)
-      // 3. Charge will be fetched (GET)
-      // 4. Service related to charge will be fetched (GET)
-      // 5. Charge status will be updated (PUT)
-      // 6. Client will be redirected to /card_details/:chargeId (304)
       cy.location('pathname').should('eq', `/card_details/${chargeId}`)
 
       // eslint-disable-next-line handle-callback-err
       cy.on('uncaught:exception', (err, runnable) => {
-        // returning false here prevents Cypress from failing when the purpose of the test is an uncaught exception
         console.log('Expected error', err)
         return false
       })
 
-      cy.task('clearStubs')
-      cy.task('setupStubs', checkCardDetailsStubsWithApplePayorGooglePay(true, false))
+      cy.intercept('/apple-pay-merchant-validation', { method: 'POST', times: 1 }, 'test').as('apple-pay-merchant-validation-request')
 
-      cy.visit(`/card_details/${chargeId}`, {
-        onBeforeLoad: win => {
-          // Stub Apple Pay API (which only exists within Safari)
-          win.ApplePaySession = getMockApplePayClass(validPaymentRequestResponse, 'badEmail')
-          win.ApplePayError = MockApplePayError
-          // Stub fetch so we can simulate
-          // 1. The merchant validation call to Apple
-          // 2. The auth call to connector
-          cy.stub(win, 'fetch', mockFetchAPI)
-        }
-      })
-
-      // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Apple Pay
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').should('be.visible')
       cy.get('#apple-pay-payment-method-submit').click()
 
-      // 8. User clicks though the native payment UI but the email is invalid and we throw an error
+      cy.wait('@apple-pay-merchant-validation-request')
+
       cy.get('#error-summary').should('be.visible')
     })
 
     it('Should not show Apple Pay as browser doesn’t support it', () => {
-      cy.task('setupStubs', createPaymentChargeStubs)
-      cy.visit(`/secure/${tokenId}`)
-
-      // 1. Charge will be created using this id as a token (GET)
-      // 2. Token will be marked as used (POST)
-      // 3. Charge will be fetched (GET)
-      // 4. Service related to charge will be fetched (GET)
-      // 5. Charge status will be updated (PUT)
-      // 6. Client will be redirected to /card_details/:chargeId (304)
-      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-
-      cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubsWithApplePayorGooglePay(false, false))
 
-      cy.visit(`/card_details/${chargeId}`)
+      cy.visit(`/secure/${tokenId}`, {
+        onBeforeLoad: win => {
+          win.ApplePaySession = getMockApplePayClass(validPaymentRequestResponse, 'jonheslop@bla.test')
+        }
+      })
 
-      // 7. Javascript will not detect browser has Apple Pay and won’t show it as an option
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').should('not.exist')
 
-      // 8. User should see normal payment form
       cy.get('#card-no').should('be.visible')
     })
 
     it('Should show Apple Pay as a payment option when Google pay is an option and allow user to use Apple Pay', () => {
-      cy.task('setupStubs', createPaymentChargeStubs)
-      cy.visit(`/secure/${tokenId}`)
-
-      // 1. Charge will be created using this id as a token (GET)
-      // 2. Token will be marked as used (POST)
-      // 3. Charge will be fetched (GET)
-      // 4. Service related to charge will be fetched (GET)
-      // 5. Charge status will be updated (PUT)
-      // 6. Client will be redirected to /card_details/:chargeId (304)
-      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-
-      // eslint-disable-next-line handle-callback-err
-      cy.on('uncaught:exception', (err, runnable) => {
-        // returning false here prevents Cypress from failing when the purpose of the test is an uncaught exception
-        console.log('Expected error', err)
-        return false
-      })
-
-      cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubsWithApplePayorGooglePay(true, true))
 
-      cy.visit(`/card_details/${chargeId}`, {
+      cy.visit(`/secure/${tokenId}`, {
         onBeforeLoad: win => {
-          // Stub Apple Pay API (which only exists within Safari)
           win.ApplePaySession = getMockApplePayClass(validPaymentRequestResponse, 'jonheslop@bla.test')
-          // Stub fetch so we can simulate
-          // 1. The merchant validation call to Apple
-          // 2. The auth call to connector
-          cy.stub(win, 'fetch', mockFetchAPI)
         }
       })
 
-      // 7. Javascript will detect browser is payment Request compatible and show the option to pay with Apple Pay
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+
+      cy.intercept('/apple-pay-merchant-validation', { method: 'POST', times: 1 }, 'test').as('apple-pay-merchant-validation-request')
+
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').should('be.visible')
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').click()
 
-      // 8. User clicks though the native payment UI and passes their tokenised card data to the auth request handler
-      // 9. The auth response comes back from connector and frontend sends capture request and redirects the user the success page
+      cy.wait('@apple-pay-merchant-validation-request')
+
       cy.location().should((loc) => {
         expect(loc.pathname).to.eq('/humans.txt')
-        expect(loc.search).to.eq('?success')
+        expect(loc.search).to.eq('?confirm')
       })
     })
 
     it('Should not show Apple Pay as payment is a recurring one', () => {
-      cy.task('setupStubs', createPaymentChargeStubsWithAgreement)
-      cy.visit(`/secure/${tokenId}`)
-
-      // 1. Charge will be created using this id as a token (GET)
-      // 2. Token will be marked as used (POST)
-      // 3. Charge will be fetched (GET)
-      // 4. Service related to charge will be fetched (GET)
-      // 5. Charge status will be updated (PUT)
-      // 6. Client will be redirected to /card_details/:chargeId (304)
-      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
-
-      cy.task('clearStubs')
       cy.task('setupStubs', checkCardDetailsStubsWithApplePayorGooglePay(true, false, 'MANDATORY', true))
 
-      cy.visit(`/card_details/${chargeId}`)
+      cy.visit(`/secure/${tokenId}`, {
+        onBeforeLoad: win => {
+          win.ApplePaySession = getMockApplePayClass(validPaymentRequestResponse, 'jonheslop@bla.test')
+        }
+      })
 
-      // 7. Javascript will not detect browser has Apple Pay and won’t show it as an option
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+
       cy.get('#apple-pay-payment-method-submit.web-payment-button--apple-pay').should('not.exist')
 
-      // 8. User should see normal payment form
       cy.get('#card-no').should('be.visible')
     })
   })

--- a/test/cypress/integration/web-payments/google-pay.test.cy.js
+++ b/test/cypress/integration/web-payments/google-pay.test.cy.js
@@ -81,7 +81,7 @@ describe('Google Pay payment flow', () => {
       connectorUpdateChargeStatus(chargeId),
       adminUsersGetService(),
       cardIdValidCardDetails(),
-      connectorAuthWalletCharge(chargeId, 'google', 'worldpay'),
+      connectorAuthWalletCharge(chargeId, 'google'),
       connectorPostValidCaptureCharge(chargeId),
       connectorWorldpay3dsFlexDdcJwt(chargeId)
     ]

--- a/test/cypress/utils/apple-pay-js-api-stubs.js
+++ b/test/cypress/utils/apple-pay-js-api-stubs.js
@@ -14,7 +14,7 @@ const getMockApplePayClass = (validPaymentRequestResponse, email = null) => {
     begin () {
       if (this._onvalidatemerchant) {
         this._onvalidatemerchant(
-          { validationURL: 'https://fakeapple.url' }
+          { validationURL: 'https://fakeapple.url/fake-apple-merchant-validation' }
         )
       }
 

--- a/test/cypress/utils/stub-builders/charge-stubs.js
+++ b/test/cypress/utils/stub-builders/charge-stubs.js
@@ -52,8 +52,8 @@ function connectorValidPatchConfirmedChargeDetails (chargeId) {
   return stubBuilder('PATCH', path, 200, { response })
 }
 
-function connectorAuthWalletCharge (chargeId, walletType, paymentProvider) {
-  const path = `/v1/frontend/charges/${chargeId}/wallets/${walletType}/${paymentProvider}`
+function connectorAuthWalletCharge (chargeId, walletType) {
+  const path = `/v1/frontend/charges/${chargeId}/wallets/${walletType}`
 
   const response = paymentFixtures.validAuthorisationRequest()
 


### PR DESCRIPTION
with @SandorArpa

Apple Pay Cypress tests
- The Apple Pay Cypress tests was not testing the Node endpoint to authorise and capture a charge for wallet payments.
- Instead, the Cypress test was mocking out the entire JS `fetch` call.
- So the test was only covering the client side code.
- This PR removes the mocked `fetch`.
- The test will now pass through all calls to the Node endpoint.
- A similar thing was done to the Google Pay Cypress tests: https://github.com/alphagov/pay-frontend/pull/3752
- Could not allow the JS fetch call for `merchant validation` go all the way to the Node endpoint
  - This involves certificates and difficult to stub the backend side of the call.
  - Therefore, had do use a `cy.intercept` when making the JS fetch call to `merchant validation`.

Google Pay Cypress tests
- Had to update the tests to use then connector stubs when authourising an Apple or Google payment.


