### PR TITLE
PP-13984 Upgrade pay-frontend with newest pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@aws-crypto/decrypt-node": "^1.0.3",
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-        "@govuk-pay/pay-js-commons": "^6.0.36",
-        "@govuk-pay/pay-js-metrics": "^1.0.6",
+        "@govuk-pay/pay-js-commons": "^7.0.1",
+        "@govuk-pay/pay-js-metrics": "^1.0.13",
         "@sentry/node": "7.119.2",
         "cert-info": "^1.5.1",
         "change-case": "2.3.x",
@@ -2099,9 +2099,10 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "6.0.36",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.36.tgz",
-      "integrity": "sha512-1OpCMjm+kCW6mJbvIN6NF++HiYiO4cQEn+zrOfe/3beOjBqDmT4//YkGuzKGoJ0UU5F7olKo803Cwexectlhxg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.1.tgz",
+      "integrity": "sha512-ss1kNjxtlNJawlQu0CSBoOA6CEO55He/NLk9I10aC26do3323wM9lRz90f/aHSS2T9yXhAGxxTu+E55dx7CRbg==",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.6.5",
         "csrf": "^3.1.0",
@@ -2112,7 +2113,7 @@
         "winston": "3.9.0"
       },
       "engines": {
-        "node": "^18.17.1"
+        "node": "^22.15.0"
       }
     },
     "node_modules/@govuk-pay/pay-js-commons/node_modules/winston": {
@@ -2137,9 +2138,10 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-metrics": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.6.tgz",
-      "integrity": "sha512-v7uqZmMPozO8jMZ3GIOmv0BDVKYk3IEsOvmizXBJbuc/hKpMFq4y1Bc0vOnyPAzxVjnESUHDlCtvCErho5JQsA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.13.tgz",
+      "integrity": "sha512-RonGgB/AZU9Qj+fthUZmN+TpVNgenSMRFk4lO57VqYESLe4ukQBagVMaFPCn2bJFat1QEyb519IASOSiTXSaWg==",
+      "license": "MIT",
       "dependencies": {
         "on-finished": "^2.4.1",
         "prom-client": "^14.2.0"
@@ -17620,9 +17622,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "6.0.36",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.36.tgz",
-      "integrity": "sha512-1OpCMjm+kCW6mJbvIN6NF++HiYiO4cQEn+zrOfe/3beOjBqDmT4//YkGuzKGoJ0UU5F7olKo803Cwexectlhxg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.1.tgz",
+      "integrity": "sha512-ss1kNjxtlNJawlQu0CSBoOA6CEO55He/NLk9I10aC26do3323wM9lRz90f/aHSS2T9yXhAGxxTu+E55dx7CRbg==",
       "requires": {
         "axios": "^1.6.5",
         "csrf": "^3.1.0",
@@ -17654,9 +17656,9 @@
       }
     },
     "@govuk-pay/pay-js-metrics": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.6.tgz",
-      "integrity": "sha512-v7uqZmMPozO8jMZ3GIOmv0BDVKYk3IEsOvmizXBJbuc/hKpMFq4y1Bc0vOnyPAzxVjnESUHDlCtvCErho5JQsA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.13.tgz",
+      "integrity": "sha512-RonGgB/AZU9Qj+fthUZmN+TpVNgenSMRFk4lO57VqYESLe4ukQBagVMaFPCn2bJFat1QEyb519IASOSiTXSaWg==",
       "requires": {
         "on-finished": "^2.4.1",
         "prom-client": "^14.2.0"

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "^6.0.36",
-    "@govuk-pay/pay-js-metrics": "^1.0.6",
+    "@govuk-pay/pay-js-commons": "^7.0.1",
+    "@govuk-pay/pay-js-metrics": "^1.0.13",
     "@sentry/node": "7.119.2",
     "cert-info": "^1.5.1",
     "change-case": "2.3.x",


### PR DESCRIPTION
## WHAT

With this change, we are updating pay-frontend to use the new pay-js-commons.

We are also updating the version for pay-js-metrics.





