### PR TITLE
PP 12165 Fix Welsh translation of "or" divider under Google Pay & Apple Pay buttons

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -127,7 +127,7 @@
                     })
                   }}
                   <span id="apple-pay-payment-method-divider" class="pay-divider">
-                  <span id="apple-pay-payment-method-divider-word" class="pay-divider--word">or</span></span>
+                  <span id="apple-pay-payment-method-divider-word" class="pay-divider--word">{{ __p("commonConjunctions.or") }}</span></span>
                 </form>
               </div>
             {% endif %}
@@ -151,7 +151,7 @@
                     })
                   }}
                   <span id="google-pay-payment-method-divider" class="pay-divider">
-                  <span id="google-pay-payment-method-divider-word" class="pay-divider--word">or</span></span>
+                  <span id="google-pay-payment-method-divider-word" class="pay-divider--word">{{ __p("commonConjunctions.or") }}</span></span>
                 </form>
               </div>
             {% endif %}


### PR DESCRIPTION
## WHAT
- Fixes the Welsh translation of "or" in the divider
- Adds some Cypress tests for Welsh translations on the Charge page when Apple Pay or Google Pay is available
