### PR TITLE
PP-13898 - Add rebrand flag middleware

### DIFF
--- a/app/middleware/add-rebrand-flag.js
+++ b/app/middleware/add-rebrand-flag.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = function (req, res, next) {
+  res.locals.enableRebrand = (process.env.ENABLE_REBRAND === 'true')
+  next()
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -21,6 +21,7 @@ const retrieveCharge = require('./middleware/retrieve-charge.js')
 const enforceSessionCookie = require('./middleware/enforce-session-cookie.js')
 const resolveService = require('./middleware/resolve-service.js')
 const resolveLanguage = require('./middleware/resolve-language.js')
+const addRebrandFlag = require('./middleware/add-rebrand-flag.js')
 const {
   cardDetails,
   rateLimitMiddleware,
@@ -52,7 +53,8 @@ exports.bind = function (app) {
     resolveLanguage,
     resolveService,
     stateEnforcer,
-    decryptCardData
+    decryptCardData,
+    addRebrandFlag
   ]
 
   const chargeCookieRequiredMiddlewareStack = [

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,6 +1,8 @@
 {% extends "govuk/template.njk" %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
+{% set govukRebrand = enableRebrand %}
+
 {% set htmlLang = language %}
 
 {% block head %}
@@ -30,6 +32,7 @@
   {% else %}
     {{ govukHeader({
       serviceName: serviceName,
+      rebrand: enableRebrand,
       attributes : {
         'data-cy': 'header'
       }
@@ -80,6 +83,7 @@
   {% endif %}
 
   {{ govukFooter({
+    rebrand: enableRebrand,
     meta: {
       items: [
         {

--- a/test/middleware/add-rebrand-flag.test.js
+++ b/test/middleware/add-rebrand-flag.test.js
@@ -1,0 +1,41 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+// Local dependencies
+const addRebrandFlag = require('../../app/middleware/add-rebrand-flag.js')
+
+const req = {}
+const res = {
+  locals: {}
+}
+
+const next = sinon.spy()
+
+describe('Add rebrand flag - middleware', function () {
+  beforeEach(function () {
+    process.env.ENABLE_REBRAND = undefined
+    res.locals = {}
+    next.resetHistory()
+  })
+
+  it('should set res.locals.enableRebrand = undefined when When process.env.ENABLE_REBRAND = undefined', function () {
+    addRebrandFlag(req, res, next)
+    expect(next.called).to.equal(true)
+    // assert.strictEqual(res.locals.enableRebrand, undefined)
+    expect(res.locals.enableRebrand).to.equal(false)
+  })
+
+  it('should set res.locals.enableRebrand = true when When process.env.ENABLE_REBRAND = true', function () {
+    process.env.ENABLE_REBRAND = 'true'
+    addRebrandFlag(req, res, next)
+    expect(res.locals.enableRebrand).to.equal(true)
+    expect(next.called).to.equal(true)
+  })
+
+  it('should set res.locals.enableRebrand = false when When process.env.ENABLE_REBRAND = false', function () {
+    process.env.ENABLE_REBRAND = 'false'
+    addRebrandFlag(req, res, next)
+    expect(next.called).to.equal(true)
+    expect(res.locals.enableRebrand).to.equal(false)
+  })
+})


### PR DESCRIPTION
- New middleware created to pass the value of process.env.ENABLE_REBRAND to then nunjucks layout.
- This flag is false by default
- We are not using this flag at the moment
- This PR is just to get things ready for the rebrand.

