### PR TITLE
Pp 12853 apple pay merchant validation revert changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -27,9 +27,6 @@
       "name": "GitHubTokenDetector"
     },
     {
-      "name": "GitLabTokenDetector"
-    },
-    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -38,9 +35,6 @@
     },
     {
       "name": "IbmCosHmacDetector"
-    },
-    {
-      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -56,13 +50,7 @@
       "name": "NpmDetector"
     },
     {
-      "name": "OpenAIDetector"
-    },
-    {
       "name": "PrivateKeyDetector"
-    },
-    {
-      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -78,9 +66,6 @@
     },
     {
       "name": "StripeDetector"
-    },
-    {
-      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -129,7 +114,16 @@
         "filename": "app/controllers/web-payments/apple-pay/merchant-validation.controller.js",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 14
+      }
+    ],
+    "test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js": [
+      {
+        "type": "Private Key",
+        "filename": "test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 68
       }
     ],
     "test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js": [
@@ -391,5 +385,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-24T08:52:06Z"
+  "generated_at": "2024-07-22T12:54:11Z"
 }

--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -1,12 +1,8 @@
 'use strict'
 
+const request = require('requestretry')
 const logger = require('../../../utils/logger')(__filename)
 const { getLoggingFields } = require('../../../utils/logging-fields-helper')
