### PR TITLE
PP-10104 payment page validation bugs

### DIFF
--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -123,7 +123,7 @@ var init = function () {
   var addHighlightError = function (addType, error) {
     var listElement = document.createElement('li')
     var errorAnchor = document.createElement('a')
-    errorAnchor.setAttribute('href', '#' + error.cssKey + '-lbl')
+    errorAnchor.setAttribute('href', '#' + error.cssKey)
     errorAnchor.id = error.cssKey + '-error'
     errorAnchor.innerText = error.value
     listElement.appendChild(errorAnchor)

--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -125,13 +125,14 @@ var init = function () {
     var errorAnchor = document.createElement('a')
     errorAnchor.setAttribute('href', '#' + error.cssKey)
     errorAnchor.id = error.cssKey + '-error'
-    errorAnchor.innerText = error.value
-    listElement.appendChild(errorAnchor)
-
-    if (addType === 'append') {
-      document.getElementsByClassName('govuk-error-summary__list')[0].appendChild(listElement)
-    } else {
-      document.getElementsByClassName('govuk-error-summary__list')[0].insertBefore(listElement, parent.firstChild)
+    if(!document.getElementById(errorAnchor.id)){
+      errorAnchor.innerText = error.value
+      listElement.appendChild(errorAnchor)
+      if (addType === 'append') {
+        document.getElementsByClassName('govuk-error-summary__list')[0].appendChild(listElement)
+      } else {
+        document.getElementsByClassName('govuk-error-summary__list')[0].insertBefore(listElement, parent.firstChild)
+      }
     }
   }
 

--- a/app/utils/charge-validation-fields.js
+++ b/app/utils/charge-validation-fields.js
@@ -155,7 +155,8 @@ function containsSuspectedCVV (input) {
 
 // Must be bound prior to use
 function cardNo (cardNo) {
-  if (!cardNo) return 'message' // default message
+  const numbersAndSpacesOnly = /^[\d ]+$/;
+  if (!cardNo || !numbersAndSpacesOnly.test(cardNo)) return 'message' // default message
   cardNo = cardNo.replace(/\D/g, '')
   const cardType = creditCardType(cardNo)
   if (!cardNo || cardNo.length < 12 || cardNo.length > 19) return 'numberIncorrectLength'

--- a/app/utils/charge-validation.js
+++ b/app/utils/charge-validation.js
@@ -6,15 +6,6 @@ const changeCase = require('change-case')
 // Local dependencies
 const chargeValidationFields = require('./charge-validation-fields')
 
-// Constants
-const CUSTOM_ERRORS = {
-  expiryYear: {
-    skip: true
-  },
-  expiryMonth: {
-    cssKey: 'expiry-date'
-  }
-}
 
 module.exports = (translations, logger, Card, chargeOptions = { collect_billing_address: true }) => {
   const validations = chargeValidationFields(Card, chargeOptions)
@@ -48,7 +39,7 @@ module.exports = (translations, logger, Card, chargeOptions = { collect_billing_
         const messageTemplate = translations.generic
         const problem = value || isOptional ? translation[customValidation] : messageTemplate.replace('%s', translation.name)
         // Push to Error Fields
-        const customError = CUSTOM_ERRORS[name] || {}
+        const customError = name === "expiryYear" ? {skip: true} : {}
         const cssKey = customError.cssKey || changeCase.paramCase(name)
         if (!customError.skip) checkResult.errorFields.push({ cssKey, key: name, value: problem })
         // Push to Highlight Fields

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -187,8 +187,8 @@
                   </label>
                   {% if highlightErrorFields.cardNo %}
                     <p class="govuk-error-message" id="error-card-no">
+                      <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                       {{ highlightErrorFields.cardNo }}
-                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cardNo }}</span>
                     </p>
                   {% endif %}
 
@@ -260,8 +260,8 @@
                     </div>
                     {% if highlightErrorFields.expiryMonth %}
                       <p class="govuk-error-message" id="error-expiry-date">
+                        <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                         {{ highlightErrorFields.expiryMonth }}
-                        <span class="govuk-visually-hidden">{{ highlightErrorFields.expiryMonth }}</span>
                       </p>
                     {% endif %}
                     <div class="govuk-date-input__item govuk-date-input__item--month govuk-date-input__item--with-separator">
@@ -310,8 +310,8 @@
 
                   {% if highlightErrorFields.cardholderName %}
                     <p class="govuk-error-message" id="error-cardholder-name">
+                      <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                       {{ highlightErrorFields.cardholderName }}
-                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cardholderName }}</span>
                     </p>
                   {% endif %}
 
@@ -349,8 +349,8 @@
 
                   {% if highlightErrorFields.cvc %}
                     <p class="govuk-error-message" id="error-cvc">
+                      <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                       {{ highlightErrorFields.cvc }}
-                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cvc }}</span>
                     </p>
                   {% endif %}
 
@@ -401,8 +401,8 @@
 
                           {% if highlightErrorFields.addressLine1 %}
                             <p class="govuk-error-message" id="error-address-line-1">
+                              <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                               {{ highlightErrorFields.addressLine1 }}
-                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressLine1 }}</span>
                             </p>
                           {% endif %}
 
