### PR TITLE
PP-14070 - Update footer to new design and use macro

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,5 +1,4 @@
 {% extends "govuk/template.njk" %}
-{% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% set htmlLang = language %}
@@ -54,51 +53,56 @@
 {% endblock %}
 
 {% block footer %}
-  <footer class="govuk-footer" role="contentinfo">
-    <div class="govuk-width-container">
-      <div class="govuk-footer__meta">
-        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-          <h2 class="govuk-visually-hidden">Support links</h2>
-          <ul class="govuk-footer__inline-list govuk-!-margin-bottom-6">
-            <li class="govuk-footer__inline-list-item">
-              Read our updated
-              <a class="govuk-footer__link" href="https://www.payments.service.gov.uk/privacy">
-                privacy notice
-              </a>
-            </li>
-            <li class="govuk-footer__inline-list-item">
-              <a class="govuk-footer__link" href="https://www.payments.service.gov.uk/accessibility-statement">
-                Accessibility Statement
-              </a>
-            </li>
-          </ul>
-          {% if service and service.merchantDetails and service.merchantDetails.name %}
-            <ul class="govuk-footer__inline-list merchant-details">
-              <li class="govuk-footer__inline-list-item merchant-details-line-1">Service provided by {{ service.merchantDetails.name }}</li>
-              {% if service.hasCompleteMerchantDetailsAddress %}
-                <li class="govuk-footer__inline-list-item merchant-details-line-2">{{ service.merchantDetails.addressLine1 }}, {% if service.merchantDetails.addressLine2 -%} {{ service.merchantDetails.addressLine2 }}, {% endif -%} {{ service.merchantDetails.city }} {{ service.merchantDetails.postcode }} {{ service.merchantDetails.countryName }}</li>
-              {% endif %}
-            </ul>
-          {% endif %}
-          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-            <path
-              fill="currentColor"
-              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-            />
-          </svg>
-          <span class="govuk-footer__licence-description">
-            All content is available under the
-            <a
-              class="govuk-footer__link"
-              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-              rel="license"
-            >Open Government Licence v3.0</a>, except where otherwise stated
-          </span>
-        </div>
-        <div class="govuk-footer__meta-item">
-          <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
-        </div>
-      </div>
-    </div>
-  </footer>
+  {% if service and service.merchantDetails and service.merchantDetails.name %}
+    {% set footerMetaText = 'Service provided by ' + service.merchantDetails.name %}
+    
+    {% if service.merchantDetails.addressLine1 %}
+      {% set footerMetaText = footerMetaText + ', ' + service.merchantDetails.addressLine1 %}
+    {% endif %}
+    
+    {% if service.merchantDetails.addressLine2 %}
+      {% set footerMetaText = footerMetaText + ', ' + service.merchantDetails.addressLine2 %}
+    {% endif %}
+
+    {% if service.merchantDetails.city %}
+      {% set footerMetaText = footerMetaText + ', ' + service.merchantDetails.city %}
+    {% endif %}
+
+    {% if service.merchantDetails.postcode %}
+      {% set footerMetaText = footerMetaText + ', ' + service.merchantDetails.postcode %}
+    {% endif %}
+
+    {% if service.merchantDetails.countryName %}
+      {% set footerMetaText = footerMetaText + ', ' + service.merchantDetails.countryName %}
+    {% endif %}
+  {% else %}
+    {% set footerMetaText = '' %}
+  {% endif %}
+
+  {{ govukFooter({
+    meta: {
+      items: [
+        {
+          text: 'Privacy notice',
+          href: 'https://www.payments.service.gov.uk/privacy'
+        },
+        {
+          text: 'reCAPTCHA notice',
+          href: 'https://www.payments.service.gov.uk/recaptcha-notice'
+        },
+        {
+          text: 'Cookies',
+          href: 'https://www.payments.service.gov.uk/cookies'
+        },
+        {
+          text: 'Accessibility statement',
+          href: 'https://www.payments.service.gov.uk/accessibility-statement/'
+        }
+      ],
+      text: footerMetaText
+    },
+    attributes : {
+        'data-cy': 'footer'
+      }
+  }) }}
 {% endblock %}

