### PR TITLE
PP-12853 Apple pay merchant validation - fix env name

### DIFF
--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -5,7 +5,7 @@ const { getLoggingFields } = require('../../../utils/logging-fields-helper')
 const axios = require('axios')
 const https = require('https')
 const { HttpsProxyAgent } = require('https-proxy-agent')
-const proxyUrl = process.env.HTTPS_PROXY_URL
+const proxyUrl = process.env.HTTPS_PROXY
 
 
 function getCertificateMultiline (cert) {

--- a/test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js
+++ b/test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js
@@ -26,7 +26,7 @@ describe('Validate with Apple the merchant is legitimate', () => {
   let res, sendSpy, axiosStub
 
   beforeEach(() => {
-    delete process.env.HTTPS_PROXY_URL
+    delete process.env.HTTPS_PROXY
 
     process.env.APPLE_PAY_MERCHANT_DOMAIN = merchantDomain
     process.env.WORLDPAY_APPLE_PAY_MERCHANT_ID = worldpayMerchantId
@@ -83,7 +83,7 @@ describe('Validate with Apple the merchant is legitimate', () => {
 
   describe('when there is a proxy', () => {
     it('should return a payload for a Worldpay payment if Merchant is valid', async () => {
-      process.env.HTTPS_PROXY_URL = 'https://fakeproxy.com'
+      process.env.HTTPS_PROXY = 'https://fakeproxy.com'
       const controller = getControllerWithMocks(axiosStub)
 
       const req = {
@@ -119,7 +119,7 @@ describe('Validate with Apple the merchant is legitimate', () => {
     })
 
     it('should return a payload for a Stripe payment if Merchant is valid', async () => {
-      process.env.HTTPS_PROXY_URL = 'https://fakeproxy.com'
+      process.env.HTTPS_PROXY = 'https://fakeproxy.com'
       const axiosStub = sinon.stub().resolves({ data: appleResponse.data, status: 200 })
       const controller = getControllerWithMocks(axiosStub)
 
@@ -170,7 +170,7 @@ describe('Validate with Apple the merchant is legitimate', () => {
     })
 
     it('should return a payload for a Sandbox payment if Merchant is valid', async () => {
-      process.env.HTTPS_PROXY_URL = 'https://fakeproxy.com'
+      process.env.HTTPS_PROXY = 'https://fakeproxy.com'
       const axiosStub = sinon.stub().resolves({ data: appleResponse.data, status: 200 })
       const controller = getControllerWithMocks(axiosStub)
 


### PR DESCRIPTION
- Correct name of the env variable used to check for the proxy:
  - Should be HTTPS_PROXY instead of HTTPS_PROXY



