### PR TITLE
PP-13377 show test payment notification on card payment screens

### DIFF
--- a/app/middleware/retrieve-charge.js
+++ b/app/middleware/retrieve-charge.js
@@ -20,6 +20,7 @@ module.exports = (req, res, next) => {
   Charge(req.headers[CORRELATION_HEADER]).find(chargeId, getLoggingFields(req))
     .then(data => {
       req.chargeData = data
+      res.locals.isTestPayment = data.gateway_account.type === 'test'
       setLoggingField(req, GATEWAY_ACCOUNT_ID, data.gateway_account.gateway_account_id)
       setLoggingField(req, GATEWAY_ACCOUNT_TYPE, data.gateway_account.type)
       setLoggingField(req, PROVIDER, data.payment_provider)

--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -85,7 +85,8 @@
   <div class="govuk-width-container govuk-main-wrapper">
     <div class="govuk-grid-row govuk-!-margin-bottom-9">
       <main class="charge-new govuk-grid-column-two-thirds" id="main-content" role="main">
-          <div class="charge-new__content">
+        {% include "includes/test-payment-notification-banner.njk" %}
+        <div class="charge-new__content">
               <div id="error-summary" data-cy="error-summary" class="govuk-error-summary {% if not hasError %}hidden{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
                 <h2 class="govuk-error-summary__title" id="error-summary-title">
                   {{ __p("fieldErrors.summary") }}

--- a/app/views/confirm.njk
+++ b/app/views/confirm.njk
@@ -10,6 +10,7 @@
   <div class="govuk-width-container govuk-main-wrapper">
     <div class="govuk-grid-row govuk-!-margin-bottom-9">
       <main class="govuk-grid-column-two-thirds confirm-page" id="main-content" role="main">
+        {% include "includes/test-payment-notification-banner.njk" %}
         <div class="confirm-page__content">
           <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">{{ __p("confirmDetails.title") }}</h1>
 
@@ -91,7 +92,7 @@
           ] %}
           {% endif %}
 
-          {% if (charge.gatewayAccount.emailCollectionMode === 'MANDATORY') 
+          {% if (charge.gatewayAccount.emailCollectionMode === 'MANDATORY')
             or(charge.gatewayAccount.emailCollectionMode === 'OPTIONAL' and charge.email) %}
             {% set emailArray = [
               [

--- a/app/views/includes/test-payment-notification-banner.njk
+++ b/app/views/includes/test-payment-notification-banner.njk
@@ -1,0 +1,14 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% if isTestPayment === true %}
+  {% set html %}
+    <p class="govuk-notification-banner__heading">
+      This is a test page. No money will be taken.
+    </p>
+    <p class="govuk-body">
+      Contact the service you’re trying to pay for if you are trying to make a payment.
+    </p>
+  {% endset %}
+  {{ govukNotificationBanner({
+    html: html
+  }) }}
+{% endif %}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,12 +1,13 @@
 {% extends "govuk/template.njk" %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% set htmlLang = language %}
 
 {% block head %}
-  {% if service and service.customBranding and service.customBranding.cssUrl  %}
-    <link href="{{ service.customBranding.cssUrl }}" media="all" rel="stylesheet" />
+  {% if service and service.customBranding and service.customBranding.cssUrl %}
+    <link href="{{ service.customBranding.cssUrl }}" media="all" rel="stylesheet"/>
   {% else %}
-    <link href="{{ css_path }}" media="all" rel="stylesheet" />
+    <link href="{{ css_path }}" media="all" rel="stylesheet"/>
   {% endif %}
 
   {% include "includes/analytics.njk" %}
@@ -48,11 +49,21 @@
         </div>
         <div class="govuk-header__content">
           <span class="govuk-header__service-name">
-            {{serviceName}}
+            {{ serviceName }}
           </span>
         </div>
       </div>
     </header>
+  {% endif %}
+  {% if isTestPayment %}
+    <div class="govuk-width-container">
+      {{ govukPhaseBanner({
+        tag: {
+          text: "Test service"
+        },
+        html: 'This is a test payment service.'
+      }) }}
+    </div>
   {% endif %}
 {% endblock %}
 
@@ -84,7 +95,7 @@
             <ul class="govuk-footer__inline-list merchant-details">
               <li class="govuk-footer__inline-list-item merchant-details-line-1">Service provided by {{ service.merchantDetails.name }}</li>
               {% if service.hasCompleteMerchantDetailsAddress %}
-              <li class="govuk-footer__inline-list-item merchant-details-line-2">{{ service.merchantDetails.addressLine1 }}, {% if service.merchantDetails.addressLine2 -%} {{ service.merchantDetails.addressLine2 }}, {% endif -%} {{ service.merchantDetails.city }} {{ service.merchantDetails.postcode }} {{ service.merchantDetails.countryName }}</li>
+                <li class="govuk-footer__inline-list-item merchant-details-line-2">{{ service.merchantDetails.addressLine1 }}, {% if service.merchantDetails.addressLine2 -%} {{ service.merchantDetails.addressLine2 }}, {% endif -%} {{ service.merchantDetails.city }} {{ service.merchantDetails.postcode }} {{ service.merchantDetails.countryName }}</li>
               {% endif %}
             </ul>
           {% endif %}

--- a/test/cypress/integration/card/test-payment-notification.test.cy.js
+++ b/test/cypress/integration/card/test-payment-notification.test.cy.js
@@ -1,0 +1,157 @@
+const cardPaymentStubs = require('../../utils/card-payment-stubs')
+const { adminUsersGetService } = require('../../utils/stub-builders/service-stubs')
+const {
+  connectorMultipleSubsequentChargeDetails,
+  connectorValidPatchConfirmedChargeDetails
+} = require('../../utils/stub-builders/charge-stubs')
+const { cardIdValidCardDetails } = require('../../utils/stub-builders/card-id-stubs')
+
+const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
+const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
+const validPayment = {
+  cardNumber: '4444333322221111',
+  expiryMonth: '01',
+  expiryYear: '30',
+  name: 'S. McDuck',
+  securityCode: '012',
+  addressLine1: 'McDuck Manor',
+  city: 'Duckburg',
+  postcode: 'SW1A 1AA',
+  email: 's.mcduck@example.com'
+}
+const createPaymentChargeStubsEnglish = (isLive) => {
+  return cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, 'en', 42, {}, {}, {
+    gatewayAccountType: isLive ? 'live' : 'test'
+  })
+}
+const checkCardDetailsStubs = (isLive) => {
+  return cardPaymentStubs.checkCardDetailsStubs(chargeId, 42, {
+    gatewayAccountType: isLive ? 'live' : 'test'
+  })
+}
+const confirmPaymentDetailsStubs = (isLive) => {
+  const gatewayAccountType = isLive ? 'live' : 'test'
+  return [
+    adminUsersGetService(),
+    connectorMultipleSubsequentChargeDetails([
+      {
+        chargeId,
+        status: 'AUTHORISATION READY',
+        state: { finished: false, status: 'started' },
+        gatewayAccountType
+      },
+      {
+        chargeId,
+        paymentDetails: validPayment,
+        status: 'AUTHORISATION READY',
+        state: { finished: false, status: 'submitted' },
+        gatewayAccountType
+      },
+      {
+        chargeId,
+        paymentDetails: validPayment,
+        status: 'AUTHORISATION SUCCESS',
+        state: { finished: false, status: 'submitted' },
+        gatewayAccountType
+      },
+      {
+        chargeId,
+        paymentDetails: validPayment,
+        status: 'AUTHORISATION SUCCESS',
+        state: { finished: false, status: 'submitted' },
+        gatewayAccountType
+      }
+    ]),
+    cardIdValidCardDetails(),
+    connectorValidPatchConfirmedChargeDetails(chargeId)
+  ]
+}
+
+
+
+describe('Card payment page', () => {
+  describe('A test payment', () => {
+    it('should show phase and notification banners', () => {
+      cy.task('setupStubs', createPaymentChargeStubsEnglish(false))
+      cy.visit(`/secure/${tokenId}`)
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      shouldCheckPhaseBanner()
+      shouldCheckNotificationBanner()
+      cy.task('clearStubs')
+      cy.task('setupStubs', checkCardDetailsStubs(false))
+      shouldEnterCardDetails()
+      cy.task('clearStubs')
+      cy.task('setupStubs', confirmPaymentDetailsStubs(false))
+      cy.get('#card-details').submit()
+      cy.location('pathname').should('eq', `/card_details/${chargeId}/auth_waiting`)
+      shouldCheckPhaseBanner()
+      cy.get('p.lede').should('exist')
+      cy.location('pathname').should('eq', `/card_details/${chargeId}/confirm`)
+      shouldCheckPhaseBanner()
+      shouldCheckNotificationBanner()
+      cy.get('#expiry-date').should(($td) => expect($td).to.contain(`${validPayment.expiryMonth}/${validPayment.expiryYear}`))
+      cy.get('#cardholder-name').should(($td) => expect($td).to.contain(validPayment.name))
+    })
+  })
+  describe('A live payment', () => {
+    it('should not show phase and notification banners', () => {
+      cy.task('setupStubs', createPaymentChargeStubsEnglish(true))
+      cy.visit(`/secure/${tokenId}`)
+      cy.location('pathname').should('eq', `/card_details/${chargeId}`)
+      cy.get('.govuk-phase-banner')
+        .should('not.exist')
+      cy.get('.govuk-notification-banner')
+        .should('not.exist')
+      cy.task('clearStubs')
+      cy.task('setupStubs', checkCardDetailsStubs(true))
+      shouldEnterCardDetails()
+      cy.task('clearStubs')
+      cy.task('setupStubs', confirmPaymentDetailsStubs(true))
+      cy.get('#card-details').submit()
+      cy.location('pathname').should('eq', `/card_details/${chargeId}/auth_waiting`)
+      cy.get('.govuk-phase-banner')
+        .should('not.exist')
+      cy.get('p.lede').should('exist')
+      cy.location('pathname').should('eq', `/card_details/${chargeId}/confirm`)
+      cy.get('.govuk-phase-banner')
+        .should('not.exist')
+      cy.get('.govuk-notification-banner')
+        .should('not.exist')
+      cy.get('#expiry-date').should(($td) => expect($td).to.contain(`${validPayment.expiryMonth}/${validPayment.expiryYear}`))
+      cy.get('#cardholder-name').should(($td) => expect($td).to.contain(validPayment.name))
+    })
+  })
+})
+
+function shouldCheckPhaseBanner () {
+  cy.get('.govuk-phase-banner')
+    .should('exist')
+    .should('contain.text', 'Test service')
+    .should('contain.text', 'This is a test payment service.')
+}
+
+function shouldCheckNotificationBanner () {
+  cy.get('.govuk-notification-banner')
+    .should('exist')
+    .find('p.govuk-notification-banner__heading')
+    .should('contain.text', 'This is a test page. No money will be taken.')
+    .parent()
+    .find('p.govuk-body')
+    .should('contain.text', 'Contact the service you’re trying to pay for if you are trying to make a payment.')
+}
+
+function shouldEnterCardDetails () {
+  cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
+  cy.log('Should enter card details')
+  cy.get('#card-no').type(validPayment.cardNumber)
+  cy.get('#card-no').blur()
+  cy.wait('@checkCard')
+  cy.get('#expiry-month').type(validPayment.expiryMonth)
+  cy.get('#expiry-year').type(validPayment.expiryYear)
+  cy.get('#cardholder-name').type(validPayment.name)
+  cy.get('#cvc').type(validPayment.securityCode)
+  cy.get('#address-line-1').type(validPayment.addressLine1)
+  cy.get('#address-city').type(validPayment.city)
+  cy.get('#address-postcode').type(validPayment.postcode)
+  cy.get('#email').type(validPayment.email)
+}

--- a/test/cypress/utils/card-payment-stubs.js
+++ b/test/cypress/utils/card-payment-stubs.js
@@ -96,7 +96,8 @@ function buildCreatePaymentChargeStubs (tokenId, chargeId, language = 'en', gate
       emailCollectionMode: gatewayAccountOpts.emailCollectionMode || 'MANDATORY',
       allowMoto: gatewayAccountOpts.allowMoto,
       motoMaskCardNumberInput: gatewayAccountOpts.motoMaskCardNumberInput,
-      motoMaskCardSecurityCodeInput: gatewayAccountOpts.motoMaskCardSecurityCodeInput
+      motoMaskCardSecurityCodeInput: gatewayAccountOpts.motoMaskCardSecurityCodeInput,
+      gatewayAccountType: gatewayAccountOpts.gatewayAccountType || 'test'
     }),
     cardIdValidCardDetails(),
     chargeStubs.connectorUpdateChargeStatus(chargeId),

--- a/test/cypress/utils/stub-builders/charge-stubs.js
+++ b/test/cypress/utils/stub-builders/charge-stubs.js
@@ -30,7 +30,7 @@ function connectorMultipleSubsequentChargeDetails (...chargesArr) {
     })
   })
 
