### PR TITLE
PP-14542: Add a new endpoint to handle Adyen 3DS redirect and submit result to Connector

### DIFF
--- a/app/controllers/three-d-secure.controller.js
+++ b/app/controllers/three-d-secure.controller.js
@@ -52,6 +52,11 @@ const build3dsPayload = (chargeId, req) => {
     auth3dsPayload.md = md
   }
 
+  const redirectResult = _.get(req, 'body.redirectResult')
+  if (!_.isUndefined(redirectResult)) {
+    auth3dsPayload.redirect_result = redirectResult
+  }
+
   return auth3dsPayload
 }
 
@@ -176,6 +181,16 @@ module.exports = {
     responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_IN_VIEW, {
       threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
       providerStatus: _.get(req, 'query.status', 'success')
+    })
+  },
+  auth3dsRequiredInAdyen: (req, res) => {
+    const charge = normalise.charge(req.chargeData, req.chargeId)
+    if (_.isUndefined(_.get(req, 'query.redirectResult'))) {
+      logger.info('redirectResult is not present')
+    }
+    responseRouter.response(req, res, views.AUTH_3DS_REQUIRED_IN_VIEW, {
+      threeDsHandlerUrl: routeFor('auth3dsHandler', charge.id),
+      redirectResult: _.get(req, 'query.redirectResult', '')
     })
   }
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -46,6 +46,10 @@ const paths = {
       path: '/card_details/:chargeId/3ds_required_in/epdq',
       action: 'post'
     },
+    auth3dsRequiredInAdyen: {
+      path: '/card_details/:chargeId/3ds_required_in/adyen',
+      action: 'post'
+    },
     auth3dsRequiredOut: {
       path: '/card_details/:chargeId/3ds_required_out',
       action: 'get'

--- a/app/routes.js
+++ b/app/routes.js
@@ -103,6 +103,8 @@ exports.bind = function (app) {
   app.get(card.auth3dsRequiredOut.path, standardMiddlewareStack, threeDS.auth3dsRequiredOut)
   app.post(card.auth3dsRequiredInEpdq.path, chargeNoCookieRequiredMiddlewareStack, threeDS.auth3dsRequiredInEpdq)
   app.get(card.auth3dsRequiredInEpdq.path, chargeNoCookieRequiredMiddlewareStack, threeDS.auth3dsRequiredInEpdq)
+  app.post(card.auth3dsRequiredInAdyen.path, chargeNoCookieRequiredMiddlewareStack, threeDS.auth3dsRequiredInAdyen)
+  app.get(card.auth3dsRequiredInAdyen.path, chargeNoCookieRequiredMiddlewareStack, threeDS.auth3dsRequiredInAdyen)
   app.post(card.auth3dsRequiredIn.path, chargeNoCookieRequiredMiddlewareStack, threeDS.auth3dsRequiredIn)
   app.get(card.auth3dsRequiredIn.path, chargeNoCookieRequiredMiddlewareStack, threeDS.auth3dsRequiredIn)
   app.post(card.auth3dsHandler.path, [actionName, enforceSessionCookie, retrieveCharge, resolveLanguage, resolveService, stateEnforcer], threeDS.auth3dsHandler)

--- a/app/views/auth-3ds-required-in.njk
+++ b/app/views/auth-3ds-required-in.njk
@@ -17,6 +17,9 @@
     {% if md %}
         <input type="hidden" name="MD" value="{{ md }}"/>
     {% endif %}
+    {% if redirectResult %}
+        <input type="hidden" name="redirectResult" value="{{ redirectResult }}"/>
+    {% endif %}
     <noscript>
         <button id="confirm" class="govuk-button">{{ __p("commonButtons.continueButton") }}</button>
     </noscript>

--- a/test/integration/three-d-secure.ft.test.js
+++ b/test/integration/three-d-secure.ft.test.js
@@ -336,6 +336,75 @@ describe('chargeTests', function () {
       })
     })
 
