### PR TITLE
Update path in static files for Apple Pay association file

### DIFF
--- a/server.js
+++ b/server.js
@@ -129,7 +129,7 @@ function initialiseTemplateEngine (app) {
 }
 
 function initialisePublic (app) {
-  app.use('/.well-known/apple-developer-merchantid-domain-association.txt', express.static(path.join(__dirname, `/app/assets/apple-pay/${process.env.ENVIRONMENT}/apple-developer-merchantid-domain-association.txt`)))
+  app.use('/.well-known/apple-developer-merchantid-domain-association.txt', express.static(path.join(__dirname, `/app/assets/apple-pay/${process.env.ENVIRONMENT}/.well-known/apple-developer-merchantid-domain-association.txt`)))
   app.use('/public/worldpay', worldpayIframe, express.static(path.join(__dirname, '/public/worldpay/'), publicCaching))
   app.use('/public', express.static(path.join(__dirname, '/public'), publicCaching))
   app.use('/public', express.static(path.join(__dirname, '/app/data'), publicCaching))


### PR DESCRIPTION
With this change, we are updating the path where the Apple Pay association file needs to be placed in order for the pay-frontend application to serve it as a static file so that Apple can verify our domain.

This change will be made in the instructions of the Pay Team manual too[1], at the step no. 8 of the section `Testing Apple Pay locally for Stripe`, linked below[2].

[1]
https://github.com/alphagov/pay-team-manual/pull/2148

[2]
https://manual.payments.service.gov.uk/manual/how-to/test-apple-and-google-pay.html#testing-apple-pay-locally-for-stripe