-  const stub = {
+  return {
     predicates: [{
       equals: {
         method: 'GET',
@@ -39,7 +39,6 @@ function connectorMultipleSubsequentChargeDetails (...chargesArr) {
     }],
     responses: responseArray
   }
-  return stub
 }
 
 function connectorValidPatchConfirmedChargeDetails (chargeId) {


### PR DESCRIPTION
## WHAT

- update charge retrieval middleware to make `isTestPayment` available to all views
- show phase banner with test status when charge is for a test account
- show notification banner on card input and confirmation screens when charge is for a test account


## HOW 

- run cypress:test-headed and start the `test-payment-notification` test to see the difference between live and test

### SCREENS

#### LIVE (no change)

<img width="1017" alt="Screenshot 2025-01-23 at 18 18 36" src="https://github.com/user-attachments/assets/9a7135de-acf9-4c9f-9663-ff68fa85cfcd" />

<img width="1017" alt="Screenshot 2025-01-23 at 18 18 52" src="https://github.com/user-attachments/assets/99a4fbac-069d-4118-bcb2-a7be37547e5e" />

#### TEST (new banners)

<img width="1017" alt="Screenshot 2025-01-23 at 18 15 57" src="https://github.com/user-attachments/assets/789c58b3-ff2c-428c-b21c-0807d1c47b22" />

<img width="1017" alt="Screenshot 2025-01-23 at 18 17 43" src="https://github.com/user-attachments/assets/a6098338-c047-46b6-966f-e19734971385" />

