### PR TITLE
PP-8287 Remove publicly visible webpack stats page from Frontend

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function (grunt) {
       files: [{
         expand: true,
         cwd: 'node_modules/govuk-country-and-territory-autocomplete/dist/',
-        src: '**',
+        src: ['**', '!stats.html'],
         dest: 'govuk_modules/govuk-country-and-territory-autocomplete/',
         rename: (dest, src) => dest + src.replace('min.css', 'scss')
       }]


### PR DESCRIPTION
## WHAT

 - ensure `stats.html` is no longer copied into `govuk_modules` during the build


