### PR TITLE
PP-13235: Removed all references to Mountebank

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ Run in two separate terminals:
 
 1. `npm run cypress:server`
 
-   _This runs both the Cypress server and Mountebank which is the virtualisation server used for stubbing out external
-   API calls._
+   _This runs both the Cypress server and @govuk-pay/run-amock which is the server used for stubbing out external API calls._
 
 2. Either:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
-        "@govuk-pay/run-amock": "0.0.3",
+        "@govuk-pay/run-amock": "0.0.4",
         "@pact-foundation/pact": "^12.1.1",
         "@pact-foundation/pact-core": "^14.0.5",
         "@snyk/protect": "^1.1235.x",
@@ -2170,9 +2170,9 @@
       }
     },
     "node_modules/@govuk-pay/run-amock": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.3.tgz",
-      "integrity": "sha512-01DmzFJLGG282DStWe6B1jyh3npV6F5f6IHjdRFve1HcI5TjkcKtEYK7eeNRK9gPhPYYptjXF5zqA9eB/C3nBg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.4.tgz",
+      "integrity": "sha512-4tq+yOQsI3pyUi7CiEJf7oqtr/1GLXjXI1//W/0ASTnHQX3SvX7dIowCzo2T3Tcf1JI2/IAVHN/HJrDmHR0nww==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -17831,9 +17831,9 @@
       }
     },
     "@govuk-pay/run-amock": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.3.tgz",
-      "integrity": "sha512-01DmzFJLGG282DStWe6B1jyh3npV6F5f6IHjdRFve1HcI5TjkcKtEYK7eeNRK9gPhPYYptjXF5zqA9eB/C3nBg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.4.tgz",
+      "integrity": "sha512-4tq+yOQsI3pyUi7CiEJf7oqtr/1GLXjXI1//W/0ASTnHQX3SvX7dIowCzo2T3Tcf1JI2/IAVHN/HJrDmHR0nww==",
       "dev": true
     },
     "@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
-    "@govuk-pay/run-amock": "0.0.3",
+    "@govuk-pay/run-amock": "0.0.4",
     "@pact-foundation/pact": "^12.1.1",
     "@pact-foundation/pact-core": "^14.0.5",
     "@snyk/protect": "^1.1235.x",

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -7,8 +7,7 @@ module.exports = (on, config) => {
   // common task definitions - used by all test specs
   on('task', {
     /**
-     * Makes a post request to Mountebank to setup an Imposter with stubs built using the array of
-     * stubs
+     * Makes a post request to @govuk-pay/run-amock to setup stubs built using the array of stubs
      *
      * Note: this task can only be called once per test, so all stubs for a test must be set up in
      * the same call.


### PR DESCRIPTION
Also included a tiny `run-amock` version bump.


