### PR TITLE
PP-14256 Add rebrand error page test to rebrand test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cypress:test": "cypress run --spec './test/cypress/integration/**/*.cy.js'",
     "cypress:test-headed": "cypress open",
     "cypress:server-rebrand": "run-amock --port=8000 | ENABLE_REBRAND=true node -r dotenv/config start.js dotenv_config_path=test/cypress/test.env",
-    "cypress:test-rebrand": "cypress run --spec './test/cypress/integration/card/rebrand-header-footer.test.cy.rebrand.js,./test/cypress/integration/card/custom-branding.test.cy.js'",
+    "cypress:test-rebrand": "cypress run --spec './test/cypress/integration/card/rebrand-header-footer.test.cy.rebrand.js,./test/cypress/integration/card/token-403.test.cy.rebrand.js,./test/cypress/integration/card/custom-branding.test.cy.js'",
     "snyk-protect": "snyk-protect",
     "publish-pacts": "./bin/publish-pacts.js"
   },


### PR DESCRIPTION
- A test to check the error pages containing the new branding was added to the code base.
- This PR is just add this test to the rebrand test suite so that it is only run when testing the new branding.


