### PR TITLE
PP-12244: Upgrade deprecated actions/checkout to v4.2.2

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Detect secrets
         uses: alphagov/pay-ci/actions/detect-secrets@master
 


### PR DESCRIPTION
## WHAT
Upgrade `actions/checkout` to run on Node 20.


