### PR TITLE
PP-12853 Add the charset in Content-Type header for Apple Pay

### DIFF
--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -108,19 +108,20 @@ module.exports = async (req, res) => {
       }
 
       const alternativeOptions = {
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
         httpsAgent: proxyAgent
       }
 
       try {
         const response = await axios.post(url, data, alternativeOptions)
 
-        logger.info('Apple Pay session successfully generated via axios')
+        logger.info('Apple Pay session successfully generated via axios and https proxy agent')
         res.status(200).send(response.data)
       } catch (error) {
         logger.info('Error generating Apple Pay session', {
           ...getLoggingFields(req),
-          error: error.message
+          error: error.message,
+          status: error.response ? error.response.status : 'No status'
         })
         logger.info('Apple Pay session via axios and https proxy agent failed', 'Apple Pay Error')
         res.status(500).send('Apple Pay Error')

--- a/test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js
+++ b/test/controllers/web-payments/apple-pay/merchant-validation.controller.test.js
@@ -108,7 +108,7 @@ describe('Validate with Apple the merchant is legitimate', () => {
           initiativeContext: merchantDomain
         }),
         sinon.match({
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
           httpsAgent: sinon.match.instanceOf(HttpsProxyAgent)
         })
       )
@@ -145,7 +145,7 @@ describe('Validate with Apple the merchant is legitimate', () => {
           initiativeContext: merchantDomain
         }),
         sinon.match({
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
           httpsAgent: sinon.match.instanceOf(HttpsProxyAgent)
         })
       )
@@ -197,7 +197,7 @@ describe('Validate with Apple the merchant is legitimate', () => {
           initiativeContext: merchantDomain
         }),
         sinon.match({
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
           httpsAgent: sinon.match.instanceOf(HttpsProxyAgent)
         })
       )


### PR DESCRIPTION
With the previous PR[1], we have made some progress in communicating with Apple Pay via Axios and HttpsProxyAgent and we have tested that the validation is initiated correctly but then fails with the following message from Apple: `Apple Pay Merchant ID not valid`.

See screenshot in the new PR[2].

With this change, we are now adding the charset to the Content-Type header in the post request, in case that is what is expected by Apple Pay, and we are also adding the status to the error log, to have a little bit more information back.

Further information in JIRA[3].

[1]
https://github.com/alphagov/pay-frontend/pull/3885

[2]
https://github.com/alphagov/pay-frontend/pull/3886

[3]
https://payments-platform.atlassian.net/browse/PP-12853

## SCREENSHOT

<img width="1163" alt="error from apple" src="https://github.com/user-attachments/assets/d4002fb6-80e2-46a0-8057-55443ddf0bda">

