### PR TITLE
PP-14110 Update custom branding Cypress tests

### DIFF
--- a/app/views/includes/custom.njk
+++ b/app/views/includes/custom.njk
@@ -1,7 +1,7 @@
 <header class="govuk-header" role="banner" data-module="govuk-header" data-cy="header">
   <div class="govuk-header__container govuk-width-container" data-cy="header-container" data-cy="header-container">
     <div class="govuk-header__logo">
-      <span class="govuk-header__link--homepage">
+      <span class="govuk-header__link--homepage" data-cy="custom-branding-image-container">
         <span class="govuk-header__logotype">
           <img src="{{ service.customBranding.imageUrl }}" class="govuk-header__logotype-crown custom-branding-image" alt="" data-cy="custom-branding-image">
         </span>

--- a/test/cypress/integration/card/custom-branding.test.cy.js
+++ b/test/cypress/integration/card/custom-branding.test.cy.js
@@ -26,12 +26,20 @@ describe('Custom branding', () => {
 
     cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(255, 255, 255)')
     cy.get('[data-cy=header-container]').should('have.css', 'border-bottom-color', 'rgb(0, 0, 0)')
+
+    cy.get('[data-cy=header-container]')
+      .should('have.css', 'border-bottom-color', 'rgb(0, 0, 0)')
+      .and('have.css', 'border-bottom-width')
+      .then((borderWidth) => {
+        expect(borderWidth).not.to.eq('0px')
+      })
+
     cy.get('[data-cy=service-name]').should('have.css', 'color', 'rgb(0, 0, 0)')
+    cy.get('[data-cy=custom-branding-image-container]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
     cy.get('[data-cy=custom-branding-image]').should('have.attr', 'src', '/public/images/custom/cypress-testing.svg')
   })
 
   it('Should setup custom branding correctly when purple background with white text', () => {
-    // Cypress.session.clearAllSavedSessions()
     cy.task('clearStubs')
     const createPaymentChargeStubs = cardPaymentStubs.buildCreatePaymentChargeStubs(
       tokenId,
@@ -53,7 +61,16 @@ describe('Custom branding', () => {
 
     cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(191, 64, 191)')
     cy.get('[data-cy=header-container]').should('have.css', 'border-bottom-color', 'rgb(0, 0, 0)')
+
+    cy.get('[data-cy=header-container]')
+      .should('have.css', 'border-bottom-color', 'rgb(0, 0, 0)')
+      .and('have.css', 'border-bottom-width')
+      .then((borderWidth) => {
+        expect(borderWidth).not.to.eq('0px')
+      })
+
     cy.get('[data-cy=service-name]').should('have.css', 'color', 'rgb(255, 255, 255)')
+    cy.get('[data-cy=custom-branding-image-container]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
     cy.get('[data-cy=custom-branding-image]').should('have.attr', 'src', '/public/images/custom/cypress-testing.svg')
   })
 })


### PR DESCRIPTION
- When testing the new branding, we identified that it caused a couple of bugs with custom branding.
- This ticket is to update custom branding tests to pick up these issues.
- This ensures that when the new branding is implemented - these tests will fail unless the bugs are fixed.
- The tests have been updated to check the following:
  - Make sure the bottom border is of the container is visible.
  - Check background colour of the logo's container.

# Current branding - tests all pass

![image](https://github.com/user-attachments/assets/b37e6bcd-62c8-4ded-9dff-1caf94575707)

# New branding - 2 tests fail

Fails if the bottom border is not visible:

![image](https://github.com/user-attachments/assets/36b2f910-b5ef-434d-941b-901dbcf409df)

Fails if the background of the logo is not transparent

![image](https://github.com/user-attachments/assets/e98bf2a1-0df1-4616-a6aa-9f1f242731a7)



