### PR TITLE
fix: the apple pay merchant validation endpoint acce... in...

### DIFF
--- a/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
+++ b/app/controllers/web-payments/apple-pay/merchant-validation.controller.js
@@ -46,6 +46,14 @@ module.exports = async (req, res) => {
     return res.sendStatus(400)
   }
   const { url, paymentProvider } = req.body
+  try {
+    const parsedUrl = new URL(url)
+    if (parsedUrl.protocol !== 'https:' || !parsedUrl.hostname.endsWith('.apple.com')) {
+      return res.sendStatus(400)
+    }
+  } catch (e) {
+    return res.sendStatus(400)
+  }
   const merchantIdentityVars = getApplePayMerchantIdentityVariables(paymentProvider)
   if (!merchantIdentityVars) {
     return res.sendStatus(400)


### PR DESCRIPTION
## Summary
Fix high severity security issue in `app/controllers/web-payments/apple-pay/merchant-validation.controller.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `app/controllers/web-payments/apple-pay/merchant-validation.controller.js:51` |
| **Assessment** | Likely exploitable |

**Description**: The Apple Pay merchant validation endpoint accepts a URL from the client request body and makes server-side HTTP POST requests without validating the target URL belongs to Apple's domain. This allows attackers to make the server request arbitrary URLs, potentially exposing internal services.

## Evidence

**Exploitation scenario**: Send POST request to /apple-pay-merchant-validation with crafted body containing URL pointing to internal services (e.g., AWS metadata endpoint) or attacker-controlled servers.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This controller appears to be publicly accessible. This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `app/controllers/web-payments/apple-pay/merchant-validation.controller.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project builds successfully with this change applied.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