@@ -455,8 +455,8 @@
 
                           {% if highlightErrorFields.addressCity %}
                             <p class="govuk-error-message" id="error-address-city">
+                              <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                               {{ highlightErrorFields.addressCity }}
-                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressCity }}</span>
                             </p>
                           {% endif %}
 
@@ -481,8 +481,8 @@
 
                           {% if highlightErrorFields.addressCountry %}
                             <p class="govuk-error-message" id="error-address-country">
+                              <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                               {{ highlightErrorFields.addressCountry }}
-                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressCountry }}</span>
                             </p>
                           {% endif %}
 
@@ -511,8 +511,8 @@
 
                           {% if highlightErrorFields.addressPostcode %}
                               <p class="govuk-error-message" id="error-address-postcode">
+                                <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                                 {{ highlightErrorFields.addressPostcode }}
-                                <span class="govuk-visually-hidden">{{ highlightErrorFields.addressPostcode }}</span>
                               </p>
                           {% endif %}
 
@@ -551,8 +551,8 @@
 
                           {% if highlightErrorFields.email %}
                               <p class="govuk-error-message" id="error-email">
+                                <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                                 {{ highlightErrorFields.email }}
-                                <span class="govuk-visually-hidden">{{ highlightErrorFields.email }}</span>
                               </p>
                             {% endif %}
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -188,6 +188,7 @@
                   {% if highlightErrorFields.cardNo %}
                     <p class="govuk-error-message" id="error-card-no">
                       {{ highlightErrorFields.cardNo }}
+                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cardNo }}</span>
                     </p>
                   {% endif %}
 
@@ -260,6 +261,7 @@
                     {% if highlightErrorFields.expiryMonth %}
                       <p class="govuk-error-message" id="error-expiry-date">
                         {{ highlightErrorFields.expiryMonth }}
+                        <span class="govuk-visually-hidden">{{ highlightErrorFields.expiryMonth }}</span>
                       </p>
                     {% endif %}
                     <div class="govuk-date-input__item govuk-date-input__item--month govuk-date-input__item--with-separator">
@@ -309,6 +311,7 @@
                   {% if highlightErrorFields.cardholderName %}
                     <p class="govuk-error-message" id="error-cardholder-name">
                       {{ highlightErrorFields.cardholderName }}
+                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cardholderName }}</span>
                     </p>
                   {% endif %}
 
@@ -347,6 +350,7 @@
                   {% if highlightErrorFields.cvc %}
                     <p class="govuk-error-message" id="error-cvc">
                       {{ highlightErrorFields.cvc }}
+                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cvc }}</span>
                     </p>
                   {% endif %}
 
@@ -398,6 +402,7 @@
                           {% if highlightErrorFields.addressLine1 %}
                             <p class="govuk-error-message" id="error-address-line-1">
                               {{ highlightErrorFields.addressLine1 }}
+                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressLine1 }}</span>
                             </p>
                           {% endif %}
 
