### PR TITLE
PP-14314 Fix GOV.UK link in header

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -29,6 +29,7 @@
     {% include "includes/custom.njk" %}
   {% else %}
     {{ govukHeader({
+      homepageUrl: "https://www.gov.uk/",
       serviceName: serviceName,
       attributes : {
         'data-cy': 'header'


### PR DESCRIPTION
Make the GOV.UK link in the header go to https://www.gov.uk/ instead of / (which redirects to https://www.gov.uk/404).