### PR TITLE
PP-12546 generate tokens from session secret over charge secret

### DIFF
--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -20,16 +20,14 @@ exports.csrfSetSecret = (req, _, next) => {
 }
 
 exports.csrfTokenGeneration = (req, res, next) => {
-  const chargeId = fetchAndValidateChargeId(req)
-  const chargeSession = session.retrieve(req, chargeId)
-  res.locals.csrf = csrf().create(chargeSession.csrfSecret) // TODO: generate tokens using the session secret
+  const csrfSecret = cookies.getSessionCsrfSecret(req)
+  res.locals.csrf = csrf().create(csrfSecret)
   next()
 }
 
 exports.csrfCheck = (req, res, next) => {
   const chargeId = fetchAndValidateChargeId(req)
   if (!chargeId) {
-    logger.warn('Session cookie is not present, rendering unauthorised page', getLoggingFields(req))
     return responseRouter.response(req, res, 'UNAUTHORISED')
   }
 

--- a/test/middleware/csrf.test.js
+++ b/test/middleware/csrf.test.js
@@ -22,6 +22,7 @@ describe('retrieve param test', function () {
     body: {},
     route: { methods: { get: true } },
     frontend_state: {
+      csrfSecret: process.env.CSRF_USER_SECRET_TWO,
       ch_foo: {
         csrfSecret: process.env.CSRF_USER_SECRET
       }
@@ -34,6 +35,7 @@ describe('retrieve param test', function () {
 
   const noSecret = _.cloneDeep(validGetRequest)
   delete noSecret.frontend_state.ch_foo.csrfSecret
+  delete noSecret.frontend_state.csrfSecret
 
   const invalidPost = _.cloneDeep(validGetRequest)
   delete invalidPost.method
@@ -47,16 +49,13 @@ describe('retrieve param test', function () {
 
   const validPostWithSessionSecretAndChargeSecretAndChargeSecretGeneratedToken = _.cloneDeep(invalidPost)
   validPostWithSessionSecretAndChargeSecretAndChargeSecretGeneratedToken.body.csrfToken = helper.csrfToken(process.env.CSRF_USER_SECRET)
-  validPostWithSessionSecretAndChargeSecretAndChargeSecretGeneratedToken.frontend_state.csrfSecret = process.env.CSRF_USER_SECRET_TWO
 
   const validPostWithSessionSecretAndChargeSecretAndSessionSecretGeneratedToken = _.cloneDeep(invalidPost)
   validPostWithSessionSecretAndChargeSecretAndSessionSecretGeneratedToken.body.csrfToken = helper.csrfToken(process.env.CSRF_USER_SECRET_TWO)
-  validPostWithSessionSecretAndChargeSecretAndSessionSecretGeneratedToken.frontend_state.csrfSecret = process.env.CSRF_USER_SECRET_TWO
 
   const validPostWithSessionSecretAndSessionSecretGeneratedToken = _.cloneDeep(invalidPost)
   delete validPostWithSessionSecretAndSessionSecretGeneratedToken.frontend_state.ch_foo.csrfSecret
   validPostWithSessionSecretAndSessionSecretGeneratedToken.body.csrfToken = helper.csrfToken(process.env.CSRF_USER_SECRET_TWO)
-  validPostWithSessionSecretAndSessionSecretGeneratedToken.frontend_state.csrfSecret = process.env.CSRF_USER_SECRET_TWO
 
   const validPut = _.cloneDeep(invalidPut)
   validPut.body.csrfToken = helper.csrfToken()


### PR DESCRIPTION
## WHAT

this change is part of a wider series that are being merged in sequence to prevent the need for a downtime deployment

- `setCsrfSecret` middle-ware has been deployed and any currently in-flight payments at the time of this deployment should have a top level session csrf secret
- modify the `csrfTokenGeneration` middle-ware to use the top level session csrf secret instead of the charge level csrf secret
- remove redundant log line from `csrfCheck` middle-ware, `fetchAndValidateChargeId` is called ahead of the removed log line and already provides all the necessary logging detail

