### PR TITLE
PP-12015: Add GHA job to check docker base images are manifests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,7 @@
 name: Github Actions Tests
 
 on:
+  workflow_dispatch:
   workflow_call:
   pull_request:
 
@@ -134,3 +135,6 @@ jobs:
           npm run cypress:server > /dev/null 2>&1 &
           sleep 5
           npm run cypress:test
+
+  check-docker-base-images-are-manifests:
+    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@pp-12015/add-reusable-workflow-to-check-manifests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -137,4 +137,4 @@ jobs:
           npm run cypress:test
 
   check-docker-base-images-are-manifests:
-    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@pp-12015/add-reusable-workflow-to-check-manifests
+    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci --quiet
 COPY . .
 RUN npm run compile
 
-FROM node:18.19.0-alpine3.18@sha256:4bdb3f3105718f0742bc8d64bb4e36e8f955ebbee295325e40ae80bc8ef78833 AS final
+FROM node:18.19.0-alpine3.18@sha256:b0df76a0c4b7a5321786724d561428f1de9bed1ea5aedbd00ac07f0c1a386bd0 AS final
 
 RUN ["apk", "--no-cache", "upgrade"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci --quiet
 COPY . .
 RUN npm run compile
 
-FROM node:18.19.0-alpine3.18@sha256:b0df76a0c4b7a5321786724d561428f1de9bed1ea5aedbd00ac07f0c1a386bd0 AS final
+FROM node:18.19.0-alpine3.18@sha256:4bdb3f3105718f0742bc8d64bb4e36e8f955ebbee295325e40ae80bc8ef78833 AS final
 
 RUN ["apk", "--no-cache", "upgrade"]
 


### PR DESCRIPTION
## WHAT
Use the reusable workflow in pay-ci to ensure all FROM lines in the Dockerfile are pointing to manifest files


