### PR TITLE
BAU increase csp request size limit

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -67,7 +67,7 @@ exports.bind = function (app) {
 
   const cspMiddlewareStack = [
     rateLimitMiddleware,
-    requestParseMiddleware(4000),
+    requestParseMiddleware(50000),
     detectErrorsMiddleware,
     captureEventMiddleware([
       'www.facebook.com',


### PR DESCRIPTION
## WHAT

- Chrome Reporting API can batch csp violation reports prior to sending, leading to larger than expected payload sizes. To ensure we are receiving all reports we need to increase the max payload size on the `/csp-report` endpoint

