### PR TITLE
[DO NOT MERGE] PP-11682 replace 'request' package with 'axios' for 'connector' and 'adminusers' clients.

### DIFF
--- a/app/controllers/secure.controller.js
+++ b/app/controllers/secure.controller.js
@@ -52,7 +52,7 @@ exports.new = async function (req, res) {
       res.redirect(303, generateRoute(resolveActionName(chargeStatus, 'get'), { chargeId }))
     }
   } catch (err) {
-    if (err.message === 'UNAUTHORISED') {
+    if (err.message === 'UNAUTHORISED' || err.message === 'CLIENT_UNAVAILABLE') {
       logger.info('Call to /secure/{tokenId} is Unauthorised. This could be due to the token not existing, ' +
         'the frontend state cookie not existing, or the frontend state cookie containing an invalid value.',
       getLoggingFields(req))

--- a/app/controllers/three-d-secure.controller.js
+++ b/app/controllers/three-d-secure.controller.js
@@ -56,10 +56,10 @@ const build3dsPayload = (chargeId, req) => {
 }
 
 const handleThreeDsResponse = (req, res, charge) => response => {
-  switch (response.statusCode) {
+  switch (response.status) {
     case 200:
     case 400:
-      if (_.get(response, 'body.status', '') === 'AUTHORISATION 3DS REQUIRED') {
+      if (_.get(response, 'data.status', '') === 'AUTHORISATION 3DS REQUIRED') {
         logger.info('3DS required again', getLoggingFields(req))
         redirect(res).toAuth3dsRequired(charge.id)
       } else {
@@ -92,7 +92,18 @@ module.exports = {
           charge_status: charge.status,
           error: err
         })
-        responseRouter.errorResponse(req, res, 'Exception in auth3dsHandler', withAnalytics(charge), err)
+        if (err.errorCode === 400) {
+          if (_.get(res, 'req.chargeData.status', '') === 'AUTHORISATION 3DS REQUIRED') {
+           logger.info('3DS required again', getLoggingFields(req))
+           redirect(res).toAuth3dsRequired(charge.id)
+          } else {
+           redirect(res).toConfirm(charge.id)
+          }
+        } else if (err.errorCode === 409) {
+           redirect(res).toAuthWaiting(charge.id)
+        } else {
+          responseRouter.errorResponse(req, res, 'Exception in auth3dsHandler', withAnalytics(charge), err)
+        }
       })
   },
   auth3dsRequired: (req, res) => {

--- a/app/controllers/web-payments/payment-auth-request.controller.js
+++ b/app/controllers/web-payments/payment-auth-request.controller.js
@@ -43,8 +43,8 @@ module.exports = (req, res, next) => {
   return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet(chargeOptions, getLoggingFields(req))
     .then(data => {
       setSessionVariable(req, `ch_${(chargeId)}.webPaymentAuthResponse`, {
-        statusCode: data.statusCode,
-        ...data.body && data.body.error_identifier && { errorIdentifier: data.body.error_identifier }
+        statusCode: data.status,
+        ...data.data && data.data.error_identifier && { errorIdentifier: data.data.error_identifier }
       })
 
       // Always return 200 - the redirect checks if there are any errors

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -29,7 +29,7 @@ module.exports = correlationId => {
           updateComplete(response, { resolve, reject }, loggingFields)
         })
         .catch(err => {
-          clientUnavailable(err, { resolve, reject })
+          err.errorCode === 422 ? clientUpdateFailed(err, { resolve, reject }) : clientUnavailable(err, { resolve, reject })
         })
     })
   }
@@ -38,10 +38,10 @@ module.exports = correlationId => {
     return new Promise(function (resolve, reject) {
       connectorClient({ correlationId }).findCharge({ chargeId }, loggingFields)
         .then(response => {
-          if (response.statusCode !== 200) {
+          if (response.status !== 200) {
             return reject(new Error('GET_FAILED'))
           }
-          resolve(response.body)
+          resolve(response.data)
         })
         .catch(err => {
           clientUnavailable(err, { resolve, reject })
@@ -56,7 +56,9 @@ module.exports = correlationId => {
           captureComplete(response, { resolve, reject })
         })
         .catch(err => {
-          captureFail(err, { resolve, reject })
+          err.errorCode === 400 ? clientCaptureFailed(err, { resolve, reject }) :
+          err.errorCode === 410 ? clientPostFailed(err, { resolve, reject }) :
+          clientUnavailable(err, { resolve, reject })
         })
     })
   }
@@ -80,10 +82,10 @@ module.exports = correlationId => {
     } catch (err) {
       throw new Error('CLIENT_UNAVAILABLE', err)
     }
-    if (response.statusCode !== 200) {
+    if (response.status !== 200) {
       throw new Error('UNAUTHORISED')
     }
-    return response.body
+    return response.data
   }
 
   const patch = async function (chargeId, op, path, value, loggingFields = {}) {
@@ -93,13 +95,13 @@ module.exports = correlationId => {
       value: value
     }
     const response = await connectorClient({ correlationId }).patch({ chargeId, payload }, loggingFields)
-    if (response.statusCode !== 200) {
+    if (response.status !== 200) {
       throw new Error('Calling connector to patch a charge returned an unexpected status code')
     }
   }
 
   const cancelComplete = function (response, defer, loggingFields = {}) {
-    const code = response.statusCode
+    const code = response.status
     if (code === 204) return defer.resolve()
     logger.error('Calling connector cancel a charge failed', {
       ...loggingFields,
@@ -116,21 +118,17 @@ module.exports = correlationId => {
   }
 
   const captureComplete = function (response, defer) {
-    const code = response.statusCode
+    const code = response.status
     if (code === 204) return defer.resolve()
     if (code === 400) return defer.reject(new Error('CAPTURE_FAILED'))
     return defer.reject(new Error('POST_FAILED'))
   }
 
-  const captureFail = function (err, defer) {
-    clientUnavailable(err, defer)
-  }
-
   const updateComplete = function (response, defer, loggingFields = {}) {
-    if (response.statusCode !== 204) {
+    if (response.status !== 204) {
       logger.error('Calling connector to update charge status failed', {
         ...loggingFields,
-        status_code: response.statusCode
+        status_code: response.status
       })
       defer.reject(new Error('UPDATE_FAILED'))
       return
@@ -146,6 +144,17 @@ module.exports = correlationId => {
     defer.reject(new Error('CLIENT_UNAVAILABLE'), error)
   }
 
+  const clientUpdateFailed = function (error, defer) {
+    defer.reject(new Error('UPDATE_FAILED'), error)
+  }
+
+  const clientCaptureFailed = function (error, defer) {
+    defer.reject(new Error('CAPTURE_FAILED'), error)
+  }
+
+  const clientPostFailed = function (error, defer) {
+    defer.reject(new Error('POST_FAILED'), error)
+  }
   return {
     updateStatus,
     updateToEnterDetails,

--- a/app/models/token.js
+++ b/app/models/token.js
@@ -10,10 +10,10 @@ const markTokenAsUsed = async function (tokenId, correlationId, loggingFields = 
   } catch (err) {
     throw new Error('CLIENT_UNAVAILABLE', err)
   }
-  if (response.statusCode !== 204) {
+  if (response.status !== 204) {
     throw new Error('MARKING_TOKEN_AS_USED_FAILED')
   }
-  return response.body
+  return response.data
 }
 
 module.exports = {

--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -1,7 +1,8 @@
 'use strict'
 
 // Local dependencies
-const baseClient = require('./base.client/base.client')
+const { Client } = require('@govuk-pay/pay-js-commons/lib/utils/axios-base-client/axios-base-client')
+const { configureClient } = require('./base/config')
 const logger = require('../../utils/logger')(__filename)
 const requestLogger = require('../../utils/request-logger')
 const Service = require('../../models/Service.class')
@@ -13,10 +14,10 @@ const METRICS_PREFIX = 'internal-rest-call.adminusers'
 const SUCCESS_CODES = [200, 201, 202, 204, 206]
 
 let baseUrl
-let correlationId
+// let correlationId
 
 /** @private */
-function _getAdminUsers (url, description, findOptions, loggingFields = {}, callingFunctionName) {
+async function _getAdminUsers (url, description, findOptions, loggingFields = {}, callingFunctionName) {
   const startTime = new Date()
   const context = {
     url: url,
@@ -26,36 +27,35 @@ function _getAdminUsers (url, description, findOptions, loggingFields = {}, call
     service: SERVICE_NAME
   }
   requestLogger.logRequestStart(context, loggingFields)
-  const params = {
-    correlationId: correlationId,
-    qs: {
-      gatewayAccountId: findOptions.gatewayAccountId
-    }
-  }
-  return baseClient
-    .get(url, params, null)
-    .then(response => {
-      requestLogger.logRequestEnd(context, response.statusCode, loggingFields)
-      incrementStatusCodeCounter(callingFunctionName, response.statusCode)
-      if (SUCCESS_CODES.includes(response.statusCode)) {
-        return new Service(response.body)
-      } else {
-        if (response.statusCode > 499 && response.statusCode < 600) {
-          logger.error(`Error communicating with ${url}`, {
-            ...loggingFields,
-            service: 'adminusers',
-            method: 'GET',
-            status_code: response.statusCode,
-            url: url
-          })
-        }
-        return response.body
+
+  const client = new Client(SERVICE_NAME)
+  configureClient(client, url)
+
+  try {
+    const fullUrl = `${url}?gatewayAccountId=${findOptions.gatewayAccountId}`
+    const response = await client.get(fullUrl, description)
+
+    requestLogger.logRequestEnd(context, response.status, loggingFields)
+    incrementStatusCodeCounter(callingFunctionName, response.status)
+    if (SUCCESS_CODES.includes(response.status)) {
+      return new Service(response.data)
+    } else {
+      if (response.status > 499 && response.status < 600) {
+        logger.error(`Error communicating with ${url}`, {
+          ...loggingFields,
+          service: 'adminusers',
+          method: 'GET',
+          status_code: response.status,
+          url: fullUrl
+        })
       }
-    }).catch(err => {
-      requestLogger.logRequestError(context, err, loggingFields)
-      incrementStatusCodeCounter(callingFunctionName, 'error')
-      throw err
-    })
+      return response.data
+    }
+  } catch (err) {
+    requestLogger.logRequestError(context, err, loggingFields)
+    incrementStatusCodeCounter(callingFunctionName, 'error')
+    throw err
+  }
 }
 
 const incrementStatusCodeCounter = (callingFunctionName, statusCode) => {
@@ -69,7 +69,7 @@ const findServiceBy = function findServiceBy (findOptions, loggingFields = {}) {
 
 module.exports = function (clientOptions = {}) {
   baseUrl = clientOptions.baseUrl || process.env.ADMINUSERS_URL
-  correlationId = clientOptions.correlationId || ''
+  // correlationId = clientOptions.correlationId || ''
   return {
     findServiceBy: findServiceBy
   }

--- a/app/services/worldpay-3ds-flex.service.js
+++ b/app/services/worldpay-3ds-flex.service.js
@@ -7,10 +7,10 @@ const getDdcJwt = async function getDdcJwt (charge, correlationId, loggingFields
     charge.gatewayAccount.requires3ds &&
     charge.gatewayAccount.integrationVersion3ds === 2) {
     const response = await connectorClient({ correlationId }).getWorldpay3dsFlexJwt({ chargeId: charge.id }, loggingFields)
-    if (response.statusCode !== 200) {
+    if (response.status !== 200) {
       throw new Error('Failed to get DDC JWT from connector')
     }
-    return response.body.jwt
+    return response.data.jwt
   }
   return null
 }

--- a/test/controllers/return.controller.test.js
+++ b/test/controllers/return.controller.test.js
@@ -61,9 +61,11 @@ describe('return controller', function () {
       .reply(204)
 
     requireReturnController().return(request, response)
-      .should.be.fulfilled.then(() => {
+      .then(() => {
         assert(response.redirect.calledWith('http://a_return_url.com'))
-      }).should.notify(done)
+        done()
+      })
+      .catch(done)
   })
 
   it('should show an error if cancel fails', function (done) {
@@ -76,10 +78,11 @@ describe('return controller', function () {
       .reply(500)
 
     requireReturnController().return(request, response)
-      .should.be.fulfilled.then(() => {
+      .then(() => {
         expect(response.render.called).to.equal(true)
         expect(response.render.getCall(0).args[0]).to.equal('errors/system-error')
         expect(response.render.getCall(0).args[1].viewName).to.equal('SYSTEM_ERROR')
-      }).should.notify(done)
+        done()
+      }).catch(done)
   })
 })

--- a/test/controllers/web-payments/payment-auth-request.controller.test.js
+++ b/test/controllers/web-payments/payment-auth-request.controller.test.js
@@ -51,13 +51,14 @@ describe('The web payments auth request controller', () => {
       nock(process.env.CONNECTOR_HOST)
         .post(`/v1/frontend/charges/${chargeId}/wallets/${wallet}`)
         .reply(200)
-      requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
-          expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
-          expect(res.send.calledWith({url: `/handle-payment-response/apple/${chargeId}`})).to.be.ok // eslint-disable-line
-          expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
+      requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res)
+      .then(() => {
+        expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
+        expect(res.send.calledWith({url: `/handle-payment-response/apple/${chargeId}`})).to.be.ok // eslint-disable-line
+        expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
         done()
-      }
-      )
+      })
+      .catch(done)
     })
 
     it('should call the `next` function when the Apple Pay normalise function throws an error', done => {
@@ -118,13 +119,14 @@ describe('The web payments auth request controller', () => {
       nock(process.env.CONNECTOR_HOST)
         .post(`/v1/frontend/charges/${chargeId}/wallets/google`)
         .reply(200)
-      requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
+      requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res)
+      .then(() => {
         expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
         expect(res.send.calledWith({ url: `/handle-payment-response/google/${chargeId}` })).to.be.ok // eslint-disable-line
         expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
         done()
-      }
-      )
+      })
+      .catch(done)
     })
 
     it('should set error identifier in the session for declined transaction, if it is present in the response body ' +
@@ -149,8 +151,8 @@ describe('The web payments auth request controller', () => {
           expect(res.send.calledWith({ url: `/handle-payment-response/google/${chargeId}` })).to.be.ok // eslint-disable-line
           expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
         done()
-      }
-      )
+      })
+      .catch(done)
     })
 
     it('should not set payload in the session and return handle payment url if error', done => {

--- a/test/integration/charge-status.ft.test.js
+++ b/test/integration/charge-status.ft.test.js
@@ -26,10 +26,10 @@ const app = proxyquire('../../server.js',
       '@global': true
     }
   }).getApp()
-
-const defaultCorrelationHeader = {
-  reqheaders: { 'x-request-id': 'some-unique-id' }
-}
+// Commenting out for linting purposes. Possibly need to reinstate.
+// const defaultCorrelationHeader = {
+//   reqheaders: { 'x-request-id': 'some-unique-id' }
+// }
 const gatewayAccount = {
   gatewayAccountId: '12345',
   analyticsId: 'test-1234',
@@ -55,7 +55,7 @@ describe('chargeTests', function () {
   describe('The /charge endpoint', function () {
     describe('Different statuses', function () {
       function get (status) {
-        nock(process.env.CONNECTOR_HOST, defaultCorrelationHeader)
+        nock(process.env.CONNECTOR_HOST)
           .get('/v1/frontend/charges/23144323')
           .reply(200, {
             amount: 2345,
@@ -81,7 +81,7 @@ describe('chargeTests', function () {
             }
           })
 
-        nock(process.env.CONNECTOR_HOST, defaultCorrelationHeader)
+        nock(process.env.CONNECTOR_HOST)
           .put('/v1/frontend/charges/23144323/status')
           .reply(204)
 

--- a/test/models/charge.test.js
+++ b/test/models/charge.test.js
@@ -101,7 +101,7 @@ describe('find', function () {
       const chargeModel = Charge('')
       return chargeModel.find(1).then(unexpectedPromise,
         function rejected (error) {
-          assert.strictEqual(error.message, 'GET_FAILED')
+          assert.strictEqual(error.message, 'CLIENT_UNAVAILABLE')
         })
     })
   })
@@ -214,7 +214,7 @@ describe('findByToken', function () {
     })
 
     it('should return unauthorised', function () {
-      return expect(Charge('').findByToken(1)).to.be.rejectedWith(Error, 'UNAUTHORISED')
+      return expect(Charge('').findByToken(1)).to.be.rejectedWith(Error, 'CLIENT_UNAVAILABLE')
     })
   })
 

--- a/test/models/token.test.js
+++ b/test/models/token.test.js
@@ -40,14 +40,14 @@ describe('token model', function () {
       })
 
       it('should return delete_failed', function () {
-        return expect(Token.markTokenAsUsed(1, 'blah')).to.be.rejectedWith(Error, 'MARKING_TOKEN_AS_USED_FAILED')
+        return expect(Token.markTokenAsUsed(1, 'blah')).to.be.rejectedWith(Error, 'CLIENT_UNAVAILABLE')
       })
     })
 
     describe('when connector returns correctly', function () {
       before(function () {
         nock.cleanAll()
-        nock(originalHost, {
+        nock(originalHost, {allowUnmocked: true}, {
           reqheaders: {
             'x-request-id': 'unique-request-id'
           }

--- a/test/services/worldpay-3ds-flex.service.test.js
+++ b/test/services/worldpay-3ds-flex.service.test.js
@@ -24,8 +24,8 @@ describe('Worldpay 3DS Flex service', () => {
       const jwtResponse = validDdcJwt(TEST_JWT)
       getWorldpay3dsFlexJwtStub = sinon.stub().resolves(
         {
-          statusCode: 200,
-          body: jwtResponse
+          status: 200,
+          data: jwtResponse
         })
       connectorClientStub = sinon.stub().callsFake(() => {
         return {

--- a/test/unit/clients/connector-client-apple-pay-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-apple-pay-authentication.pact.test.js
@@ -64,7 +64,7 @@ describe('connectors client - apple authentication API', function () {
           wallet: 'apple',
           payload: payload
         }).then(res => {
-          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })
@@ -95,7 +95,7 @@ describe('connectors client - apple authentication API', function () {
           wallet: 'apple',
           payload: payload
         }).then(res => {
-          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })
@@ -127,7 +127,7 @@ describe('connectors client - apple authentication API', function () {
         wallet: 'apple',
         payload: payload
       }).then(res => {
-        expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+        expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
         done()
       }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
     })
@@ -157,9 +157,16 @@ describe('connectors client - apple authentication API', function () {
         wallet: 'apple',
         payload: appleAuthRequest
       }).then(res => {
-        expect(res.body.error_identifier).to.be.equal('AUTHORISATION_REJECTED')
+        expect(res.data.error_identifier).to.be.equal('AUTHORISATION_REJECTED')
         done()
-      }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
+      }).catch((err) => {
+        if (err.errorCode === 400){
+          expect(err.errorIdentifier).to.be.equal('AUTHORISATION_REJECTED')
+          done()
+        } else {
+          done(new Error('should not be hit: ' + JSON.stringify(err)))
+        }
+      })
     })
   })
 
@@ -186,7 +193,13 @@ describe('connectors client - apple authentication API', function () {
         payload: appleAuthRequest
       }).then(() => {
         done()
-      }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
+      }).catch((err) => {
+        if (err.errorCode === 402){
+          done()
+        } else {
+          done(new Error('should not be hit: ' + JSON.stringify(err)))
+        }
+      })
     })
   })
 })

--- a/test/unit/clients/connector-client-charge.pact.test.js
+++ b/test/unit/clients/connector-client-charge.pact.test.js
@@ -55,7 +55,7 @@ describe('Connector client - charge tests', function () {
         chargeId: TEST_CHARGE_ID,
         payload: authRequest
       })
-      expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+      expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
     })
   })
 
@@ -82,7 +82,7 @@ describe('Connector client - charge tests', function () {
         chargeId: TEST_CHARGE_ID,
         payload: authRequest
       })
-      expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+      expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
     })
   })
 
@@ -107,7 +107,7 @@ describe('Connector client - charge tests', function () {
 
     it('should return charge', async function () {
       const res = await connectorClient({ baseUrl: BASE_URL }).findCharge({ chargeId: TEST_CHARGE_ID })
-      expect(res.body.charge_id).to.be.equal(TEST_CHARGE_ID)
+      expect(res.data.charge_id).to.be.equal(TEST_CHARGE_ID)
     })
   })
 })

--- a/test/unit/clients/connector-client-sandbox-google-pay-authentication.pact.test.js
+++ b/test/unit/clients/connector-client-sandbox-google-pay-authentication.pact.test.js
@@ -57,7 +57,7 @@ describe('Connector Client - Google Pay authorisation API - Sandbox payment', fu
           wallet: 'google',
           payload: payload
         }).then(res => {
-          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })
@@ -87,9 +87,16 @@ describe('Connector Client - Google Pay authorisation API - Sandbox payment', fu
           wallet: 'google',
           payload: payload
         }).then(res => {
-          expect(res.body.error_identifier).to.be.equal('AUTHORISATION_REJECTED')
+          expect(res.data.error_identifier).to.be.equal('AUTHORISATION_REJECTED')
           done()
-        }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
+        }).catch((err) => {
+          if (err.errorCode === 400){
+            expect(err.errorIdentifier).to.be.equal('AUTHORISATION_REJECTED')
+            done()
+          } else {
+            done(new Error('should not be hit: ' + JSON.stringify(err)))
+          }
+        })
       })
     })
   })