@@ -451,6 +456,7 @@
                           {% if highlightErrorFields.addressCity %}
                             <p class="govuk-error-message" id="error-address-city">
                               {{ highlightErrorFields.addressCity }}
+                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressCity }}</span>
                             </p>
                           {% endif %}
 
@@ -476,6 +482,7 @@
                           {% if highlightErrorFields.addressCountry %}
                             <p class="govuk-error-message" id="error-address-country">
                               {{ highlightErrorFields.addressCountry }}
+                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressCountry }}</span>
                             </p>
                           {% endif %}
 
@@ -505,6 +512,7 @@
                           {% if highlightErrorFields.addressPostcode %}
                               <p class="govuk-error-message" id="error-address-postcode">
                                 {{ highlightErrorFields.addressPostcode }}
+                                <span class="govuk-visually-hidden">{{ highlightErrorFields.addressPostcode }}</span>
                               </p>
                           {% endif %}
 
@@ -544,6 +552,7 @@
                           {% if highlightErrorFields.email %}
                               <p class="govuk-error-message" id="error-email">
                                 {{ highlightErrorFields.email }}
+                                <span class="govuk-visually-hidden">{{ highlightErrorFields.email }}</span>
                               </p>
                             {% endif %}
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -181,12 +181,10 @@
                   <label id="card-no-lbl" for="card-no" class="govuk-label govuk-label--s govuk-!-width-three-quarters">
                     <span
                         class="card-no-label"
-                        data-label-replace="cardNo"
                         data-original-label="{{ __p("cardDetails.cardNo") }}">
                       {{ __p("cardDetails.cardNo") }}
                     </span>
                   </label>
-
                   {% if highlightErrorFields.cardNo %}
                     <p class="govuk-error-message" id="error-card-no">
                       {{ highlightErrorFields.cardNo }}
@@ -204,12 +202,15 @@
                   <p class="govuk-body accepted-cards-hint withdrawal-text govuk-!-margin-bottom-0">
                     {% if withdrawalText === 'debit_credit' %}
                       {{ __p("cardDetails.withdrawalText").debit_credit }}
+                      <span data-label-replace="cardNo"></span>
                     {% endif %}
                     {% if withdrawalText === 'debit' %}
                       {{ __p("cardDetails.withdrawalText").debit }}
+                      <span data-label-replace="cardNo"></span>
                     {% endif %}
                     {% if withdrawalText === 'credit' %}
                       {{ __p("cardDetails.withdrawalText").credit }}
+                      <span data-label-replace="cardNo"></span>
                     {% endif %}
                   </p>
 
@@ -247,14 +248,14 @@
                     <legend>
                       <div class="govuk-label govuk-label--s" id="expiry-date-lbl" for="expiry-month">
                         <span class="expiry-date-label"
-                  data-label-replace="expiryMonth"
                   data-original-label="{{ __p("cardDetails.expiry") }}">
                           {{ __p("cardDetails.expiry") }}
                         </span>
                       </div>
                     </legend>
-                    <div class="govuk-hint govuk-!-margin-bottom-2" id="expiry-date-hint">
+                    <div class="govuk-hint govuk-!-margin-bottom-0" id="expiry-date-hint">
                       {{ __p("cardDetails.expiryHint", exampleCardExpiryDateYear) }}
+                      <span data-label-replace="expiryMonth"></span>
                     </div>
                     {% if highlightErrorFields.expiryMonth %}
                       <p class="govuk-error-message" id="error-expiry-date">
@@ -323,7 +324,7 @@
 
                 <div class="govuk-form-group{% if highlightErrorFields.cvc %} govuk-form-group--error{% endif %} cvc govuk-clearfix" data-validation="cvc">
                   <label id="cvc-lbl" for="cvc" class="govuk-label govuk-label--s">
-                    <span class="cvc-label" data-label-replace="cvc" data-original-label="{{ __p("cardDetails.cvc") }}">
+                    <span class="cvc-label" data-original-label="{{ __p("cardDetails.cvc") }}" >
                       {{ __p("cardDetails.cvc") }}
                     </span>
                   </label>
