### PR TITLE
PP-10104 remaining payment page validation bug

### DIFF
--- a/app/assets/javascripts/browsered/form-validation.js
+++ b/app/assets/javascripts/browsered/form-validation.js
@@ -125,7 +125,7 @@ var init = function () {
     var errorAnchor = document.createElement('a')
     errorAnchor.setAttribute('href', '#' + error.cssKey)
     errorAnchor.id = error.cssKey + '-error'
-    if(!document.getElementById(errorAnchor.id)){
+    if (!document.getElementById(errorAnchor.id)) {
       errorAnchor.innerText = error.value
       listElement.appendChild(errorAnchor)
       if (addType === 'append') {
@@ -192,8 +192,14 @@ var init = function () {
       if (isAnExpiryDateField) {
         expiryMonthElement.classList.remove(CSS_ERROR_CLASS)
         expiryYearElement.classList.remove(CSS_ERROR_CLASS)
+        if (document.getElementById('expiry-month-error')) {
+          document.getElementById('expiry-month-error').remove()
+        }
       } else {
         input.classList.remove(CSS_ERROR_CLASS)
+        if (document.getElementById(`${input.id}-error`)) {
+          document.getElementById(`${input.id}-error`).remove()
+        }
       }
     }
   }

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -189,7 +189,6 @@
                     <p class="govuk-error-message" id="error-card-no">
                       <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                       {{ highlightErrorFields.cardNo }}
-                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cardNo }}</span>
                     </p>
                   {% endif %}
 
@@ -263,7 +262,6 @@
                       <p class="govuk-error-message" id="error-expiry-date">
                         <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                         {{ highlightErrorFields.expiryMonth }}
-                        <span class="govuk-visually-hidden">{{ highlightErrorFields.expiryMonth }}</span>
                       </p>
                     {% endif %}
                     <div class="govuk-date-input__item govuk-date-input__item--month govuk-date-input__item--with-separator">
@@ -314,7 +312,6 @@
                     <p class="govuk-error-message" id="error-cardholder-name">
                       <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                       {{ highlightErrorFields.cardholderName }}
-                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cardholderName }}</span>
                     </p>
                   {% endif %}
 
@@ -354,7 +351,6 @@
                     <p class="govuk-error-message" id="error-cvc">
                       <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                       {{ highlightErrorFields.cvc }}
-                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cvc }}</span>
                     </p>
                   {% endif %}
 
@@ -407,7 +403,6 @@
                             <p class="govuk-error-message" id="error-address-line-1">
                               <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                               {{ highlightErrorFields.addressLine1 }}
-                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressLine1 }}</span>
                             </p>
                           {% endif %}
 
@@ -462,7 +457,6 @@
                             <p class="govuk-error-message" id="error-address-city">
                               <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                               {{ highlightErrorFields.addressCity }}
-                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressCity }}</span>
                             </p>
                           {% endif %}
 
@@ -489,7 +483,6 @@
                             <p class="govuk-error-message" id="error-address-country">
                               <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                               {{ highlightErrorFields.addressCountry }}
-                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressCountry }}</span>
                             </p>
                           {% endif %}
 
@@ -520,7 +513,6 @@
                               <p class="govuk-error-message" id="error-address-postcode">
                                 <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                                 {{ highlightErrorFields.addressPostcode }}
-                                <span class="govuk-visually-hidden">{{ highlightErrorFields.addressPostcode }}</span>
                               </p>
                           {% endif %}
 
@@ -561,7 +553,6 @@
                               <p class="govuk-error-message" id="error-email">
                                 <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                                 {{ highlightErrorFields.email }}
-                                <span class="govuk-visually-hidden">{{ highlightErrorFields.email }}</span>
                               </p>
                             {% endif %}
 

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -189,6 +189,7 @@
                     <p class="govuk-error-message" id="error-card-no">
                       <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                       {{ highlightErrorFields.cardNo }}
+                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cardNo }}</span>
                     </p>
                   {% endif %}
 
@@ -262,6 +263,7 @@
                       <p class="govuk-error-message" id="error-expiry-date">
                         <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                         {{ highlightErrorFields.expiryMonth }}
