### PR TITLE
PP-12039 Bump axios to 1.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@pact-foundation/pact": "^12.1.1",
         "@pact-foundation/pact-core": "^14.0.5",
         "@snyk/protect": "^1.1235.x",
-        "axios": "^1.6.0",
+        "axios": "^1.6.4",
         "browserify": "17.0.x",
         "chai": "^4.3.8",
         "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@pact-foundation/pact": "^12.1.1",
     "@pact-foundation/pact-core": "^14.0.5",
     "@snyk/protect": "^1.1235.x",
-    "axios": "^1.6.0",
+    "axios": "^1.6.4",
     "browserify": "17.0.x",
     "chai": "^4.3.8",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
## WHAT
- Bump axios to the latest version which includes updates to vulnerable indirect dependencies (follow_redirects, formToJSON)

