### PR TITLE
PP-13360 move csrf middleware functions to pay-js-commons

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -14,7 +14,7 @@ const { log } = require('./controllers/client-side-logging.controller')
 const paths = require('./paths.js')
 
 // Express middleware
-const { csrfSetSecret, csrfCheck, csrfTokenGeneration } = require('./middleware/csrf.js')
+const { setSecret, generateToken, checkToken } = require('./middleware/csrf.js')
 const actionName = require('./middleware/action-name.js')
 const stateEnforcer = require('./middleware/state-enforcer.js')
 const retrieveCharge = require('./middleware/retrieve-charge.js')
@@ -43,9 +43,9 @@ exports.bind = function (app) {
   const card = paths.card
 
   const standardMiddlewareStack = [
-    csrfSetSecret,
-    csrfCheck,
-    csrfTokenGeneration,
+    setSecret,
+    checkToken,
+    generateToken,
     actionName,
     enforceSessionCookie,
     retrieveCharge,

--- a/app/utils/response-router.js
+++ b/app/utils/response-router.js
@@ -239,7 +239,7 @@ const actions = {
   }
 }
 
-exports.errorResponse = function errorReponse (req, res, reason, options = {}, error) {
+exports.errorResponse = function errorResponse (req, res, reason, options = {}, error) {
   const action = actions.ERROR
   logErrorPageShown(action.view, reason, getLoggingFields(req), error)
   options.viewName = 'ERROR'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-crypto/decrypt-node": "^1.0.3",
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-        "@govuk-pay/pay-js-commons": "^6.0.18",
+        "@govuk-pay/pay-js-commons": "^6.0.22",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "7.119.2",
         "cert-info": "^1.5.1",
@@ -19,7 +19,6 @@
         "client-sessions": "0.8.x",
         "compression": "1.7.x",
         "credit-card-type": "6.3.x",
-        "csrf": "3.1.x",
         "express": "4.21.2",
         "express-rate-limit": "^7.1.4",
         "gaap-analytics": "^3.1.0",
@@ -2124,11 +2123,12 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "6.0.18",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.18.tgz",
-      "integrity": "sha512-lWQByrDSjV8/AeSypkPSsYNdxejXWlBzIxOS/isbD3K2jkaB+ZurR1vWkVTnjSN9tED+rvqe9eBdEtMEtX3sBw==",
+      "version": "6.0.22",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.22.tgz",
+      "integrity": "sha512-b9Vt14mr/G+uSXK/1uWUQg73wrghRYA7vtNlpvW5WaMpippyI3a7osVLmRsKUphNC30YyPGXBXtfuwvOerYngA==",
       "dependencies": {
         "axios": "^1.6.5",
+        "csrf": "^3.1.0",
         "lodash": "4.17.21",
         "moment-timezone": "0.5.43",
         "rfc822-validate": "1.0.0",
@@ -17699,11 +17699,12 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "6.0.18",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.18.tgz",
-      "integrity": "sha512-lWQByrDSjV8/AeSypkPSsYNdxejXWlBzIxOS/isbD3K2jkaB+ZurR1vWkVTnjSN9tED+rvqe9eBdEtMEtX3sBw==",
+      "version": "6.0.22",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.22.tgz",
+      "integrity": "sha512-b9Vt14mr/G+uSXK/1uWUQg73wrghRYA7vtNlpvW5WaMpippyI3a7osVLmRsKUphNC30YyPGXBXtfuwvOerYngA==",
       "requires": {
         "axios": "^1.6.5",
+        "csrf": "^3.1.0",
         "lodash": "4.17.21",
         "moment-timezone": "0.5.43",
         "rfc822-validate": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "^6.0.18",
+    "@govuk-pay/pay-js-commons": "^6.0.22",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "7.119.2",
     "cert-info": "^1.5.1",
@@ -80,7 +80,6 @@
     "client-sessions": "0.8.x",
     "compression": "1.7.x",
     "credit-card-type": "6.3.x",
-    "csrf": "3.1.x",
     "express": "4.21.2",
     "express-rate-limit": "^7.1.4",
     "gaap-analytics": "^3.1.0",


### PR DESCRIPTION
## WHAT

- bump `pay-js-commons` `6.0.18` -> `6.0.22`
- move to `pay-js-commons` csrf middleware impl
- new `handleCsrfError` middleware to retain existing router behaviour