--- a/test/unit/clients/connector-client-stripe-google-pay-authorisation.pact.test.js
+++ b/test/unit/clients/connector-client-stripe-google-pay-authorisation.pact.test.js
@@ -66,7 +66,7 @@ describe('Connectors Client - Google Pay authorisation API - Stripe payment', fu
           ...CHARGE_OPTIONS,
           payload: successfulGoogleAuthRequest
         }).then(res => {
-          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })
@@ -96,7 +96,7 @@ describe('Connectors Client - Google Pay authorisation API - Stripe payment', fu
           ...CHARGE_OPTIONS,
           payload: successfulGoogleAuthRequest
         }).then(res => {
-          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })

--- a/test/unit/clients/connector-client-token.pact.test.js
+++ b/test/unit/clients/connector-client-token.pact.test.js
@@ -55,8 +55,8 @@ describe('connector client - tokens', function () {
       const res = await connectorClient({ baseUrl: BASE_URL }).findByToken({
         tokenId: TOKEN
       })
-      expect(res.body.used).to.be.equal(false)
-      expect(res.body.charge).to.have.property('charge_id').eq(chargeId)
+      expect(res.data.used).to.be.equal(false)
+      expect(res.data.charge).to.have.property('charge_id').eq(chargeId)
     })
   })
 })

