### PR TITLE
Changes for pay-frontend to use axios via pay-js-commons

### DIFF
--- a/app/models/token-axios.js
+++ b/app/models/token-axios.js
@@ -1,0 +1,22 @@
+'use strict'
+
+// Local dependencies
+const connectorClient = require('../services/clients/connector-axios.client')
+
+const markTokenAsUsed = async function (tokenId, loggingFields = {}) {
+  let response
+  try {
+    response = await connectorClient().markTokenAsUsed({ tokenId }, loggingFields)
+  } catch (err) {
+    throw new Error('CLIENT_UNAVAILABLE', err)
+  }
+
+  if (response.status !== 204) {
+    throw new Error('MARKING_TOKEN_AS_USED_FAILED')
+  }
+  return response.data
+}
+
+module.exports = {
+  markTokenAsUsed: markTokenAsUsed
+}

--- a/app/models/token-axios.js
+++ b/app/models/token-axios.js
@@ -3,10 +3,15 @@
 // Local dependencies
 const connectorClient = require('../services/clients/connector-axios.client')
 
+const SUCCESS_CODES = [200, 201, 202, 204, 206]
+
 const markTokenAsUsed = async function (tokenId, loggingFields = {}) {
   let response
   try {
     response = await connectorClient().markTokenAsUsed({ tokenId }, loggingFields)
+    if (!SUCCESS_CODES.includes(response.status)) {
+      throw new Error('CLIENT_UNAVAILABLE')
+    }
   } catch (err) {
     throw new Error('CLIENT_UNAVAILABLE', err)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-crypto/decrypt-node": "^1.0.3",
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-        "@govuk-pay/pay-js-commons": "^5.0.2",
+        "@govuk-pay/pay-js-commons": "file:../pay-js-commons",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "7.74.0",
         "cert-info": "^1.5.1",
@@ -85,6 +85,52 @@
         "stylelint": "^15.10.3",
         "stylelint-config-gds": "^1.0.0",
         "supertest": "^6.3.3"
+      },
+      "engines": {
+        "node": "^18.17.1"
+      }
+    },
+    "../pay-js-commons": {
+      "version": "5.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.5",
+        "lodash": "4.17.21",
+        "moment-timezone": "0.5.43",
+        "rfc822-validate": "1.0.0",
+        "slugify": "1.6.6",
+        "winston": "3.9.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "babelify": "^10.0.0",
+        "brfs": "^2.0.2",
+        "browser-env": "^3.2.6",
+        "browserify": "^17.0.0",
+        "chai": "^4.2.0",
+        "eslint-plugin-import": "^2.18.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "jest": "^29.4.3",
+        "jest-environment-jsdom": "^29.4.3",
+        "js-cookie": "^3.0.0",
+        "jsdom": "^20.0.3",
+        "jsdom-global": "^3.0.2",
+        "karma": "^6.0.0",
+        "karma-browserify": "^8.0.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-mocha": "^2.0.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-source-map-support": "^1.2.0",
+        "lint-staged": "^13.0.1",
+        "mocha": "^10.0.0",
+        "nock": "^13.5.1",
+        "sinon": "^15.0.0",
+        "standard": "^17.0.0",
+        "uglify-js": "^3.6.0",
+        "watchify": "^4.0.0",
+        "xo": "^0.54.0"
       },
       "engines": {
         "node": "^18.17.1"
@@ -2125,41 +2171,8 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-5.0.2.tgz",
-      "integrity": "sha512-dCkLfQ5gdhXR4KA+jTGCvZ+oNVDeFiWcrmcWCRlejfItHYZ9P+tT2DGP4l56jVV6S5yKZK/y7zDqCu8/nlKDAg==",
-      "dependencies": {
-        "axios": "^1.6.5",
-        "lodash": "4.17.21",
-        "moment-timezone": "0.5.43",
-        "rfc822-validate": "1.0.0",
-        "slugify": "1.6.6",
-        "winston": "3.9.0"
-      },
-      "engines": {
-        "node": "^18.17.1"
-      }
-    },
-    "node_modules/@govuk-pay/pay-js-commons/node_modules/winston": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.9.0.tgz",
-      "integrity": "sha512-jW51iW/X95BCW6MMtZWr2jKQBP4hV5bIDq9QrIjfDk6Q9QuxvTKEAlpUNAzP+HYHFFCeENhph16s0zEunu4uuQ==",
-      "dependencies": {
-        "@colors/colors": "1.5.0",
-        "@dabh/diagnostics": "^2.0.2",
-        "async": "^3.2.3",
-        "is-stream": "^2.0.0",
-        "logform": "^2.4.0",
-        "one-time": "^1.0.0",
-        "readable-stream": "^3.4.0",
-        "safe-stable-stringify": "^2.3.1",
-        "stack-trace": "0.0.x",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
+      "resolved": "../pay-js-commons",
+      "link": true
     },
     "node_modules/@govuk-pay/pay-js-metrics": {
       "version": "1.0.6",
@@ -2842,14 +2855,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/amdefine": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.0.4.tgz",
-      "integrity": "sha512-+9uNlaqm8kZ0bYDuhFt1mqNoLM2I4AsSeB+6dddNiSfmRlJRq38IUuNtUD4+xOzOoPltOHzSvnlSgscMfpnDDg==",
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -3268,6 +3273,7 @@
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
       "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -3278,6 +3284,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7306,6 +7313,7 @@
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -11416,25 +11424,6 @@
       "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
       "dev": true
     },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.43",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
