### PR TITLE
PP-11039 System error nunjucks file - update page title

### DIFF
--- a/app/views/errors/system-error.njk
+++ b/app/views/errors/system-error.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-  {{ __p("errorViews.error") }} - GOV.UK Pay
+  {{ __p("errorViews.technicalProblems") }} - GOV.UK Pay
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
- Make the page title and H1 heading match - as this was a WCAG failure.
- This is the only error page that is affected by this.


