### PR TITLE
Update Apple Pay Merchant Validation with Axios

### DIFF
--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -61,6 +61,9 @@ module.exports = async (req, res) => {
   });
 
   const proxyAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : null
+  if (proxyUrl) {
+    logger.info('Using proxy URL')
+  }
 
   const options = applePayMerchantValidationViaAxios ?
     {
@@ -94,13 +97,8 @@ module.exports = async (req, res) => {
   if (applePayMerchantValidationViaAxios) {
     logger.info('Generating Apple Pay session via axios')
     try {
-      let response
+      const response = await axios(options)
 
-      if (proxyUrl) {
-        response = await axios(options, httpsAgent)
-      } else {
-        response = await axios(options)
-      }
       logger.info('Apple Pay session successfully generated via axios')
       res.status(200).send(response.data)
     } catch (error) {


### PR DESCRIPTION
With this change, we are updating the implementation of the Apple Pay Merchant Validation so that when Axios is enabled (which is the case on Test only, for now[1]), then we pass the HttpsAgent or the HttpsProxyAgent to Axios correctly based on the presence or absence of a proxy URL.

We are also adding a log to check that the proxy URL is correctly setup, although we are not logging the URL itself for security reasons.

Further information in Jira[2].

[1]
https://github.com/alphagov/pay-infra/pull/4913

[2]
https://payments-platform.atlassian.net/browse/PP-12853