@@ -331,6 +332,7 @@
                   <div class="govuk-hint govuk-!-margin-bottom-2">
                     <span class="generic-cvc">
                       {{ __p("cardDetails.cvcTip") }}
+                    <span data-label-replace="cvc"></span>
                     </span>
                     <span class="amex-cvc hidden">
                       <span class="hidden">

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -103,6 +103,7 @@
 	"fieldErrors": {
 		"summary": "Mae’r meysydd canlynol yn wag neu yn cynnwys camgymeriadau",
 		"generic": "Rhowch %s dilys",
+		"visuallyHiddenError": "Gwall:",
 		"fields": {
 			"cardholderName": {
 				"name": "enw",

--- a/locales/en.json
+++ b/locales/en.json
@@ -100,6 +100,7 @@
 	"fieldErrors": {
 		"summary": "The following fields are missing or contain errors",
 		"generic": "Enter a valid %s",
+		"visuallyHiddenError": "Error:",
 		"fields": {
 			"cardholderName": {
 				"name": "name",

--- a/test/cypress/integration/card/card-details-page-validation.test.cy.js
+++ b/test/cypress/integration/card/card-details-page-validation.test.cy.js
@@ -18,7 +18,7 @@ describe('Card details page validation', () => {
     cy.get('#error-summary-title').should(($td) => expect($td).to.contain('The following fields are missing or contain errors'))
     cy.get('#cardholder-name-error').should('exist')
     cy.get('#cvc-error').should('exist')
-    cy.get('#expiry-date-error').should('exist')
+    cy.get('#expiry-month-error').should('exist')
     cy.get('#address-line-1-error').should('exist')
     cy.get('#address-city-error').should('exist')
     cy.get('#address-postcode-error').should('exist')

--- a/test/integration/card-details-errors.ft.test.js
+++ b/test/integration/card-details-errors.ft.test.js
@@ -256,7 +256,7 @@ describe('chargeTests', function () {
           }
           expect($('#card-no-error').text()).to.contains(errorMessages.cardNo)
           expect($('#error-card-no').text()).to.contains(errorMessages.cardNo)
-          expect($('#expiry-date-error').text()).to.contains(errorMessages.expiryDate)
+          expect($('#expiry-month-error').text()).to.contains(errorMessages.expiryDate)
           expect($('#error-expiry-date').text()).to.contains(errorMessages.expiryDate)
           expect($('#cardholder-name-error').text()).to.contains('Enter a valid name')
           expect($('#error-cardholder-name').text()).to.contains('Enter the name as it appears on the card')

--- a/test/utils/charge-validation-fields/card-number-field-validation.test.js
+++ b/test/utils/charge-validation-fields/card-number-field-validation.test.js
@@ -9,9 +9,9 @@ describe('card validation: card number', function () {
     expect(result).to.equal(true)
   })
 
-  it('should strip non numbers', function () {
+  it('should return invalid if cardNo contains non-numbers', function () {
     const result = fields.fieldValidations.cardNo('42424242424242dsakljl42')
-    expect(result).to.equal(true)
+    expect(result).to.equal('message')
   })
 
   it('should return incorrect length', function () {


### PR DESCRIPTION
## WHAT
Fixing payment page form validation bugs which do not work as per current Design system. Also added are a `<span>` tags with a class of  `"govuk-visually-hidden"` as per GOV.UK Design System.

## HOW 
### 1st Bug
1. Go to payment page.
2. Submit an empty form and the page shows the error summary at the top. 
3. When you click on each one you should be taken to the corresponding input.

### 2nd Bug
1. Go to the payment page.
2. Enter an invalid card number in the card number field.
3. The error message should appear after the hint text. 

### 3rd Bug
1. Go to the payment page.
2. Enter the following invalid card number in the card number field: 4444333322221111aaa
3. This should show an error.

### 4th Bug
1. Go to  the payment page
2. Submit an empty form.  The page displays the error summary at the top.
3. In the card number field, enter an invalid value and then press tab.
4. The error summary should not be duplicated.

N.B. Will squash on merging.