### PR TITLE
PP-13557: Using the latest release of Run Amock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
-        "@govuk-pay/run-amock": "0.0.5",
+        "@govuk-pay/run-amock": "0.0.9",
         "@pact-foundation/pact": "^12.1.1",
         "@pact-foundation/pact-core": "^14.0.5",
         "@snyk/protect": "^1.1235.x",
@@ -2170,9 +2170,9 @@
       }
     },
     "node_modules/@govuk-pay/run-amock": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.5.tgz",
-      "integrity": "sha512-hkchJmDAC+IzE4qwjF3t4P4Atxsov9tWbWHssVirEO30Pl+dMoKwZqjGNhWu80+wdGZ1KiC6xWcUWU5GtOTc4Q==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.9.tgz",
+      "integrity": "sha512-5XJybR2TBjENM1Lji5KqozDH9zPyBhmZbFK60vMIzzbuq12dcrx+NGQ3TIM77tAOZfsr/GL5vyMv9O98a45tcg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -17742,9 +17742,9 @@
       }
     },
     "@govuk-pay/run-amock": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.5.tgz",
-      "integrity": "sha512-hkchJmDAC+IzE4qwjF3t4P4Atxsov9tWbWHssVirEO30Pl+dMoKwZqjGNhWu80+wdGZ1KiC6xWcUWU5GtOTc4Q==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.9.tgz",
+      "integrity": "sha512-5XJybR2TBjENM1Lji5KqozDH9zPyBhmZbFK60vMIzzbuq12dcrx+NGQ3TIM77tAOZfsr/GL5vyMv9O98a45tcg==",
       "dev": true
     },
     "@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
-    "@govuk-pay/run-amock": "0.0.5",
+    "@govuk-pay/run-amock": "0.0.9",
     "@pact-foundation/pact": "^12.1.1",
     "@pact-foundation/pact-core": "^14.0.5",
     "@snyk/protect": "^1.1235.x",


### PR DESCRIPTION
## WHAT
After undoing a breaking change to Run Amock, this updates to the new latest (non-breaking) release of Run Amock.

This should be compatible with the existing tests.

Related PRs:

The change in Run Amock: https://github.com/alphagov/pay-run-amock/pull/16

Updates to other projects:
https://github.com/alphagov/pay-selfservice/pull/4439
https://github.com/alphagov/pay-products-ui/pull/2742


