### PR TITLE
PP-13898 Add tests for rebranding

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -20,7 +20,10 @@ module.exports = defineConfig({
       return require('./test/cypress/plugins')(on, config)
     },
     baseUrl: 'http://127.0.0.1:3000',
-    specPattern: './test/cypress/integration/**/*.cy.{js,jsx,ts,tsx}',
+    specPattern: [
+      './test/cypress/integration/**/*.cy.{js,jsx,ts,tsx}',
+      './test/cypress/integration/**/*.rebrand.{js,jsx,ts,tsx}'
+    ],
     supportFile: './test/cypress/support'
   }
 })

--- a/package.json
+++ b/package.json
@@ -48,8 +48,10 @@
     "watch-live-reload": "grunt watch",
     "test": "rm -rf ./pacts && NODE_ENV=test mocha --exclude **/*.cy.test.js '!(node_modules)/**/*.test'.js",
     "cypress:server": "run-amock --port=8000 | node -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
-    "cypress:test": "cypress run",
+    "cypress:test": "cypress run --spec './test/cypress/integration/**/*.cy.js'",
     "cypress:test-headed": "cypress open",
+    "cypress:server-rebrand": "run-amock --port=8000 | ENABLE_REBRAND=true node -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
+    "cypress:test-rebrand": "cypress run --spec './test/cypress/integration/card/rebrand-header-footer.test.cy.rebrand.js,./test/cypress/integration/card/custom-branding.test.cy.js'",
     "snyk-protect": "snyk-protect",
     "publish-pacts": "./bin/publish-pacts.js"
   },

--- a/test/cypress/integration/card/rebrand-header-footer.test.cy.rebrand.js
+++ b/test/cypress/integration/card/rebrand-header-footer.test.cy.rebrand.js
@@ -1,0 +1,26 @@
+const cardPaymentStubs = require('../../utils/card-payment-stubs')
+
+describe('Rebrand', () => {
+  const tokenId = 'be88a908-3b99-4254-9807-c855d53f6b2b'
+  const chargeId = 'ub8de8r5mh4pb49rgm1ismaqfv'
+  const language = 'en'
+
+  it('should display the header and footer with new branding when ENABLE_REBRAND = true', () => {
+    cy.task('setupStubs', cardPaymentStubs.buildCreatePaymentChargeStubs(tokenId, chargeId, language))
+    cy.visit(`/secure/${tokenId}`)
+
+    cy.log('Should display the header with new branding')
+
+    cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(29, 112, 184)')
+    cy.get('[data-cy=header]').should('have.css', 'color', 'rgb(255, 255, 255)')
+    cy.get('[data-cy=header]')
+      .find('.govuk-header__container')
+      .should('have.css', 'border-bottom-color', 'rgb(255, 255, 255)')
+
+    cy.log('Should display the footer with new branding')
+
+    cy.get('[data-cy=footer]')
+      .should('have.css', 'background-color', 'rgb(244, 248, 251)')
+      .should('have.css', 'border-top-color', 'rgb(29, 112, 184)')
+  })
+})


### PR DESCRIPTION
- We now need 2 Cypress test suites temporarily until the new branding is live
- Main test suite
  - Rebranding flag ENABLE_REBRAND is undefined.
  - Standard Cypress tests with the current branding.
  - Custom branding tests.
  - These are run with
    - npm run cypress:server
    - npm run cypress:test
- Rebranding test suite
  - Rebranding flag ENABLE_REBRAND = true
  - Want to run the test to check the rebranding
    - I.e. Check that the header and footer has the new CSS styling.
    - This is a new test that is only run when ENABLE_FLAG=true.
  - Custom branding tests
    - These tests should work whether the ENABLE_REBRAND is true or false/undefined.
  - These are run with
    - npm run cypress:server-rebrand
    - npm run cypress:test-rebrand
- To stop the rebranding test running during the main test suite, it has a different file extension - *cy.rebrand.js*
  - We use this file extension to exclude this test when the main test suite is run.
  - Cypress config had to be updated to recognise this file extension.
- Once the new branding is LIVE, we can update the existing tests and go to just needing the main test suite.
- CICD will be updated to run both test suites in a future PR.

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


