### PR TITLE
Use `hpagent` with `axios` for Apple Pay Merchant Validation with egress proxy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -114,7 +118,7 @@
         "filename": "app/controllers/web-payments/apple-pay/merchant-validation.controller.js",
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 19
       }
     ],
     "test/controllers/web-payments/apple-pay/normalise-apple-pay-payload.test.js": [
@@ -385,5 +389,5 @@
       }
     ]
   },
-  "generated_at": "2024-07-30T15:02:23Z"
+  "generated_at": "2024-08-09T08:40:47Z"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "gaap-analytics": "^3.1.0",
         "govuk-frontend": "^4.8.0",
         "helmet": "^7.1.0",
-        "https-proxy-agent": "^7.0.5",
+        "hpagent": "^1.2.0",
         "i18n": "0.15.x",
         "lodash": "4.17.x",
         "mailcheck": "^1.1.1",
@@ -2831,6 +2831,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
       "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -8879,6 +8880,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -9002,18 +9011,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
       "dev": true
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/human-signals": {
       "version": "1.1.1",
@@ -14782,9 +14779,9 @@
       }
     },
     "node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
     },
     "node_modules/sshpk": {
@@ -19130,6 +19127,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
       "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
       "requires": {
         "debug": "^4.3.4"
       }
@@ -23848,6 +23846,11 @@
         }
       }
     },
+    "hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="
+    },
     "html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -23940,15 +23943,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
       "dev": true
-    },
-    "https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
-      "requires": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      }
     },
     "human-signals": {
       "version": "1.1.1",
@@ -28420,9 +28414,9 @@
       "dev": true
     },
     "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
     },
     "sshpk": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "gaap-analytics": "^3.1.0",
     "govuk-frontend": "^4.8.0",
     "helmet": "^7.1.0",
-    "https-proxy-agent": "^7.0.5",
+    "hpagent": "^1.2.0",
     "i18n": "0.15.x",
     "lodash": "4.17.x",
     "mailcheck": "^1.1.1",


### PR DESCRIPTION
With this change, we have update the Apple Pay Merchant Validation implementation in order to use `hpagent` and `axios` in the presence of an egress proxy, as it's the case on our AWS environments.

This is needed because we want to remove the use of `requestretry`, however `axios` has a problem preventing it from working with an egress proxy[1].

For this reason, we need to use an HttpsProxyAgent with it.

We would want to use `https-proxy-agent`, however it has its own problem[2].

While we wait for these issues to be fixed, we can use `hpagent` which has been tested and works well with an egress proxy.

Further information in the JIRA ticket[3].

[1]
https://github.com/axios/axios/issues/4531

[2]
https://github.com/TooTallNate/proxy-agents/pull/235

[3]
https://payments-platform.atlassian.net/browse/PP-12853


Co-authored-by: Jonathan Harden <jonathan.harden@digital.cabinet-office.gov.uk>
Co-authored-by: Dominic Belcher <dominic.belcher@digital.cabinet-office.gov.uk>
Co-authored-by: Marco Tranchino <marco.tranchino@digital.cabinet-office.gov.uk>