+                        <span class="govuk-visually-hidden">{{ highlightErrorFields.expiryMonth }}</span>
                       </p>
                     {% endif %}
                     <div class="govuk-date-input__item govuk-date-input__item--month govuk-date-input__item--with-separator">
@@ -312,6 +314,7 @@
                     <p class="govuk-error-message" id="error-cardholder-name">
                       <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                       {{ highlightErrorFields.cardholderName }}
+                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cardholderName }}</span>
                     </p>
                   {% endif %}
 
@@ -351,6 +354,7 @@
                     <p class="govuk-error-message" id="error-cvc">
                       <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                       {{ highlightErrorFields.cvc }}
+                      <span class="govuk-visually-hidden">{{ highlightErrorFields.cvc }}</span>
                     </p>
                   {% endif %}
 
@@ -403,6 +407,7 @@
                             <p class="govuk-error-message" id="error-address-line-1">
                               <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                               {{ highlightErrorFields.addressLine1 }}
+                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressLine1 }}</span>
                             </p>
                           {% endif %}
 
@@ -457,6 +462,7 @@
                             <p class="govuk-error-message" id="error-address-city">
                               <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                               {{ highlightErrorFields.addressCity }}
+                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressCity }}</span>
                             </p>
                           {% endif %}
 
@@ -483,6 +489,7 @@
                             <p class="govuk-error-message" id="error-address-country">
                               <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                               {{ highlightErrorFields.addressCountry }}
+                              <span class="govuk-visually-hidden">{{ highlightErrorFields.addressCountry }}</span>
                             </p>
                           {% endif %}
 
@@ -513,6 +520,7 @@
                               <p class="govuk-error-message" id="error-address-postcode">
                                 <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                                 {{ highlightErrorFields.addressPostcode }}
+                                <span class="govuk-visually-hidden">{{ highlightErrorFields.addressPostcode }}</span>
                               </p>
                           {% endif %}
 
@@ -553,6 +561,7 @@
                               <p class="govuk-error-message" id="error-email">
                                 <span class="govuk-visually-hidden">{{ __p("fieldErrors.visuallyHiddenError") }}</span>
                                 {{ highlightErrorFields.email }}
+                                <span class="govuk-visually-hidden">{{ highlightErrorFields.email }}</span>
                               </p>
                             {% endif %}
 

--- a/test/cypress/integration/card/card-details-page-validation.test.cy.js
+++ b/test/cypress/integration/card/card-details-page-validation.test.cy.js
@@ -81,4 +81,22 @@ describe('Card details page validation', () => {
     cy.get('[data-cy=expiry-month]').not('have.class', 'govuk-input--error')
     cy.get('[data-cy=expiry-year]').not('have.class', 'govuk-input--error')
   })
+
+  it('Should remove summary field errors after clicking out of a correctly validated field', () => {
+    cy.task('setupStubs', createPaymentChargeStubs)
+    cy.visit(`/secure/${tokenId}`)
+
+    cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+    cy.window().its('chargeId').should('eq', `${chargeId}`)
+    
+    cy.get('[data-cy=cardholder-name]').invoke('val', '')
+    cy.get('#card-details').submit()
+    
+    cy.get('#cardholder-name-error').should('exist')
+
+    cy.get('[data-cy=cardholder-name]').clear().type('Jeff')
+    cy.get('[data-cy=expiry-month]').click()
+
+    cy.get('#cardholder-name-error').should('not.exist')
+  })
 })


### PR DESCRIPTION
## WHAT
Fixing same errors appearing multiple times after focus shifts to next item.

## HOW 
1. Submit an empty form.
2. See error messages above both inputs as well as in the summary fields above.
3. Fill out a field, e.g. the card number field, with valid data.
4. Tab out of the field to go to the next. 
5. There should now not be an error message above the data field and the corresponding error message should not be in the error summary at the top of the page. 

![Screenshot 2024-08-28 at 10 30 56](https://github.com/user-attachments/assets/47ac3530-3cbf-40c8-9285-7954dd9d376d)
![Screenshot 2024-08-28 at 10 31 15](https://github.com/user-attachments/assets/977fe7a1-006f-498c-854d-329a0cd6da4e)
![Screenshot 2024-08-28 at 10 31 31](https://github.com/user-attachments/assets/e4ecb5f6-157d-44ec-b7b5-717c3600a398)


N.B. Will squash on merging.
