### PR TITLE
ZD-5569361 bump pay-js-commons version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-crypto/decrypt-node": "^1.0.3",
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-        "@govuk-pay/pay-js-commons": "^4.0.5",
+        "@govuk-pay/pay-js-commons": "^4.0.9",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "7.74.0",
         "cert-info": "^1.5.1",
@@ -2125,9 +2125,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-4.0.5.tgz",
-      "integrity": "sha512-Fk/R44IgHumKL6n9HoNCkjuCguvMN86Rz7CwzS7UMS+iN6R5Rk23UYFtTZ5adb18vVv/yqhu64feDSCpXFkjbw==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-4.0.9.tgz",
+      "integrity": "sha512-sKzktyw3+CMGHIhceb4tLhgiezI8glLTl99TO80r6fgmErU3fhxylsr+pKyfXs1NjH6jdjWRVlsKETwoz3xQEg==",
       "dependencies": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.43",
@@ -18990,9 +18990,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-4.0.5.tgz",
-      "integrity": "sha512-Fk/R44IgHumKL6n9HoNCkjuCguvMN86Rz7CwzS7UMS+iN6R5Rk23UYFtTZ5adb18vVv/yqhu64feDSCpXFkjbw==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-4.0.9.tgz",
+      "integrity": "sha512-sKzktyw3+CMGHIhceb4tLhgiezI8glLTl99TO80r6fgmErU3fhxylsr+pKyfXs1NjH6jdjWRVlsKETwoz3xQEg==",
       "requires": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.43",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "^4.0.5",
+    "@govuk-pay/pay-js-commons": "^4.0.9",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "7.74.0",
     "cert-info": "^1.5.1",


### PR DESCRIPTION
## WHAT

Bump `pay-js-commons` version to 4.0.9. This bump includes the custom branding for Penzance Council.

