### PR TITLE
Pass cert and key to proxy agent for Apple Pay validation

### DIFF
--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -60,7 +60,13 @@ module.exports = async (req, res) => {
     key: merchantIdentityVars.key
   });
 
-  const proxyAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl) : null
+  const proxyAgentOptions = {
+    cert: merchantIdentityVars.cert,
+    key: merchantIdentityVars.key
+  };
+
+  const proxyAgent = proxyUrl ? new HttpsProxyAgent(proxyUrl, proxyAgentOptions) : null;
+
   if (proxyUrl) {
     logger.info('Using proxy URL')
   }


### PR DESCRIPTION
With the previous PRs[1][2], we have made some progress in communicating with Apple Pay via Axios and HttpsProxyAgent and we have tested that the validation is initiated correctly but then fails with the following message from Apple: `Apple Pay Merchant ID not valid`.

See screenshot in the second PR[2].

With this change, we are now passing the certificate and key to the Proxy Agent via additional options.

Further information in JIRA[3].

[1]
https://github.com/alphagov/pay-frontend/pull/3885

[2]
https://github.com/alphagov/pay-frontend/pull/3886

[3]
https://payments-platform.atlassian.net/browse/PP-12853



