### PR TITLE
PP-15339 Bump pay-js-metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-crypto/decrypt-node": "^1.0.3",
         "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
         "@govuk-pay/pay-js-commons": "^7.0.43",
-        "@govuk-pay/pay-js-metrics": "^1.0.14",
+        "@govuk-pay/pay-js-metrics": "^2.0.1",
         "@sentry/node": "7.119.2",
         "cert-info": "^1.5.1",
         "change-case": "2.3.x",
@@ -57,7 +57,7 @@
         "chai-string": "^1.4.0",
         "cheerio": "^1.0.0-rc.12",
         "chokidar": "^3.5.3",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^13.3.1",
         "dotenv": "^16.3.1",
         "govuk-country-and-territory-autocomplete": "^2.0.0",
@@ -2242,9 +2242,10 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-metrics": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.14.tgz",
-      "integrity": "sha512-UqQ6V/6xUt1N62j0ugOUGmSRfZkg1tO9OYlT9YZoDXCEPFZeMo69dDIp+LJzvJJSHMdiPXLw+y0PeME6McWuUQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-2.0.1.tgz",
+      "integrity": "sha512-t3GXcQ68B+s7AVhzM0FdIyi9wHFC1yDCDkZ+Wa2N0y0OT4nTRsq+R3cIM7dR5qk/xCWaGPL6AB7Rz3iHXNR5uQ==",
+      "license": "MIT",
       "dependencies": {
         "on-finished": "^2.4.1",
         "prom-client": "^14.2.0"
@@ -18957,9 +18958,9 @@
       }
     },
     "@govuk-pay/pay-js-metrics": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.14.tgz",
-      "integrity": "sha512-UqQ6V/6xUt1N62j0ugOUGmSRfZkg1tO9OYlT9YZoDXCEPFZeMo69dDIp+LJzvJJSHMdiPXLw+y0PeME6McWuUQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-2.0.1.tgz",
+      "integrity": "sha512-t3GXcQ68B+s7AVhzM0FdIyi9wHFC1yDCDkZ+Wa2N0y0OT4nTRsq+R3cIM7dR5qk/xCWaGPL6AB7Rz3iHXNR5uQ==",
       "requires": {
         "on-finished": "^2.4.1",
         "prom-client": "^14.2.0"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@aws-crypto/decrypt-node": "^1.0.3",
     "@aws-crypto/raw-rsa-keyring-node": "^1.1.0",
     "@govuk-pay/pay-js-commons": "^7.0.43",
-    "@govuk-pay/pay-js-metrics": "^1.0.14",
+    "@govuk-pay/pay-js-metrics": "^2.0.1",
     "@sentry/node": "7.119.2",
     "cert-info": "^1.5.1",
     "change-case": "2.3.x",


### PR DESCRIPTION
## WHAT
Bump the NPM module `pay-js-metrics`.

## HOW 
- Localhost:
  - Go to `<localhost:port>/metrics`, e.g. `localhsot:3000/metrics`
    - This page should be working.
  - Production:
    - Check Grafana and make Node metrics are being updated.
 


