### PR TITLE
PP-11093: Remove unused dev dependencies from pay-js-metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,30 +88,6 @@
         "node": "^18.20.4"
       }
     },
-    "../pay-js-metrics": {
-      "name": "@alphagov/pay-js-metrics",
-      "version": "1.0.1",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "on-finished": "^2.4.1",
-        "prom-client": "^14.2.0"
-      },
-      "devDependencies": {
-        "@tsconfig/node18-strictest": "^1.0.0",
-        "@types/express": "^4.17.17",
-        "@types/jest": "^29.5.3",
-        "@types/node": "^20.2.3",
-        "concurrently": "^8.2.0",
-        "express": "^4.18.2",
-        "jest": "^29.6.1",
-        "prettier": "2.8.8",
-        "supertest": "^6.3.3",
-        "ts-jest": "^29.1.1",
-        "ts-node": "^10.9.1",
-        "typescript": "^5.0.4"
-      }
-    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",


### PR DESCRIPTION
[Dev dependencies from pay-js-metrics](https://github.com/alphagov/pay-js-metrics/blob/main/package.json#L28) shouldn't be included.