--- a/test/cypress/integration/card/footer.test.cy.js
+++ b/test/cypress/integration/card/footer.test.cy.js
@@ -24,9 +24,19 @@ describe('The footer displayed on payment pages', () => {
     cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
-    cy.get('.merchant-details').should('exist')
-    cy.get('.merchant-details-line-1').should('have.text', 'Service provided by Org')
-    cy.get('.merchant-details-line-2').should('have.text', 'Street, Borough, City AW1H 9UX United Kingdom')
+    cy.get('[data-cy=footer]')
+      .find('.govuk-footer__inline-list .govuk-footer__link')
+      .should('have.length', 4)
+      .then(($elements) => {
+        expect($elements.eq(0).text()).to.contain('Privacy notice')
+        expect($elements.eq(1).text()).to.contain('reCAPTCHA notice')
+        expect($elements.eq(2).text()).to.contain('Cookies')
+        expect($elements.eq(3).text()).to.contain('Accessibility statement')
+      })
+
+    cy.get('[data-cy=footer]')
+      .find('.govuk-footer__meta-custom')
+      .should('contain', 'Service provided by Org, Street, Borough, City, AW1H 9UX, United Kingdom')
   })
 
   it('should display the service name and address when service does not have a second line', () => {
@@ -45,9 +55,9 @@ describe('The footer displayed on payment pages', () => {
     cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
-    cy.get('.merchant-details').should('exist')
-    cy.get('.merchant-details-line-1').should('have.text', 'Service provided by Org')
-    cy.get('.merchant-details-line-2').should('have.text', 'Street, City AW1H 9UX United Kingdom')
+    cy.get('[data-cy=footer]')
+      .find('.govuk-footer__meta-custom')
+      .should('contain', 'Service provided by Org, Street, City, AW1H 9UX, United Kingdom')
   })
 
   it('should display just the service name when mandatory address fields are missing', () => {
@@ -65,9 +75,9 @@ describe('The footer displayed on payment pages', () => {
     cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
-    cy.get('.merchant-details').should('exist')
-    cy.get('.merchant-details-line-1').should('have.text', 'Service provided by Org')
-    cy.get('.merchant-details-line-2').should('not.exist')
+    cy.get('[data-cy=footer]')
+      .find('.govuk-footer__meta-custom')
+      .should('contain', 'Service provided by Org, City, AW1H 9UX, United Kingdom')
   })
 
   it('should not display the service details if there are no organisation for the service', () => {
@@ -80,7 +90,9 @@ describe('The footer displayed on payment pages', () => {
     cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
-    cy.get('.merchant-details').should('not.exist')
+    cy.get('[data-cy=footer]')
+      .find('.govuk-footer__meta-custom')
+      .should('not.exist')
   })
 
   it('should not display the service details if there is an organisation address but no organisation name', () => {
@@ -98,6 +110,8 @@ describe('The footer displayed on payment pages', () => {
     cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language, gatewayAccountId, serviceOpts))
     cy.visit(`/secure/${tokenId}`)
 
-    cy.get('.merchant-details').should('not.exist')
+    cy.get('[data-cy=footer]')
+      .find('.govuk-footer__meta-custom')
+      .should('not.exist')
   })
 })


### PR DESCRIPTION
- Updated the footer to use the Nunjucks macro.
- Updated the footer as per new design.
- Removed the reference to the header macro import - as this is automatically imported with the `govuk-frontend` layout.
- Percy results will be added to the PR.

# Percy results

Build: https://percy.io/55ba5e1a/web/pay-frontend/builds/40520702/changed/2179804504?browser=chrome&browser_ids=64&group_snapshots_by=similar_diff&subcategories=approved&test_case_ids=&viewLayout=side-by-side&viewMode=new&width=1280&widths=375%2C1280

## Standard footer

Percy identified the changes in the footer.

<img width="1415" alt="image" src="https://github.com/user-attachments/assets/77f2090e-b3c7-475c-82ef-a5961d9aee60" />

## Custom branding

Percy identified the changes in the footer.  Custom branding uses a slightly different font - so the org details appear a few pixels wider

![image](https://github.com/user-attachments/assets/e71dc125-f9da-43ab-b9ce-dd5a32281151)