-      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/moo": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
@@ -13312,7 +13301,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/proxyquire": {
       "version": "2.1.3",
@@ -14147,14 +14137,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfc822-validate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rfc822-validate/-/rfc822-validate-1.0.0.tgz",
-      "integrity": "sha512-FWFY2H1jgdALCel/BfTeTbUrf3AEStTmPD0bOvDIqg1RPGGOizoRLFuQmG9jGDCvOc7do4DBx1wnOlSot+jrsg==",
-      "dependencies": {
-        "amdefine": "0.0.4"
-      }
-    },
     "node_modules/rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
@@ -14681,14 +14663,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/slugify": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/smtp-server": {
@@ -18544,36 +18518,43 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-5.0.2.tgz",
-      "integrity": "sha512-dCkLfQ5gdhXR4KA+jTGCvZ+oNVDeFiWcrmcWCRlejfItHYZ9P+tT2DGP4l56jVV6S5yKZK/y7zDqCu8/nlKDAg==",
+      "version": "file:../pay-js-commons",
       "requires": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
         "axios": "^1.6.5",
+        "babelify": "^10.0.0",
+        "brfs": "^2.0.2",
+        "browser-env": "^3.2.6",
+        "browserify": "^17.0.0",
+        "chai": "^4.2.0",
+        "eslint-plugin-import": "^2.18.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "jest": "^29.4.3",
+        "jest-environment-jsdom": "^29.4.3",
+        "js-cookie": "^3.0.0",
+        "jsdom": "^20.0.3",
+        "jsdom-global": "^3.0.2",
+        "karma": "^6.0.0",
+        "karma-browserify": "^8.0.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-mocha": "^2.0.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-source-map-support": "^1.2.0",
+        "lint-staged": "^13.0.1",
         "lodash": "4.17.21",
+        "mocha": "^10.0.0",
         "moment-timezone": "0.5.43",
+        "nock": "^13.5.1",
         "rfc822-validate": "1.0.0",
+        "sinon": "^15.0.0",
         "slugify": "1.6.6",
-        "winston": "3.9.0"
-      },
-      "dependencies": {
-        "winston": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/winston/-/winston-3.9.0.tgz",
-          "integrity": "sha512-jW51iW/X95BCW6MMtZWr2jKQBP4hV5bIDq9QrIjfDk6Q9QuxvTKEAlpUNAzP+HYHFFCeENhph16s0zEunu4uuQ==",
-          "requires": {
-            "@colors/colors": "1.5.0",
-            "@dabh/diagnostics": "^2.0.2",
-            "async": "^3.2.3",
-            "is-stream": "^2.0.0",
-            "logform": "^2.4.0",
-            "one-time": "^1.0.0",
-            "readable-stream": "^3.4.0",
-            "safe-stable-stringify": "^2.3.1",
-            "stack-trace": "0.0.x",
-            "triple-beam": "^1.3.0",
-            "winston-transport": "^4.5.0"
-          }
-        }
+        "standard": "^17.0.0",
+        "uglify-js": "^3.6.0",
+        "watchify": "^4.0.0",
+        "winston": "3.9.0",
+        "xo": "^0.54.0"
       }
     },
     "@govuk-pay/pay-js-metrics": {
@@ -19136,11 +19117,6 @@
         "uri-js": "^4.2.2"
       }
     },
