### PR TITLE
PP-13509 Fix custom branding service alignment bug

### DIFF
--- a/app/views/includes/custom.njk
+++ b/app/views/includes/custom.njk
@@ -1,5 +1,5 @@
 <header class="govuk-header" role="banner" data-module="govuk-header" data-cy="header">
-  <div class="govuk-header__container govuk-width-container" data-cy="header-container" data-cy="header-container>
+  <div class="govuk-header__container govuk-width-container" data-cy="header-container" data-cy="header-container">
     <div class="govuk-header__logo">
       <span class="govuk-header__link--homepage">
         <span class="govuk-header__logotype">


### PR DESCRIPTION
- Bug is caused by an unclosed Cypress attribute that was added for Cypress testing.
- Closing the attribute fixes the issue.

![image](https://github.com/user-attachments/assets/23c7f06c-2b54-42fc-bdf8-9b84aaf9250e)



