### PR TITLE
PP-12475 - Remove HTML5 polyfill and IE8 stylesheet references

### DIFF
--- a/app/views/auth-waiting.njk
+++ b/app/views/auth-waiting.njk
@@ -5,18 +5,6 @@
 {% endblock %}
 
 {% block head %}
-  {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md #}
-  <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" />
-  <![endif]-->
-
-  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-  <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
-
-
   {% if service and service.customBranding and service.customBranding.cssUrl  %}
     <link href="{{ service.customBranding.cssUrl }}" media="screen" rel="stylesheet" type="text/css" />
   {% else %}

--- a/app/views/capture-waiting.njk
+++ b/app/views/capture-waiting.njk
@@ -5,18 +5,6 @@
 {% endblock %}
 
 {% block head %}
-  {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md #}
-  <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" />
-  <![endif]-->
-
-  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-  <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
-
-
   {% if service and service.customBranding and service.customBranding.cssUrl  %}
     <link href="{{ service.customBranding.cssUrl }}" media="screen" rel="stylesheet" type="text/css" />
   {% else %}

--- a/app/views/errors/incorrect-state/capture-waiting.njk
+++ b/app/views/errors/incorrect-state/capture-waiting.njk
@@ -5,18 +5,6 @@
 {% endblock %}
 
 {% block head %}
-  {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md #}
-  <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" />
-  <![endif]-->
-
-  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-  <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
-
-
   {% if service and service.customBranding and service.customBranding.cssUrl  %}
     <link href="{{ service.customBranding.cssUrl }}" media="screen" rel="stylesheet" type="text/css" />
   {% else %}


### PR DESCRIPTION
- The HTML5 polyfill and IE8 stylesheet files have been removed previously.
- This commit removes the references to those files as they are no longer required
  - This is because we no longer provide full support to older that require these files.