-    "amdefine": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.0.4.tgz",
-      "integrity": "sha512-+9uNlaqm8kZ0bYDuhFt1mqNoLM2I4AsSeB+6dddNiSfmRlJRq38IUuNtUD4+xOzOoPltOHzSvnlSgscMfpnDDg=="
-    },
     "ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -19464,6 +19440,7 @@
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
       "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -19474,6 +19451,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
           "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -22676,7 +22654,8 @@
     "follow-redirects": {
       "version": "1.15.6",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true
     },
     "for-each": {
       "version": "0.3.3",
@@ -25815,19 +25794,6 @@
       "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
       "dev": true
     },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
-    },
-    "moment-timezone": {
-      "version": "0.5.43",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
-      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
-      "requires": {
-        "moment": "^2.29.4"
-      }
-    },
     "moo": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
@@ -27259,7 +27225,8 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "proxyquire": {
       "version": "2.1.3",
@@ -27908,14 +27875,6 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
-    "rfc822-validate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rfc822-validate/-/rfc822-validate-1.0.0.tgz",
-      "integrity": "sha512-FWFY2H1jgdALCel/BfTeTbUrf3AEStTmPD0bOvDIqg1RPGGOizoRLFuQmG9jGDCvOc7do4DBx1wnOlSot+jrsg==",
-      "requires": {
-        "amdefine": "0.0.4"
-      }
-    },
     "rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
@@ -28336,11 +28295,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
-    },
-    "slugify": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw=="
     },
     "smtp-server": {
       "version": "3.13.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "^5.0.2",
+    "@govuk-pay/pay-js-commons": "file:../pay-js-commons",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "7.74.0",
     "cert-info": "^1.5.1",

--- a/test/models/card.test.js
+++ b/test/models/card.test.js
@@ -43,6 +43,9 @@ describe('card', function () {
     describe('when an unexpected response code', function () {
       before(function () {
         nock.cleanAll()
+        nock(process.env.CARDID_HOST)
+        .post('/v1/api/card')
+        .reply(406)
 
         nock(process.env.CARDID_HOST, aCorrelationHeader)
           .post('/v1/api/card')

--- a/test/models/token-axios.test.js
+++ b/test/models/token-axios.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+// NPM dependencies
+const nock = require('nock')
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+// Local dependencies
+const Token = require('../../app/models/token-axios.js')
+const wrongPromise = require('../test-helpers/test-helpers.js').unexpectedPromise
+
+// Constants
+const originalHost = process.env.CONNECTOR_HOST
+
+// Configure
+require('../test-helpers/html-assertions.js')
+
+describe('token model', function () {
+  describe('mark token as used', function () {
+    describe('when connector is unavailable', function () {
+      before(function () {
+        nock.cleanAll()
+      })
+      it('should return client unavailable', function () {
+        return expect(Token.markTokenAsUsed(1)).to.be.rejectedWith(Error, 'CLIENT_UNAVAILABLE')
+      })
+    })
+
+    describe('when connector returns incorrect response code', function () {
+      before(function () {
+        nock.cleanAll()
+        nock(originalHost).post('/v1/frontend/tokens/1/used')
+          .reply(404, '{}')
+      })
+
+      it('should return delete_failed', function () {
+        return expect(Token.markTokenAsUsed(1)).to.be.rejectedWith(Error, 'CLIENT_UNAVAILABLE')
+      })
+    })
+
+    describe('when connector returns correctly', function () {
+      before(function () {
+        nock.cleanAll()
+        nock(originalHost).post('/v1/frontend/tokens/1/used')
+          .reply(204)
+      })
+
+      it('should return delete_failed', function () {
+        return Token.markTokenAsUsed(1).then(function (data) {
+        }, wrongPromise)
+      })
+    })
+  })
+})


### PR DESCRIPTION
With this PR, we are proposing two changes to pay-frontend in order to use
the new axios client via pay-js-commons.

The changes are only in the final two commits listed below, just after the 
[temporary commit ](https://github.com/alphagov/pay-frontend/pull/3841/commits/bd3a06b8b4e253ac77a451f94284d5a87bfa0b6b) to use the local (WIP) version of pay-js-commons. 

[The first commit](https://github.com/alphagov/pay-frontend/commit/51c9b20f3bb19e82365d513b8536cce1c8ce0184) checks explicitly for success status codes returned by the 
client and throws CLIENT_UNAVAILABLE for all other codes.

[The second commit ](https://github.com/alphagov/pay-frontend/commit/665a7b559b160fee295f2b3363678c2db031ab06)ensures that the test is setup correctly
by replying with a status code that is not included in the options handled by the client, so that we can verify
that the operation is managed correctly by resolving the promise.

This is all to be discussed with @iqbalgds. 