-const axios = require('axios')
-const https = require('https')
-const { HttpsProxyAgent } = require('https-proxy-agent')
-const proxyUrl = process.env.HTTPS_PROXY
-
 
 function getCertificateMultiline (cert) {
   return `-----BEGIN CERTIFICATE-----
@@ -42,9 +38,7 @@ function getApplePayMerchantIdentityVariables (paymentProvider) {
 // When an Apple payment is initiated in Safari, it must check that the request
 // is coming from a registered and authorised Apple Merchant Account. The
 // browser will produce a URL which we should dial with our certificates server side.
-module.exports = async (req, res) => {
-  let agent
-
+module.exports = (req, res) => {
   if (!req.body.url) {
     return res.sendStatus(400)
   }
@@ -54,41 +48,30 @@ module.exports = async (req, res) => {
     return res.sendStatus(400)
   }
 
-  if (proxyUrl) {
-    agent = new HttpsProxyAgent(proxyUrl, {
-      cert: merchantIdentityVars.cert,
-      key: merchantIdentityVars.key
-    })
-  } else {
-    agent = new https.Agent({
-      cert: merchantIdentityVars.cert,
-      key: merchantIdentityVars.key
-    })
-  }
-
   const options = {
     url: url,
+    cert: merchantIdentityVars.cert,
+    key: merchantIdentityVars.key,
     method: 'post',
-    headers: { 'Content-Type': 'application/json' },
-    data: {
+    body: {
       merchantIdentifier: merchantIdentityVars.merchantIdentifier,
       displayName: 'GOV.UK Pay',
       initiative: 'web',
       initiativeContext: process.env.APPLE_PAY_MERCHANT_DOMAIN
     },
-    httpsAgent: agent
+    json: true
   }
 
-  try {
-    const response = await axios(options)
-    res.status(200).send(response.data)
-  } catch (error) {
-    logger.info('Error generating Apple Pay session', {
-      ...getLoggingFields(req),
-      error: error,
-      response: error.response,
-      data: error.response ? error.response.data : null
-    })
-    res.status(500).send(error.response ? error.response.data : 'Apple Pay Error')
-  }
+  request(options, (err, response, body) => {
+    if (err) {
+      logger.info('Error generating Apple Pay session', {
+        ...getLoggingFields(req),
+        error: err,
+        response: response,
+        body: body
+      })
+      return res.status(500).send(body)
+    }
+    res.status(200).send(body)
+  })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "gaap-analytics": "^3.1.0",
         "govuk-frontend": "^4.8.0",
         "helmet": "^7.1.0",
-        "https-proxy-agent": "^7.0.5",
         "i18n": "0.15.x",
         "lodash": "4.17.x",
         "mailcheck": "^1.1.1",
@@ -2502,29 +2501,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/node/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@sentry/types": {
       "version": "7.74.0",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.74.0.tgz",
@@ -2828,14 +2804,14 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dependencies": {
-        "debug": "^4.3.4"
+        "debug": "4"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -8983,6 +8959,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http-signature": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
@@ -9004,15 +8992,15 @@
       "dev": true
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "6",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -11572,6 +11560,18 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/mountebank/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/mountebank/node_modules/body-parser": {
@@ -18836,25 +18836,6 @@
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^2.4.1 || ^1.9.3"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-          "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        }
       }
     },
     "@sentry/types": {
@@ -19127,11 +19108,11 @@
       "dev": true
     },
     "agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
-        "debug": "^4.3.4"
+        "debug": "4"
       }
     },
     "aggregate-error": {
@@ -23922,6 +23903,17 @@
       "requires": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        }
       }
     },
     "http-signature": {
@@ -23942,11 +23934,11 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "requires": {
-        "agent-base": "^7.0.2",
+        "agent-base": "6",
         "debug": "4"
       }
     },
@@ -25906,6 +25898,15 @@
         "yargs": "17.7.2"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        },
         "body-parser": {
           "version": "1.20.1",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "gaap-analytics": "^3.1.0",
     "govuk-frontend": "^4.8.0",
     "helmet": "^7.1.0",
-    "https-proxy-agent": "^7.0.5",
     "i18n": "0.15.x",
     "lodash": "4.17.x",
     "mailcheck": "^1.1.1",

--- a/test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js
+++ b/test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js
@@ -2,8 +2,6 @@
 
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
-const https = require('https')
-const { HttpsProxyAgent } = require('https-proxy-agent')
 
 const merchantDomain = 'www.pymnt.uk'
 const worldpayMerchantId = 'worldpay.merchant.id'
@@ -14,20 +12,19 @@ const stripeCertificate = 'A-STRIPE-CERTIFICATE'
 const stripeKey = 'A-STRIPE-KEY'
 const url = 'https://fakeapple.url'
 
-const appleResponse = { status: 200, data: { foo: 'bar' } }
+const appleResponse = { status: 200 }
+const appleResponseBody = { foo: 'bar' }
 
-function getControllerWithMocks (axiosMock) {
+function getControllerWithMocks (requestMock) {
   return proxyquire('../../../../app/controllers/web-payments/apple-pay/merchant-validation.controller', {
-    axios: axiosMock
+    requestretry: requestMock
   })
 }
 
 describe('Validate with Apple the merchant is legitimate', () => {
-  let res, sendSpy, axiosStub
+  let res, sendSpy
 
   beforeEach(() => {
-    delete process.env.HTTPS_PROXY
-
     process.env.APPLE_PAY_MERCHANT_DOMAIN = merchantDomain
     process.env.WORLDPAY_APPLE_PAY_MERCHANT_ID = worldpayMerchantId
     process.env.WORLDPAY_APPLE_PAY_MERCHANT_ID_CERTIFICATE = worldpayCertificate
@@ -41,199 +38,146 @@ describe('Validate with Apple the merchant is legitimate', () => {
       status: sinon.spy(() => ({ send: sendSpy })),
       sendStatus: sinon.spy()
     }
-
-    axiosStub = sinon.stub().resolves(appleResponse)
   })
 
-  describe('when running locally with no proxy', () => {
-    it('should return a payload for a Worldpay payment if Merchant is valid', async () => {
-      const controller = getControllerWithMocks(axiosStub)
+  it('should return a payload for a Worldpay payment if Merchant is valid', async () => {
+    const mockRequest = sinon.stub().yields(null, appleResponse, appleResponseBody)
+    const controller = getControllerWithMocks(mockRequest)
 
-      const req = {
-        body: {
-          url,
-          paymentProvider: 'worldpay'
-        }
-      }
-      await controller(req, res)
-
-      sinon.assert.calledWith(axiosStub, sinon.match({
+    const req = {
+      body: {
         url,
-        method: 'post',
-        headers: { 'Content-Type': 'application/json' },
-        data: {
-          merchantIdentifier: worldpayMerchantId,
-          displayName: 'GOV.UK Pay',
-          initiative: 'web',
-          initiativeContext: merchantDomain
-        },
-        httpsAgent: sinon.match.instanceOf(https.Agent)
-      }))
+        paymentProvider: 'worldpay'
+      }
+    }
+    await controller(req, res)
 
-      const httpsAgentArg = axiosStub.getCall(0).args[0].httpsAgent
-      sinon.assert.match(httpsAgentArg.options, {
-        cert: sinon.match(cert => cert.includes(worldpayCertificate)),
-        key: sinon.match(key => key.includes(worldpayKey))
-      })
-
-      sinon.assert.calledWith(res.status, 200)
-      sinon.assert.calledWith(sendSpy, appleResponse.data)
+    sinon.assert.calledWith(mockRequest, {
+      url,
+      body: {
+        merchantIdentifier: worldpayMerchantId,
+        displayName: 'GOV.UK Pay',
+        initiative: 'web',
+        initiativeContext: merchantDomain
+      },
+      method: 'post',
+      json: true,
+      cert: `-----BEGIN CERTIFICATE-----
+${worldpayCertificate}
+-----END CERTIFICATE-----`,
+      key: `-----BEGIN PRIVATE KEY-----
+${worldpayKey}
+-----END PRIVATE KEY-----`
     })
+    sinon.assert.calledWith(res.status, 200)
+    sinon.assert.calledWith(sendSpy, appleResponseBody)
   })
 
-  describe('when there is a proxy', () => {
-    it('should return a payload for a Worldpay payment if Merchant is valid', async () => {
-      process.env.HTTPS_PROXY = 'https://fakeproxy.com'
-      const controller = getControllerWithMocks(axiosStub)
+  it('should return a payload for a Stripe payment if Merchant is valid', async () => {
+    const mockRequest = sinon.stub().yields(null, appleResponse, appleResponseBody)
+    const controller = getControllerWithMocks(mockRequest)
 
-      const req = {
-        body: {
-          url,
-          paymentProvider: 'worldpay'
-        }
-      }
-      await controller(req, res)
-
-      sinon.assert.calledWith(axiosStub, sinon.match({
+    const req = {
+      body: {
         url,
-        method: 'post',
-        headers: { 'Content-Type': 'application/json' },
-        data: {
-          merchantIdentifier: worldpayMerchantId,
-          displayName: 'GOV.UK Pay',
-          initiative: 'web',
-          initiativeContext: merchantDomain
-        },
-        httpsAgent: sinon.match.instanceOf(HttpsProxyAgent)
-      }))
-
-      const httpsAgentArg = axiosStub.getCall(0).args[0].httpsAgent
-      sinon.match(httpsAgentArg.proxy, 'https://fakeproxy.com')
-      sinon.assert.match(httpsAgentArg.connectOpts, {
-        cert: sinon.match(cert => cert.includes(worldpayCertificate)),
-        key: sinon.match(key => key.includes(worldpayKey))
-      })
-
-      sinon.assert.calledWith(res.status, 200)
-      sinon.assert.calledWith(sendSpy, appleResponse.data)
-    })
-
-    it('should return a payload for a Stripe payment if Merchant is valid', async () => {
-      process.env.HTTPS_PROXY = 'https://fakeproxy.com'
-      const axiosStub = sinon.stub().resolves({ data: appleResponse.data, status: 200 })
-      const controller = getControllerWithMocks(axiosStub)
-
-      const req = {
-        body: {
-          url,
-          paymentProvider: 'stripe'
-        }
+        paymentProvider: 'stripe'
       }
-      await controller(req, res)
+    }
+    await controller(req, res)
 
-      sinon.assert.calledWith(axiosStub, sinon.match({
+    sinon.assert.calledWith(mockRequest, {
+      url,
+      body: {
+        merchantIdentifier: stripeMerchantId,
+        displayName: 'GOV.UK Pay',
+        initiative: 'web',
+        initiativeContext: merchantDomain
+      },
+      method: 'post',
+      json: true,
+      cert: `-----BEGIN CERTIFICATE-----
+${stripeCertificate}
+-----END CERTIFICATE-----`,
+      key: `-----BEGIN PRIVATE KEY-----
+${stripeKey}
+-----END PRIVATE KEY-----`
+    })
+    sinon.assert.calledWith(res.status, 200)
+    sinon.assert.calledWith(sendSpy, appleResponseBody)
+  })
+
+  it('should return 400 if no url is provided', async () => {
+    const mockRequest = sinon.stub().yields(null, appleResponse, appleResponseBody)
+    const controller = getControllerWithMocks(mockRequest)
+
+    const req = {
+      body: {
+        paymentProvider: 'worldpay'
+      }
+    }
+    await controller(req, res)
+    sinon.assert.calledWith(res.sendStatus, 400)
+  })
+
+  it('should return a payload for a Sandbox payment if Merchant is valid', async () => {
+    const mockRequest = sinon.stub().yields(null, appleResponse, appleResponseBody)
+    const controller = getControllerWithMocks(mockRequest)
+
+    const req = {
+      body: {
         url,
-        method: 'post',
-        headers: { 'Content-Type': 'application/json' },
-        data: {
-          merchantIdentifier: stripeMerchantId,
-          displayName: 'GOV.UK Pay',
-          initiative: 'web',
-          initiativeContext: merchantDomain
-        },
-        httpsAgent: sinon.match.instanceOf(HttpsProxyAgent)
-      }))
-
-      const httpsAgentArg = axiosStub.getCall(0).args[0].httpsAgent
-      sinon.match(httpsAgentArg.proxy, 'https://fakeproxy.com')
-      sinon.assert.match(httpsAgentArg.connectOpts, {
-        cert: sinon.match(cert => cert.includes(stripeCertificate)),
-        key: sinon.match(key => key.includes(stripeKey))
-      })
-
-      sinon.assert.calledWith(res.status, 200)
-      sinon.assert.calledWith(sendSpy, appleResponse.data)
-    })
-
-    it('should return 400 if no url is provided', async () => {
-      const axiosStub = sinon.stub().resolves({ data: appleResponse.data, status: 200 })
-      const controller = getControllerWithMocks(axiosStub)
-
-      const req = {
-        body: {
-          paymentProvider: 'worldpay'
-        }
+        paymentProvider: 'sandbox'
       }
-      await controller(req, res)
-      sinon.assert.calledWith(res.sendStatus, 400)
-      sinon.assert.notCalled(axiosStub)
+    }
+    await controller(req, res)
+
+    sinon.assert.calledWith(mockRequest, {
+      url,
+      body: {
+        merchantIdentifier: worldpayMerchantId,
+        displayName: 'GOV.UK Pay',
+        initiative: 'web',
+        initiativeContext: merchantDomain
+      },
+      method: 'post',
+      json: true,
+      cert: `-----BEGIN CERTIFICATE-----
+${worldpayCertificate}
+-----END CERTIFICATE-----`,
+      key: `-----BEGIN PRIVATE KEY-----
+${worldpayKey}
+-----END PRIVATE KEY-----`
     })
+    sinon.assert.calledWith(res.status, 200)
+    sinon.assert.calledWith(sendSpy, appleResponseBody)
+  })
 
-    it('should return a payload for a Sandbox payment if Merchant is valid', async () => {
-      process.env.HTTPS_PROXY = 'https://fakeproxy.com'
-      const axiosStub = sinon.stub().resolves({ data: appleResponse.data, status: 200 })
-      const controller = getControllerWithMocks(axiosStub)
+  it('should return 400 for unexpected payment provider', async () => {
+    const mockRequest = sinon.stub().yields(null, appleResponse, appleResponseBody)
+    const controller = getControllerWithMocks(mockRequest)
 
-      const req = {
-        body: {
-          url,
-          paymentProvider: 'sandbox'
-        }
-      }
-      await controller(req, res)
-
-      sinon.assert.calledWith(axiosStub, sinon.match({
+    const req = {
+      body: {
         url,
-        method: 'post',
-        headers: { 'Content-Type': 'application/json' },
-        data: {
-          merchantIdentifier: worldpayMerchantId,
-          displayName: 'GOV.UK Pay',
-          initiative: 'web',
-          initiativeContext: merchantDomain
-        },
-        httpsAgent: sinon.match.instanceOf(HttpsProxyAgent)
-      }))
-
-      const httpsAgentArg = axiosStub.getCall(0).args[0].httpsAgent
-      sinon.match(httpsAgentArg.proxy, 'https://fakeproxy.com')
-      sinon.assert.match(httpsAgentArg.connectOpts, {
-        cert: sinon.match(cert => cert.includes(worldpayCertificate)),
-        key: sinon.match(key => key.includes(worldpayKey))
-      })
-
-      sinon.assert.calledWith(res.status, 200)
-      sinon.assert.calledWith(sendSpy, appleResponse.data)
-    })
-
-    it('should return 400 for unexpected payment provider', async () => {
-      const axiosStub = sinon.stub().resolves({ data: appleResponse.data, status: 200 })
-      const controller = getControllerWithMocks(axiosStub)
-
-      const req = {
-        body: {
-          url,
-          paymentProvider: 'mystery'
-        }
+        paymentProvider: 'mystery'
       }
-      await controller(req, res)
-      sinon.assert.calledWith(res.sendStatus, 400)
-      sinon.assert.notCalled(axiosStub)
-    })
+    }
+    await controller(req, res)
+    sinon.assert.calledWith(res.sendStatus, 400)
+  })
 
-    it('should return an error if Apple Pay returns an error', async () => {
-      const axiosErrorStub = sinon.stub().rejects(new Error('Whatever error from Apple Pay'))
-      const controller = getControllerWithMocks(axiosErrorStub)
+  it('should return an error if Apple Pay returns an error', async () => {
+    const mockRequest = sinon.stub().yields(new Error(), appleResponse, appleResponseBody)
+    const controller = getControllerWithMocks(mockRequest)
 
-      const req = {
-        body: {
-          url,
-          paymentProvider: 'worldpay'
-        }
+    const req = {
+      body: {
+        url,
+        paymentProvider: 'worldpay'
       }
-      await controller(req, res)
-      sinon.assert.calledWith(res.status, 500)
-      sinon.assert.calledWith(sendSpy, 'Apple Pay Error')
-    })
+    }
+    await controller(req, res)
+    sinon.assert.calledWith(res.status, 500)
+    sinon.assert.calledWith(sendSpy, appleResponseBody)
   })
 })


### PR DESCRIPTION
Reverts 2 Apple pay mechant validation fixes that were tried
on the test env but are not working and therefore cannot be released
to PROD.

Revert "PP-12853 Apple pay merchant validation - fix env name"

This reverts commit https://github.com/alphagov/pay-frontend/commit/5450a8e48d48c56cbf1c085796d902db20850c79.

Revert "PP-12853 Update apple pay merchant validation to use Axios"

This reverts commit https://github.com/alphagov/pay-frontend/commit/0c4ab162a38c65a7a7e325135a91fcf4dbc80675.


