### PR TITLE
PP-15136 Pin Axios to v1.14.0 and disable post-install npm scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-crypto/decrypt-node": "^1.0.3",
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-        "@govuk-pay/pay-js-commons": "^7.0.42",
+        "@govuk-pay/pay-js-commons": "^7.0.43",
         "@govuk-pay/pay-js-metrics": "^1.0.14",
         "@sentry/node": "7.119.2",
         "cert-info": "^1.5.1",
@@ -50,14 +50,14 @@
         "@pact-foundation/pact": "~12.5.2",
         "@pact-foundation/pact-core": "~14.3.8",
         "@snyk/protect": "^1.1235.x",
-        "axios": "^1.13.5",
+        "axios": "1.14.0",
         "browserify": "17.0.x",
         "chai": "^4.3.8",
         "chai-as-promised": "^7.1.1",
         "chai-string": "^1.4.0",
         "cheerio": "^1.0.0-rc.12",
         "chokidar": "^3.5.3",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^13.3.1",
         "dotenv": "^16.3.1",
         "govuk-country-and-territory-autocomplete": "^2.0.0",
@@ -2200,12 +2200,12 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "7.0.42",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.42.tgz",
-      "integrity": "sha512-F2i82HnubqeD8IYd74VM3D1nOQOSiubP9XnoYPmR4rPq68H68rnCiT72hP12iyydHGLo9Zpat5QfiNwABcdZEw==",
+      "version": "7.0.43",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.43.tgz",
+      "integrity": "sha512-65dhmbYmd+O2xIm9GgZtk6l+sWWVuntyLd1lw16cKE9ewbOm+kmVB+v2GFU9jzs0NS/0R/3g8WyKW6B/u+VDnw==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.5",
+        "axios": "1.14.0",
         "csrf": "^3.1.0",
         "express-rate-limit": "^8.1.0",
         "lodash": "4.17.23",
@@ -3415,13 +3415,14 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -13150,9 +13151,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/proxyquire": {
       "version": "2.1.3",
@@ -18392,11 +18397,11 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "7.0.42",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.42.tgz",
-      "integrity": "sha512-F2i82HnubqeD8IYd74VM3D1nOQOSiubP9XnoYPmR4rPq68H68rnCiT72hP12iyydHGLo9Zpat5QfiNwABcdZEw==",
+      "version": "7.0.43",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.43.tgz",
+      "integrity": "sha512-65dhmbYmd+O2xIm9GgZtk6l+sWWVuntyLd1lw16cKE9ewbOm+kmVB+v2GFU9jzs0NS/0R/3g8WyKW6B/u+VDnw==",
       "requires": {
-        "axios": "^1.6.5",
+        "axios": "1.14.0",
         "csrf": "^3.1.0",
         "express-rate-limit": "^8.1.0",
         "lodash": "4.17.23",
@@ -18558,7 +18563,7 @@
       "requires": {
         "@pact-foundation/pact-core": "^14.3.4",
         "@types/express": "^4.17.11",
-        "axios": "^1.6.1",
+        "axios": "1.14.0",
         "body-parser": "^1.20.0",
         "cli-color": "^2.0.1",
         "express": "^4.19.2",
@@ -19350,13 +19355,13 @@
       "dev": true
     },
     "axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "requires": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "babel-plugin-polyfill-corejs2": {
@@ -26776,9 +26781,9 @@
       }
     },
     "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     },
     "proxyquire": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
-    "@govuk-pay/pay-js-commons": "^7.0.42",
+    "@govuk-pay/pay-js-commons": "^7.0.43",
     "@govuk-pay/pay-js-metrics": "^1.0.14",
     "@sentry/node": "7.119.2",
     "cert-info": "^1.5.1",
@@ -112,7 +112,7 @@
     "@pact-foundation/pact": "~12.5.2",
     "@pact-foundation/pact-core": "~14.3.8",
     "@snyk/protect": "^1.1235.x",
-    "axios": "^1.13.5",
+    "axios": "1.14.0",
     "browserify": "17.0.x",
     "chai": "^4.3.8",
     "chai-as-promised": "^7.1.1",
@@ -156,7 +156,11 @@
     "staticify": {
       "send": "0.19.0"
     },
-    "cross-spawn": "^7.0.5"
+    "cross-spawn": "^7.0.5",
+    "axios": "1.14.0"
+  },
+  "resolutions": {
+    "axios": "1.14.0"
   },
   "snyk": true
 }


### PR DESCRIPTION
## WHAT

- pin axios to version 1.14.0 to prevent installation of compromised version 1.14.1
- disable post-install npm scripts to reduce security risk from malicious packages
- bump pay-js-commons to ensure pinned version of axios


