### PR TITLE
PP-14162 Update Cypress footer tests - check colours

### DIFF
--- a/test/cypress/integration/card/footer.test.cy.js
+++ b/test/cypress/integration/card/footer.test.cy.js
@@ -25,6 +25,10 @@ describe('The footer displayed on payment pages', () => {
     cy.visit(`/secure/${tokenId}`)
 
     cy.get('[data-cy=footer]')
+      .should('have.css', 'background-color', 'rgb(243, 242, 241)')
+      .should('have.css', 'border-top-color', 'rgb(29, 112, 184)')
+
+    cy.get('[data-cy=footer]')
       .find('.govuk-footer__inline-list .govuk-footer__link')
       .should('have.length', 4)
       .then(($elements) => {


### PR DESCRIPTION
- Adding some more tests to check the colours of the footer when it is using the current branding.
- This is to prepare us for some more work that will be done later where we will need to add code to toggle the new branding.



