### PR TITLE
PP-12546 hold payments in state after completion

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -372,7 +372,7 @@
         "filename": "test/unit/cookies.test.js",
         "hashed_secret": "ef5c25da3f68da43b33a9bc96de633756beb2d88",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 36
       }
     ],
     "test/utils/normalise.test.js": [
@@ -385,5 +385,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-29T10:56:11Z"
+  "generated_at": "2024-07-30T15:02:23Z"
 }

--- a/app/models/ChargeState.js
+++ b/app/models/ChargeState.js
@@ -1,0 +1,52 @@
+const logger = require('../utils/logger')(__filename)
+
+class ChargeState {
+  /**
+   * @param {Number} [createdAt]
+   * @param {Number} [accessedAt]
+   * @param {boolean} [isTerminal]
+   */
+  constructor (createdAt, accessedAt, isTerminal) {
+    this.createdAt = createdAt || epochSecondsNow()
+    this.accessedAt = accessedAt || epochSecondsNow()
+    this.isTerminal = isTerminal || false
+  }
+
+  updateAccessedAt () {
+    this.accessedAt = epochSecondsNow()
+  }
+
+  markTerminal () {
+    this.updateAccessedAt()
+    this.isTerminal = true
+  }
+
+  toString () {
+    return `${this.createdAt},${this.accessedAt},${this.isTerminal ? 'T' : 'F'}`
+  }
+}
+
+const chargeStateFromString = (data) => {
+  try {
+    const dataParts = data.split(',')
+    if (dataParts.length === 3) {
+      return new ChargeState(Number(dataParts[0]), Number(dataParts[1]), dataParts[2] === 'T')
+    } else {
+      logger.error('argument is not a valid ChargeState')
+      return null
+    }
+  } catch (e) {
+    logger.warn(`Error de-serialising ChargeState from string: ${e.message}`)
+    return null
+  }
+}
+
+const epochSecondsNow = () => {
+  return Math.floor(Date.now() / 1000)
+}
+
+module.exports = {
+  ChargeState,
+  chargeStateFromString,
+  epochSecondsNow
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -14,7 +14,7 @@ const { log } = require('./controllers/client-side-logging.controller')
 const paths = require('./paths.js')
 
 // Express middleware
-const { csrfCheck, csrfTokenGeneration } = require('./middleware/csrf.js')
+const { csrfSetSecret, csrfCheck, csrfTokenGeneration } = require('./middleware/csrf.js')
 const actionName = require('./middleware/action-name.js')
 const stateEnforcer = require('./middleware/state-enforcer.js')
 const retrieveCharge = require('./middleware/retrieve-charge.js')
@@ -43,6 +43,7 @@ exports.bind = function (app) {
   const card = paths.card
 
   const standardMiddlewareStack = [
+    csrfSetSecret,
     csrfCheck,
     csrfTokenGeneration,
     actionName,

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -74,7 +74,7 @@ async function _putConnector (url, payload, description, loggingFields = {}, cal
   requestLogger.logRequestStart(context, loggingFields)
   try {
     configureClient(client, url)
-    const response = await client.put(url, payload, description )
+    const response = await client.put(url, payload, description)
     logger.info('PUT to %s ended - total time %dms', url, new Date() - startTime, loggingFields)
     incrementStatusCodeCounter(callingFunctionName, response.status)
     if (response.status > 499 && response.status < 600) {

--- a/server.js
+++ b/server.js
@@ -18,7 +18,6 @@ const loggingMiddleware = require('./app/middleware/logging-middleware')
 const router = require('./app/routes')
 const cookies = require('./app/utils/cookies')
 const noCache = require('./app/utils/no-cache')
-const session = require('./app/utils/session')
 const i18nConfig = require('./config/i18n')
 const i18nPayTranslation = require('./config/pay-translation')
 const Sentry = require('./app/utils/sentry.js').initialiseSentry()
@@ -71,9 +70,6 @@ function initialiseGlobalMiddleware (app) {
     } else {
       res.locals.analyticsTrackingId = ANALYTICS_TRACKING_ID
     }
-    res.locals.session = function () {
-      return session.retrieve(req, req.chargeId)
-    }
     res.locals.nonce = crypto.randomBytes(16).toString('hex')
     next()
   })
@@ -84,7 +80,6 @@ function initialiseGlobalMiddleware (app) {
   app.use(compression())
 
   app.disable('x-powered-by')
-
 
   app.use(correlationHeader)
 }

--- a/test/cypress/integration/web-payments/apple-pay.test.cy.js
+++ b/test/cypress/integration/web-payments/apple-pay.test.cy.js
@@ -467,12 +467,12 @@ describe('Apple Pay payment flow', () => {
         cy.task('setupStubs', createPaymentChargeStubsWelsh)
         cy.visit(`/secure/${tokenId}`)
 
-      // 1. Charge will be created using this id as a token (GET)
-      // 2. Token will be marked as used (POST)
-      // 3. Charge will be fetched (GET)
-      // 4. Service related to charge will be fetched (GET)
-      // 5. Charge status will be updated (PUT)
-      // 6. Client will be redirected to /card_details/:chargeId (304)
+        // 1. Charge will be created using this id as a token (GET)
+        // 2. Token will be marked as used (POST)
+        // 3. Charge will be fetched (GET)
+        // 4. Service related to charge will be fetched (GET)
+        // 5. Charge status will be updated (PUT)
+        // 6. Client will be redirected to /card_details/:chargeId (304)
         cy.location('pathname').should('eq', `/card_details/${chargeId}`)
 
         cy.task('clearStubs')

--- a/test/integration/card-details-errors.ft.test.js
+++ b/test/integration/card-details-errors.ft.test.js
@@ -217,7 +217,7 @@ describe('chargeTests', function () {
     })
 
     it('should return country list when invalid fields submitted', (done) => {
-      const cookieValue = cookie.create(chargeId, {})
+      const cookieValue = cookie.create(chargeId, {}) // empty charge session left here to prove backwards compatability prior to merge of PP-12546, remove once backcompat code is deleted
       mockSuccessCardIdResponse(defaultCardID)
       mockSuccessPatchEmail(chargeId)
       defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
@@ -231,7 +231,7 @@ describe('chargeTests', function () {
     })
 
     it('shows an error when a card is submitted with missing fields', function (done) {
-      const cookieValue = cookie.create(chargeId, {})
+      const cookieValue = cookie.create(chargeId, {}) // empty charge session left here to prove backwards compatability prior to merge of PP-12546, remove once backcompat code is deleted
       mockSuccessCardIdResponse(defaultCardID)
       mockSuccessPatchEmail(chargeId)
       defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
@@ -277,7 +277,7 @@ describe('chargeTests', function () {
     })
 
     it('shows an error when a card is submitted that is not supported', function (done) {
-      const cookieValue = cookie.create(chargeId, {})
+      const cookieValue = cookie.create(chargeId, {}) // empty charge session left here to prove backwards compatability prior to merge of PP-12546, remove once backcompat code is deleted
       nock.cleanAll()
       mockSuccessPatchEmail(chargeId)
       defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
@@ -304,7 +304,7 @@ describe('chargeTests', function () {
     })
 
     it('shows an error when a card is submitted that is not supported withdrawal type', function (done) {
-      const cookieValue = cookie.create(chargeId, {})
+      const cookieValue = cookie.create(chargeId, {}) // empty charge session left here to prove backwards compatability prior to merge of PP-12546, remove once backcompat code is deleted
       nock.cleanAll()
       nock(process.env.CARDID_HOST)
         .post('/v1/api/card', () => {
@@ -332,7 +332,7 @@ describe('chargeTests', function () {
     })
 
     it('preserve card fields, cardholder name, address lines and email when a card is submitted with validation errors', function (done) {
-      const cookieValue = cookie.create(chargeId, {})
+      const cookieValue = cookie.create(chargeId, {}) // empty charge session left here to prove backwards compatability prior to merge of PP-12546, remove once backcompat code is deleted
       defaultConnectorResponseForGetCharge(chargeId, State.ENTERING_CARD_DETAILS, gatewayAccountId)
       defaultAdminusersResponseForGetService(gatewayAccountId)
       mockSuccessPatchEmail(chargeId)

--- a/test/models/ChargeState.test.js
+++ b/test/models/ChargeState.test.js
@@ -1,0 +1,75 @@
+const expect = require('chai').expect
+const sinon = require('sinon')
+const { ChargeState, chargeStateFromString } = require('../../app/models/ChargeState')
+
+describe('ChargeState model should', () => {
+  let clock
+
+  beforeEach(() => {
+    const fixedDate = new Date(1721390000000) // 19 July 2024 11:53:20
+    clock = sinon.useFakeTimers(fixedDate)
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  it('create new ChargeState with no parameters', () => {
+    const result = new ChargeState()
+    expect(result.isTerminal).to.equal(false)
+    expect(result.accessedAt).to.equal(1721390000)
+    expect(result.createdAt).to.equal(1721390000)
+  })
+  it('create new ChargeState with parameters', () => {
+    const result = new ChargeState(1721390555, 1721390999, true)
+    expect(result.isTerminal).to.equal(true)
+    expect(result.accessedAt).to.equal(1721390999)
+    expect(result.createdAt).to.equal(1721390555)
+  })
+  it('set isComplete to true and update accessedAt when done is called', () => {
+    const result = new ChargeState()
+    expect(result.isTerminal).to.equal(false)
+    expect(result.createdAt).to.equal(1721390000)
+    expect(result.accessedAt).to.equal(1721390000)
+    clock.restore()
+    clock = sinon.useFakeTimers(1721399999999)
+    result.markTerminal()
+    expect(result.createdAt).to.equal(1721390000)
+    expect(result.isTerminal).to.equal(true)
+    expect(result.accessedAt).to.equal(1721399999)
+  })
+  it('set accessedAt to now when updateAccessedAt is called', () => {
+    const result = new ChargeState(1721390000, 1721390000, false)
+    expect(result.isTerminal).to.equal(false)
+    expect(result.accessedAt).to.equal(1721390000)
+    clock.restore()
+    clock = sinon.useFakeTimers(1721399999999)
+    result.updateAccessedAt()
+    expect(result.isTerminal).to.equal(false)
+    expect(result.accessedAt).to.equal(1721399999)
+  })
+  it('return string representation when toString is called', () => {
+    const result = new ChargeState().toString()
+    expect(result).to.equal('1721390000,1721390000,F')
+  })
+  it('return ChargeState representation from string', () => {
+    const result = chargeStateFromString('1721390000,1721399999,F')
+    expect(result.isTerminal).to.equal(false)
+    expect(result.accessedAt).to.equal(1721399999)
+    expect(result.createdAt).to.equal(1721390000)
+  })
+  const invalidArgs = [
+    { input: null },
+    { input: undefined },
+    { input: '' },
+    { input: 'randomstringhere' },
+    { input: 'too,many,arg,umen,ts' },
+    { input: 'toofew,arguments' }
+  ]
+  invalidArgs.forEach(({ input }) => {
+    it(`return null if chargeStateFromString argument is not valid [${input}]`, () => {
+      const result = chargeStateFromString(input)
+      expect(result).to.be.null // eslint-disable-line
+    })
+  })
+})

--- a/test/test-helpers/session.js
+++ b/test/test-helpers/session.js
@@ -2,6 +2,7 @@
 
 const clientSessions = require('client-sessions')
 const cookies = require('../../app/utils/cookies.js')
+const { ChargeState } = require('../../app/models/ChargeState')
 
 function createSessionChargeKey (chargeId) {
   return 'ch_' + chargeId
@@ -12,10 +13,11 @@ function createReturnUrlKey (chargeId) {
 }
 
 function createSessionWithReturnUrl (chargeId, chargeSession, returnUrl) {
-  chargeSession = chargeSession || {}
+  chargeSession = chargeSession || { data: new ChargeState().toString() }
   chargeSession.csrfSecret = process.env.CSRF_USER_SECRET
   const session = {}
   if (arguments.length > 0) {
+    session.csrfSecret = process.env.CSRF_USER_SECRET
     session[createSessionChargeKey(chargeId)] = chargeSession
     session[createReturnUrlKey(chargeId)] = encodeURIComponent(returnUrl)
   }

--- a/test/test-helpers/test-helpers.js
+++ b/test/test-helpers/test-helpers.js
@@ -336,8 +336,8 @@ module.exports = {
     throw new Error('Promise was unexpectedly fulfilled.')
   },
 
-  csrfToken: function () {
-    return csrf().create(process.env.CSRF_USER_SECRET)
+  csrfToken: function (secret = process.env.CSRF_USER_SECRET) {
+    return csrf().create(secret)
   },
 
   cardTypes

--- a/test/test.env
+++ b/test/test.env
@@ -4,6 +4,7 @@ SECURE_COOKIE_OFF=false
 COOKIE_MAX_AGE=5400000
 SESSION_ENCRYPTION_KEY=naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk
 CSRF_USER_SECRET=123456789012345678
+CSRF_USER_SECRET_TWO=987654321012345678
 CARDID_HOST=http://cardid.pymnt.localdomain:65530
 WORLDPAY_APPLE_PAY_MERCHANT_ID=merchant.uk.gov.service.payments.test
 STRIPE_APPLE_PAY_MERCHANT_ID=merchant.uk.gov.service.payments.stripe.test

--- a/test/unit/session.test.js
+++ b/test/unit/session.test.js
@@ -2,8 +2,10 @@
 
 const { expect } = require('chai')
 const session = require('../../app/utils/session')
+const { ChargeState } = require('../../app/models/ChargeState')
 
 const chargeId = 'foo'
+const chargeStateString = new ChargeState().toString()
 
 const EMPTY_RESPONSE = { params: {}, body: {}, get: () => null }
 
@@ -25,7 +27,7 @@ const VALID_GET_RESPONSE = {
   params: { chargeId: chargeId },
   body: {},
   method: 'GET',
-  frontend_state: { ch_foo: true },
+  frontend_state: { ch_foo: { data: chargeStateString } },
   get: () => null
 }
 
@@ -33,7 +35,7 @@ const VALID_POST_RESPONSE = {
   params: {},
   body: { chargeId: chargeId },
   method: 'POST',
-  frontend_state: { ch_foo: true },
+  frontend_state: { ch_foo: { data: chargeStateString } },
   get: () => null
 }
 
@@ -46,29 +48,29 @@ describe('session utils ', () => {
 
   describe('retrieve ', () => {
     it('should return session', function () {
-            expect(session.retrieve(VALID_GET_RESPONSE, chargeId)).to.be.true // eslint-disable-line
+      expect(session.retrieve(VALID_GET_RESPONSE, chargeId)).to.deep.equal({ data: chargeStateString })
     })
   })
 
   describe('validateSessionCookie ', () => {
     it('should return true for GET request with valid session cookie', function () {
-            expect(session.validateSessionCookie(VALID_GET_RESPONSE)).to.be.true // eslint-disable-line
+      expect(session.validateSessionCookie(VALID_GET_RESPONSE)).to.be.true // eslint-disable-line
     })
 
     it('should return true for POST request with valid session cookie', function () {
-            expect(session.validateSessionCookie(VALID_POST_RESPONSE)).to.be.true // eslint-disable-line
+      expect(session.validateSessionCookie(VALID_POST_RESPONSE)).to.be.true // eslint-disable-line
     })
 
     it('should return false if the charge param is not present in params or body', function () {
-            expect(session.validateSessionCookie(EMPTY_RESPONSE)).to.be.false // eslint-disable-line
+      expect(session.validateSessionCookie(EMPTY_RESPONSE)).to.be.false // eslint-disable-line
     })
 
     it('should return false if the charge param is in params but not in session', function () {
-            expect(session.validateSessionCookie(NO_SESSION_GET_RESPONSE)).to.be.false // eslint-disable-line
+      expect(session.validateSessionCookie(NO_SESSION_GET_RESPONSE)).to.be.false // eslint-disable-line
     })
 
     it('should return false if the charge param is in THE BODY but not in session', function () {
-            expect(session.validateSessionCookie(NO_SESSION_POST_RESPONSE)).to.be.false // eslint-disable-line
+      expect(session.validateSessionCookie(NO_SESSION_POST_RESPONSE)).to.be.false // eslint-disable-line
     })
   })
 })


### PR DESCRIPTION
## WHAT

frontend now holds up to 10 charge objects on the client to allow users
who navigate back to Pay from the service to see the status of their payment

a charge will be removed from the client if 10 charges exist and an 11th payment
is started

the logic for determining which charge to remove is documented in this ADR:
https://github.com/alphagov/pay-architecture/blob/main/adr/026-keep-payments-in-cookie-for-longer.md

- new ChargeState model
- new csrf secret management middleware
  - csrf secret is set at the root of the session object as part of a gradual migration of csrf behaviour
- remove used csrf token store from frontend state
- add new cookie functions for handling charge state
- remove unused session code from server