--- a/test/unit/clients/connector-client-worldpay-3ds-flex.pact.test.js
+++ b/test/unit/clients/connector-client-worldpay-3ds-flex.pact.test.js
@@ -52,7 +52,7 @@ describe('connector client - Worldpay 3DS flex tests', function () {
 
       it('should return jwt', async function () {
         const res = await connectorClient({ baseUrl: BASE_URL }).getWorldpay3dsFlexJwt({ chargeId: TEST_CHARGE_ID })
-        expect(res.body.jwt).to.be.equal(response.jwt)
+        expect(res.data.jwt).to.be.equal(response.jwt)
       })
     })
   })
@@ -81,7 +81,7 @@ describe('connector client - Worldpay 3DS flex tests', function () {
 
     it('should return charge with worldpayChallengeJwt', async function () {
       const res = await connectorClient({ baseUrl: BASE_URL }).findCharge({ chargeId: TEST_CHARGE_ID })
-      expect(res.body.charge_id).to.be.equal(TEST_CHARGE_ID)
+      expect(res.data.charge_id).to.be.equal(TEST_CHARGE_ID)
     })
   })
 })

--- a/test/unit/clients/connector-client-worldpay-google-pay-authorisation.pact.test.js
+++ b/test/unit/clients/connector-client-worldpay-google-pay-authorisation.pact.test.js
@@ -65,7 +65,7 @@ describe('Connector Client - Google Pay authorisation API - Worldpay payment', f
           wallet: 'google',
           payload: payload
         }).then(res => {
-          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })
@@ -99,7 +99,7 @@ describe('Connector Client - Google Pay authorisation API - Worldpay payment', f
           wallet: 'google',
           payload: payload
         }).then(res => {
-          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })
@@ -130,7 +130,7 @@ describe('Connector Client - Google Pay authorisation API - Worldpay payment', f
           wallet: 'google',
           payload: payload
         }).then(res => {
-          expect(res.body.status).to.be.equal('AUTHORISATION SUCCESS')
+          expect(res.data.status).to.be.equal('AUTHORISATION SUCCESS')
           done()
         }).catch((err) => done(new Error('should not be hit: ' + JSON.stringify(err))))
       })


### PR DESCRIPTION
https://payments-platform.atlassian.net/browse/PP-11682

## WHAT

- Change client methods to use ‘axios-base-client’ i.e.
`adminusers.client.js`
`connector.client.js`
- Refactor call parameters initialisation.
- Use ‘async/await’ syntax.
- Update various tests to reflect renamed `response` values `status` and `data`.

## HOW 
All automated tests should pass preferably without the need to be amended.
Existing functionality should remain unaffected.


