### PR TITLE
PP-11682 - Update pay-js-commons and admins users and card client

### DIFF
--- a/app/services/clients/adminusers.client.js
+++ b/app/services/clients/adminusers.client.js
@@ -48,7 +48,7 @@ async function _getAdminUsers (url, description, findOptions, loggingFields = {}
           url: fullUrl
         })
       }
-      return response.data
+      return response
     }
   } catch (err) {
     requestLogger.logRequestError(context, err, loggingFields)

--- a/app/services/clients/base/config.js
+++ b/app/services/clients/base/config.js
@@ -31,7 +31,8 @@ function configureClient (client, baseUrl) {
     transformRequestAddHeaders,
     onRequestStart,
     onSuccessResponse,
-    onFailureResponse
+    onFailureResponse,
+    acceptAllStatusCodes: true
   })
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-crypto/decrypt-node": "^1.0.3",
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-        "@govuk-pay/pay-js-commons": "^5.0.3",
+        "@govuk-pay/pay-js-commons": "^6.0.2",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "7.74.0",
         "cert-info": "^1.5.1",
@@ -2125,9 +2125,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-5.0.3.tgz",
-      "integrity": "sha512-+gWpd0GsAC2BJU37u90EOXIvLlfehFYur/4FiAPbh5FGdAi3CsGbzANbV6iGKpeFfzJ3I8+ekaW9xM6bVShSvA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.3.tgz",
+      "integrity": "sha512-Hf6g6jkV5GcNyOCnmmBwEPgpAlHUEkcEJeILWkB4iWC7y/eONgRDSkIGyW/ClOYRiCbVfgJnEb3QRZIAwIoGwQ==",
       "dependencies": {
         "axios": "^1.6.5",
         "lodash": "4.17.21",
@@ -18544,9 +18544,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-5.0.3.tgz",
-      "integrity": "sha512-+gWpd0GsAC2BJU37u90EOXIvLlfehFYur/4FiAPbh5FGdAi3CsGbzANbV6iGKpeFfzJ3I8+ekaW9xM6bVShSvA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.3.tgz",
+      "integrity": "sha512-Hf6g6jkV5GcNyOCnmmBwEPgpAlHUEkcEJeILWkB4iWC7y/eONgRDSkIGyW/ClOYRiCbVfgJnEb3QRZIAwIoGwQ==",
       "requires": {
         "axios": "^1.6.5",
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "^5.0.3",
+    "@govuk-pay/pay-js-commons": "^6.0.2",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "7.74.0",
     "cert-info": "^1.5.1",

--- a/test/unit/clients/adminusers-client-find-service.pact.test.js
+++ b/test/unit/clients/adminusers-client-find-service.pact.test.js
@@ -80,12 +80,12 @@ describe('adminusers client - services API', function () {
 
       it('error 400', async function () {
         try {
-          await adminUsersClient({ baseUrl: BASE_URL }).findServiceBy(
+          const response = await adminUsersClient({ baseUrl: BASE_URL }).findServiceBy(
             { gatewayAccountId: invalidGatewayAccountId }
           )
-          throw new Error('should not be hit')
+          expect(response.status).to.be.equal(400)
         } catch (error) {
-          expect(error.errorCode).to.be.equal(400)
+          throw new Error('should not be hit')
         }
       })
     })
@@ -107,12 +107,12 @@ describe('adminusers client - services API', function () {
 
       it('error 404', async function () {
         try {
-          await adminUsersClient({ baseUrl: BASE_URL }).findServiceBy(
+          const response = await adminUsersClient({ baseUrl: BASE_URL }).findServiceBy(
             { gatewayAccountId: nonAssociatedGatewayAccountId }
           )
-          throw new Error('should not be hit')
+          expect(response.status).to.be.equal(404)
         } catch (error) {
-          expect(error.errorCode).to.be.equal(404)
+          throw new Error('should not be hit')
         }
       })
     })


### PR DESCRIPTION
- Bump pay-js-commons to v6.0.3
- Update the `axios base client` config to set `acceptAllStatusCodes=true`
  - This will mean that all status codes returned from backend API calls will be considered successful.
  - The consuming code will then need to decide what to do with those responses.
- Update `admin users` and `card` base client to work with the new `acceptAllStatusCodes=true` setting.
- Update tests


