### PR TITLE
Only print error message when Apple Pay validation fails

### DIFF
--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -107,7 +107,7 @@ module.exports = async (req, res) => {
       const errorResponseData = error.response ? error.response.data : null
       logger.info('Error generating Apple Pay session', {
         ...getLoggingFields(req),
-        error: error,
+        error: error.message,
         response: error.response,
         data: errorResponseData
       })
@@ -120,7 +120,7 @@ module.exports = async (req, res) => {
       if (err) {
         logger.info('Error generating Apple Pay session', {
           ...getLoggingFields(req),
-          error: err,
+          error: err.message,
           response: response,
           body: body
         })


### PR DESCRIPTION
With this change, we are changing what is logged when Apple Pay validation fails by only printing the error message.




