### PR TITLE
PP-12828 Return 404 on /secure/{tokenId} when token is not found

### DIFF
--- a/app/controllers/secure.controller.js
+++ b/app/controllers/secure.controller.js
@@ -55,6 +55,10 @@ exports.new = async function (req, res) {
       res.redirect(303, generateRoute(resolveActionName(chargeStatus, 'get'), { chargeId }))
     }
   } catch (err) {
+    if (err.message === 'NOT_FOUND') {
+      logger.info(`Call to /secure/{tokenId} is invalid. Token not found for tokenId [${chargeTokenId}].`, getLoggingFields(req))
+      return responseRouter.response(req, res, 'NOT_FOUND')
+    }
     if (err.message === 'UNAUTHORISED') {
       logger.info('Call to /secure/{tokenId} is Unauthorised. This could be due to the token not existing, ' +
         'the frontend state cookie not existing, or the frontend state cookie containing an invalid value.',

--- a/app/models/charge.js
+++ b/app/models/charge.js
@@ -80,6 +80,9 @@ module.exports = correlationId => {
     } catch (err) {
       throw new Error('CLIENT_UNAVAILABLE', err)
     }
+    if (response.status === 404) {
+      throw new Error('NOT_FOUND')
+    }
     if (response.status !== 200) {
       throw new Error('UNAUTHORISED')
     }


### PR DESCRIPTION
## WHAT
 - return a `404` error on `/secure/{tokenId}` when the `tokenId` is not found in Connector.
 - This prevents a `403` being returned, which is returned by default for any non `200` response from Connector


