### PR TITLE
PP-12248 Log error message when rendering error page

### DIFF
--- a/app/utils/response-router.js
+++ b/app/utils/response-router.js
@@ -274,7 +274,7 @@ function logErrorPageShown (page, reason, loggingFields, error) {
   logger.info('Rendering error response', {
     page,
     reason,
-    error,
+    error: (error && error.message) || error,
     ...loggingFields
   })
 }

--- a/test/utils/response-router.test.js
+++ b/test/utils/response-router.test.js
@@ -122,7 +122,7 @@ describe('rendering behaviour', () => {
   })
 
   it('should render error response', () => {
-    responseRouter.errorResponse(request, response, 'A reason', { returnUrl: 'http://example.com' }, 'err')
+    responseRouter.errorResponse(request, response, 'A reason', { returnUrl: 'http://example.com' }, new Error('err'))
     expect(render.lastCall.args).to.deep.equal(['error', {
       returnUrl: 'http://example.com',
       viewName: 'ERROR',
@@ -136,7 +136,7 @@ describe('rendering behaviour', () => {
   })
 
   it('should render system error response', () => {
-    responseRouter.systemErrorResponse(request, response, 'A reason', { returnUrl: 'http://example.com' }, 'err')
+    responseRouter.systemErrorResponse(request, response, 'A reason', { returnUrl: 'http://example.com' }, new Error('err'))
     expect(render.lastCall.args).to.deep.equal(['errors/system-error', {
       returnUrl: 'http://example.com',
       viewName: 'SYSTEM_ERROR'


### PR DESCRIPTION
If we catch an error and render the error page, we do not currently log the error message. The `error` always evaluates as an empty JSON object when we attempt to log it so it is not included. Instead, log the error message.


