### PR TITLE
PP-11682 - Update axios connect tests

### DIFF
--- a/test/unit/clients/connector-axios-client-apple-pay-authentication.pact.test.js
+++ b/test/unit/clients/connector-axios-client-apple-pay-authentication.pact.test.js
@@ -165,17 +165,16 @@ describe('connectors client - apple authentication API', function () {
 
     it('should return authorisation declined with error identifier in response payload', async () => {
       try {
-        await connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
+        const response = await connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
           chargeId: TEST_CHARGE_ID,
           wallet: 'apple',
           payload: appleAuthRequest
         })
+
+        expect(response.status).to.be.equal(400)
+        expect(response.data.error_identifier).to.be.equal('AUTHORISATION_REJECTED')
       } catch (err) {
-        if (err.errorCode === 400) {
-          expect(err.errorIdentifier).to.be.equal('AUTHORISATION_REJECTED')
-        } else {
-          throw new Error('should not be hit: ' + JSON.stringify(err))
-        }
+        throw new Error('should not be hit: ' + JSON.stringify(err))
       }
     })
   })
@@ -198,13 +197,15 @@ describe('connectors client - apple authentication API', function () {
 
     it('should return authorisation declined', async () => {
       try {
-        await connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
+        const response = await connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
           chargeId: TEST_CHARGE_ID,
           wallet: 'apple',
           payload: appleAuthRequest
         })
+
+        expect(response.status).to.be.equal(402)
       } catch (err) {
-        expect(err.errorCode).to.be.equal(402)
+        throw new Error('should not be hit: ' + JSON.stringify(err))
       }
     })
   })

--- a/test/unit/clients/connector-axios-client-sandbox-google-pay-authentication.pact.test.js
+++ b/test/unit/clients/connector-axios-client-sandbox-google-pay-authentication.pact.test.js
@@ -87,17 +87,16 @@ describe('Connector Client - Google Pay authorisation API - Sandbox payment', fu
       it('should return authorisation declined with error identifier in response payloads', async () => {
         const payload = googlePayAuthRequest
         try {
-          await connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
+          const response = await connectorClient({ baseUrl: BASEURL }).chargeAuthWithWallet({
             chargeId: TEST_CHARGE_ID,
             wallet: 'google',
             payload: payload
           })
+
+          expect(response.status).to.be.equal(400)
+          expect(response.data.error_identifier).to.be.equal('AUTHORISATION_REJECTED')
         } catch (err) {
-          if (err.errorCode === 400) {
-            expect(err.errorIdentifier).to.be.equal('AUTHORISATION_REJECTED')
-          } else {
-            throw new Error('should not be hit: ' + JSON.stringify(err))
-          }
+          throw new Error('should not be hit: ' + JSON.stringify(err))
         }
       })
     })


### PR DESCRIPTION
- Update tests to work with the updated `axios-base-client` from pay-js-commons.
- All status codes are now considered successful.  The consuming code will now need to decide how to manage not 2xx responses.


