### PR TITLE
PP-12853 Update apple pay merchant validation to use Axios

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,16 +118,7 @@
         "filename": "app/controllers/web-payments/apple-pay/merchant-validation.controller.js",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 14
-      }
-    ],
-    "test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js": [
-      {
-        "type": "Private Key",
-        "filename": "test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 68
+        "line_number": 15
       }
     ],
     "test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js": [
@@ -389,5 +380,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-09T18:54:00Z"
+  "generated_at": "2024-07-09T14:54:04Z"
 }

--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -1,8 +1,9 @@
 'use strict'
 
-const request = require('requestretry')
 const logger = require('../../../utils/logger')(__filename)
 const { getLoggingFields } = require('../../../utils/logging-fields-helper')
+const axios = require('axios')
+const https = require('https')
 
 function getCertificateMultiline (cert) {
   return `-----BEGIN CERTIFICATE-----
@@ -38,7 +39,7 @@ function getApplePayMerchantIdentityVariables (paymentProvider) {
 // When an Apple payment is initiated in Safari, it must check that the request
 // is coming from a registered and authorised Apple Merchant Account. The
 // browser will produce a URL which we should dial with our certificates server side.
-module.exports = (req, res) => {
+module.exports = async (req, res) => {
   if (!req.body.url) {
     return res.sendStatus(400)
   }
@@ -48,30 +49,34 @@ module.exports = (req, res) => {
     return res.sendStatus(400)
   }
 
+  const httpsAgent = new https.Agent({
+    cert: merchantIdentityVars.cert,
+    key: merchantIdentityVars.key
+  })
+
   const options = {
     url: url,
-    cert: merchantIdentityVars.cert,
-    key: merchantIdentityVars.key,
     method: 'post',
-    body: {
+    headers: { 'Content-Type': 'application/json' },
+    data: {
       merchantIdentifier: merchantIdentityVars.merchantIdentifier,
       displayName: 'GOV.UK Pay',
       initiative: 'web',
       initiativeContext: process.env.APPLE_PAY_MERCHANT_DOMAIN
     },
-    json: true
+    httpsAgent
   }
 
-  request(options, (err, response, body) => {
-    if (err) {
-      logger.info('Error generating Apple Pay session', {
-        ...getLoggingFields(req),
-        error: err,
-        response: response,
-        body: body
-      })
-      return res.status(500).send(body)
-    }
-    res.status(200).send(body)
-  })
+  try {
+    const response = await axios(options)
+    res.status(200).send(response.data)
+  } catch (error) {
+    logger.info('Error generating Apple Pay session', {
+      ...getLoggingFields(req),
+      error: error,
+      response: error.response,
+      data: error.response ? error.response.data : null
+    })
+    res.status(500).send(error.response ? error.response.data : 'Apple Pay Error')
+  }
 }


### PR DESCRIPTION
With this change, we are removing the use of `requestretry` from the Merchant Validation Controller which currently uses this module.

We are replacing it by using Axios directly.

Note that the previous attempted did not pass our QA on the test environment[1].

Further information in Jira[2].

[1]
https://github.com/alphagov/pay-frontend/pull/3862

[2]
https://payments-platform.atlassian.net/browse/PP-12853
