### PR TITLE
PP-13898 Add new Cypress rebrand tests to GHA

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -41,6 +41,11 @@ jobs:
     needs: [ install-and-compile ]
     uses: alphagov/pay-ci/.github/workflows/_run-node-cypress-tests.yml@master
 
+  cypress-tests-rebrand:
+    name: "Cypress tests for rebranding"
+    needs: [ install-and-compile ]
+    uses: alphagov/pay-ci/.github/workflows/_run-node-cypress-tests-rebrand.yml@master
+
   pact-providers-contract-tests:
     name: "Provider tests"
     needs: tests


### PR DESCRIPTION
- Add the step to run the Cypress rebranding tests to GHA.