+    describe('for adyen payment provider', function () {
+      it('should return the data, including redirectResult, in the UI for POST to 3ds_required_in/adyen', function (done) {
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          paymentProvider: 'adyen'
+        })
+        defaultAdminusersResponseForGetService(gatewayAccountId)
+
+        nock(process.env.CONNECTOR_HOST)
+          .get('/v1/frontend/charges/' + chargeId).reply(200, chargeResponse)
+
+        const data = {}
+        postChargeRequest(app, false, data, chargeId, false, '/3ds_required_in/adyen')
+          .expect(200)
+          .expect(function (res) {
+            expect(res.header['set-cookie'] === undefined).to.be.true // eslint-disable-line
+            const $ = cheerio.load(res.text)
+            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist // eslint-disable-line
+            expect($('form[name=\'three_ds_required\'] > input[name=\'redirectResult\']').attr('value')).to.not.exist // eslint-disable-line
+            expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(`/card_details/${chargeId}/3ds_handler`)
+          })
+          .end(done)
+      })
+
+      it('should return the data, including redirectResult, in the UI for GET to 3ds_required_in/adyen', function (done) {
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          paymentProvider: 'adyen'
+        })
+        defaultAdminusersResponseForGetService(gatewayAccountId)
+
+        nock(process.env.CONNECTOR_HOST)
+          .get('/v1/frontend/charges/' + chargeId).reply(200, chargeResponse)
+
+        getChargeRequest(app, false, chargeId, '/3ds_required_in/adyen?redirectResult=XtestX')
+          .expect(200)
+          .expect(function (res) {
+            expect(res.header['set-cookie'] === undefined).to.be.true // eslint-disable-line
+            const $ = cheerio.load(res.text)
+            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist // eslint-disable-line
+            expect($('form[name=\'three_ds_required\'] > input[name=\'redirectResult\']').attr('value')).to.eql('XtestX')
+            expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(`/card_details/${chargeId}/3ds_handler`)
+          })
+          .end(done)
+      })
+
+      it('should return the data, with missing redirectResult, in the UI for GET to 3ds_required_in/adyen', function (done) {
+        const chargeResponse = paymentFixtures.validChargeDetails({
+          ...chargeOptionsWith3dsRequired,
+          paymentProvider: 'adyen'
+        })
+        defaultAdminusersResponseForGetService(gatewayAccountId)
+
+        nock(process.env.CONNECTOR_HOST)
+          .get('/v1/frontend/charges/' + chargeId).reply(200, chargeResponse)
+
+        getChargeRequest(app, false, chargeId, '/3ds_required_in/adyen')
+          .expect(200)
+          .expect(function (res) {
+            expect(res.header['set-cookie'] === undefined).to.be.true // eslint-disable-line
+            const $ = cheerio.load(res.text)
+            expect($('form[name=\'three_ds_required\'] > input[name=\'csrfToken\']').attr('value')).to.not.exist // eslint-disable-line
+            expect($('form[name=\'three_ds_required\'] > input[name=\'redirectResult\']').attr('value')).to.not.exist // eslint-disable-line
+            expect($('form[name=\'three_ds_required\']').attr('action')).to.eql(`/card_details/${chargeId}/3ds_handler`)
+          })
+          .end(done)
+      })
+    })
+
     describe('for smartpay payment provider', function () {
       it('should return the data needed for the UI when GET', function (done) {
         const chargeResponse = paymentFixtures.validChargeDetails(chargeOptionsWith3dsRequired)
@@ -364,6 +433,19 @@ describe('chargeTests', function () {
 
   describe('The /card_details/charge_id/3ds_handler', function () {
     const chargeResponse = paymentFixtures.validChargeDetails(chargeOptionsWith3dsRequired)
+
+    it('should send adyen 3ds data to connector and redirect to confirm', function (done) {
+      const cookieValue = cookie.create(chargeId)
+      nock(process.env.CONNECTOR_HOST)
+        .get(`/v1/frontend/charges/${chargeId}`).reply(200, chargeResponse)
+        .post(`${connectorChargePath}${chargeId}/3ds`, { redirect_result: 'XtestX' }).reply(200)
+      defaultAdminusersResponseForGetService(gatewayAccountId)
+
+      postChargeRequest(app, cookieValue, { redirectResult: 'XtestX' }, chargeId, true, '/3ds_handler')
+        .expect(303)
+        .expect('Location', `${frontendCardDetailsPath}/${chargeId}/confirm`)
+        .end(done)
+    })
 
     it('should send 3ds data to connector and redirect to confirm', function (done) {
       const cookieValue = cookie.create(chargeId)


### PR DESCRIPTION
## WHAT
- added a new path for `auth3dsRequiredInAdyen`
- extracted `redirectResult` from Adyen's response to be sent to connector


