### PR TITLE
PP-15020 Label email input as optional when appropriate

### DIFF
--- a/app/views/charge.njk
+++ b/app/views/charge.njk
@@ -546,7 +546,11 @@
                             class="email-label"
                             data-label-replace="email"
                             data-original-label="{{ __p("cardDetails.email") }}">
+                            {% if gatewayAccount.emailCollectionMode === 'OPTIONAL' %}
+                              {{ __p("cardDetails.emailOptional") }}
+                            {% else %}
                               {{ __p("cardDetails.email") }}
+                            {% endif %}
                           </span>
                         </label>
 

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -33,6 +33,7 @@
 		"country": "Gwlad neu diriogaeth",
 		"contactDetails": "Manylion cyswllt",
 		"email": "E-bost",
+		"emailOptional": "E-bost (dewisol)",
 		"emailHint": "Byddwn yn anfon eich cadarnhad taliad yma",
 		"emailConfirmation": "Byddwn an anfon e-bost i:",
 		"corporateCreditCardSurchargeMessage": "Mae ffi o £%s am ddefnyddio cerdyn credyd corfforaethol",

--- a/locales/en.json
+++ b/locales/en.json
@@ -30,6 +30,7 @@
 		"country": "Country or territory",
 		"contactDetails": "Contact details",
 		"email": "Email",
+		"emailOptional": "Email (optional)",
 		"emailHint": "We’ll send your payment confirmation here",
 		"emailConfirmation": "An email will be sent to:",
 		"corporateCreditCardSurchargeMessage": "There is a fee of £%s for using a corporate credit card",

--- a/test/cypress/integration/card/email-collection.test.cy.js
+++ b/test/cypress/integration/card/email-collection.test.cy.js
@@ -50,6 +50,7 @@ describe('Standard card payment flow', () => {
       cy.get('#address-postcode').type(validPayment.postcode)
 
       cy.get('#email').should('not.exist')
+      cy.get('#email-lbl').should('not.exist')
 
       cy.task('clearStubs')
       cy.task('setupStubs', confirmPaymentDetailsStubs)
@@ -59,6 +60,7 @@ describe('Standard card payment flow', () => {
       cy.get('#card-details').submit()
       cy.location('pathname').should('eq', `/card_details/${chargeId}/confirm`)
       cy.get('#email').should('not.exist')
+      cy.get('#email-lbl').should('not.exist')
 
       cy.log('Checking for presence of email hint when email collection is off and payment confirmation is disabled')
       cy.get('#email-hint').should('not.exist')
@@ -95,6 +97,7 @@ describe('Standard card payment flow', () => {
       cy.get('#address-postcode').type(validPayment.postcode)
 
       cy.get('#email').should('exist')
+      cy.get('#email-lbl').should('exist').and('not.contain', '(optional)')
 
       cy.log('Submitting confirmation should show email error')
 
@@ -141,6 +144,7 @@ describe('Standard card payment flow', () => {
       cy.get('#address-postcode').type(validPayment.postcode)
 
       cy.get('#email').should('exist')
+      cy.get('#email-lbl').should('exist').and('contain', '(optional)')
 
       cy.log('Submitting confirmation with valid details should redirect to confirmation page')
 


### PR DESCRIPTION
On the enter card details page, if email address collection is set to optional, label the input email as ‘Email (optional)’ in English and ‘E-bost (dewisol)’ in Welsh instead of ‘Email’ and ‘E-bost’ respectively.

### Email optional (English)
<img width="976" height="400" alt="Email (optional)" src="https://github.com/user-attachments/assets/0d1a1856-f035-4303-b9bb-7748188a63d7" />

### Email mandatory (English)
<img width="976" height="400" alt="Email" src="https://github.com/user-attachments/assets/02bf3967-660a-4e09-8dcb-bb3d492d18ed" />

### Email optional (Welsh)
<img width="978" height="442" alt="E-bost (dewisol)" src="https://github.com/user-attachments/assets/eb21c1cb-9839-4df7-b629-51de4c521ea9" />

### Email mandatory (Welsh)
<img width="978" height="442" alt="E-bost" src="https://github.com/user-attachments/assets/8e02c838-5d8b-411f-a791-68d5586331c7" />


