### PR TITLE
PP-15720 Google pay normalisation adds additional adyen browser info

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,56 +150,56 @@
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 40
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 40
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 40
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 40
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 66
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1ee4b74cf4b89c3cd9792a34a1fdfed2c8d4b71d",
         "is_verified": false,
-        "line_number": 67
+        "line_number": 68
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "29537aaf22996353c2fe981aaa72e960b2ed2d70",
         "is_verified": false,
-        "line_number": 67
+        "line_number": 68
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "6464ec4579ee376ccaa76867f536aa1061bc89bf",
         "is_verified": false,
-        "line_number": 67
+        "line_number": 68
       }
     ],
     "test/cypress/integration/card/payment.test.cy.js": [
@@ -380,5 +380,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-29T21:11:06Z"
+  "generated_at": "2026-08-19T14:06:28Z"
 }

--- a/app/assets/javascripts/browsered/collect-additional-browser-info-adyen.js
+++ b/app/assets/javascripts/browsered/collect-additional-browser-info-adyen.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const { keysToCamelCase } = require('../../../utils/key-camelizer')
+const { getBrowserInfo } = require('./web-payments/helpers')
+
 const init = () => {
   if (window.Charge.collect_additional_browser_info_adyen) {
     addAdditionalInformation()
@@ -8,26 +11,11 @@ const init = () => {
 
 const addAdditionalInformation = () => {
   document.getElementById('jsEnabled').value = 'true'
-  if (typeof navigator.language === 'string') {
-    appendHiddenInputToForm('jsNavigatorLanguage', navigator.language)
+  const browserInfo = keysToCamelCase(getBrowserInfo())
+
+  for (const [key, value] of Object.entries(browserInfo)) {
+    appendHiddenInputToForm(key, value)
   }
-
-  if (window.screen) {
-    if (typeof window.screen.colorDepth === 'number') {
-      appendHiddenInputToForm('jsScreenColorDepth', window.screen.colorDepth)
-    }
-
-    if (typeof window.screen.height === 'number') {
-      appendHiddenInputToForm('jsScreenHeight', window.screen.height)
-    }
-
-    if (typeof window.screen.width === 'number') {
-      appendHiddenInputToForm('jsScreenWidth', window.screen.width)
-    }
-  }
-
-  const date = new Date()
-  appendHiddenInputToForm('jsTimezoneOffsetMins', date.getTimezoneOffset())
 }
 
 const appendHiddenInputToForm = (name, value) => {

--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { getGooglePaymentsConfiguration, showErrorSummary } = require('./helpers')
+const { getGooglePaymentsConfiguration, showErrorSummary, getBrowserInfo } = require('./helpers')
 const { toggleSubmitButtons, showSpinnerAndHideMainContent, hideSpinnerAndShowMainContent, sendLogMessage } = require('../helpers')
 const { email_collection_mode, payment_provider } = window.Charge // eslint-disable-line camelcase
 
@@ -111,6 +111,10 @@ const performDeviceDataCollectionForGooglePay = (paymentData) => {
 const processPayment = paymentData => {
   toggleSubmitButtons()
   showSpinnerAndHideMainContent()
+
+  if (payment_provider === 'adyen' && Charge.collect_additional_browser_info_adyen === true) { // eslint-disable-line camelcase
+    paymentData.browser_info = getBrowserInfo()
+  }
 
   // attempt device data collection for worldpay only
   if (payment_provider === 'worldpay') { // eslint-disable-line camelcase

--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -124,10 +124,23 @@ const getGooglePaymentsConfiguration = (paymentProvider) => {
   }
 }
 
+const getBrowserInfo = () => {
+  const timezoneOffset = new Date().getTimezoneOffset()
+  return {
+    js_enabled: true,
+    js_navigator_language: typeof navigator.language === 'string' ? navigator.language : null,
+    js_screen_color_depth: typeof window.screen.colorDepth === 'number' ? window.screen.colorDepth : null,
+    js_screen_height: typeof window.screen.height === 'number' ? window.screen.height : null,
+    js_screen_width: typeof window.screen.width === 'number' ? window.screen.width : null,
+    js_timezone_offset_mins: typeof timezoneOffset === 'number' ? timezoneOffset : null
+  }
+}
+
 module.exports = {
   showErrorSummary,
   clearErrorSummary,
   toggleWaiting,
   prepareAppleRequestObject,
-  getGooglePaymentsConfiguration
+  getGooglePaymentsConfiguration,
+  getBrowserInfo
 }

--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -83,7 +83,6 @@ module.exports = (req, paymentProvider) => {
   logSelectedPayloadProperties(req)
 
   const payload = req.body
-
   const paymentInfo = {
     last_digits_card_number: normaliseLastDigitsCardNumber(lodash.get(payload, 'paymentResponse.details.paymentMethodData.info.cardDetails', '')),
     brand: normaliseCardName(lodash.get(payload, 'paymentResponse.details.paymentMethodData.info.cardNetwork', '')),
@@ -99,15 +98,28 @@ module.exports = (req, paymentProvider) => {
 
   delete payload.paymentResponse.details.paymentMethodData
 
-  if (paymentProvider === 'stripe') {
-    return {
-      payment_info: paymentInfo,
-      token_id: paymentData.id
-    }
-  } else {
-    return {
-      payment_info: paymentInfo,
-      encrypted_payment_data: paymentData
-    }
+  switch (paymentProvider) {
+    case 'stripe':
+      return {
+        payment_info: paymentInfo,
+        token_id: paymentData.id
+      }
+    case 'adyen':
+      paymentInfo.js_enabled = payload.paymentResponse.browser_info.js_enabled
+      paymentInfo.js_navigator_language = payload.paymentResponse.browser_info.js_navigator_language
+      paymentInfo.js_screen_color_depth = payload.paymentResponse.browser_info.js_screen_color_depth
+      paymentInfo.js_screen_height = payload.paymentResponse.browser_info.js_screen_height
+      paymentInfo.js_screen_width = payload.paymentResponse.browser_info.js_screen_width
+      paymentInfo.js_timezone_offset_mins = payload.paymentResponse.browser_info.js_timezone_offset_mins
+      return {
+        payment_info: paymentInfo,
+        token: JSON.stringify(paymentData)
+      }
+    case 'sandbox':
+    case 'worldpay':
+      return {
+        payment_info: paymentInfo,
+        encrypted_payment_data: paymentData
+      }
   }
 }

--- a/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
+++ b/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
@@ -1,6 +1,7 @@
 const expect = require('chai').expect
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
+const { keysToSnakeCase } = require('../../../../app/utils/key-camelizer')
 
 const loggerInfoMock = sinon.spy()
 
@@ -48,7 +49,7 @@ describe('normalise Google Pay payload', () => {
       worldpay3dsFlexDdcResult: 'some long opaque string that’s a device data collection result'
     }
 
-    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload })
+    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload }, 'sandbox')
     expect(normalisedPayload).to.eql(
       {
         payment_info: {
@@ -86,6 +87,85 @@ describe('normalise Google Pay payload', () => {
           },
           worldpay3dsFlexDdcResult: '(redacted non-blank string)'
 
+        }
+    }
+
+    sinon.assert.calledWithExactly(loggerInfoMock, 'Received Google Pay payload', loggingPayload)
+  })
+
+  it('should return the correct format for the payload if payment provider is Adyen', () => {
+    const googlePayPayload = {
+      paymentResponse: {
+        browser_info: {
+          js_enabled: true,
+          js_navigator_language: 'en-GB',
+          js_screen_color_depth: 24,
+          js_screen_height: 1024,
+          js_screen_width: 2048,
+          js_timezone_offset_mins: -60
+        },
+        details: {
+          apiVersionMinor: 0,
+          apiVersion: 2,
+          paymentMethodData: {
+            description: 'Mastercard •••• 4242',
+            info: {
+              cardNetwork: 'MASTERCARD',
+              cardDetails: '4242'
+            },
+            tokenizationData: {
+              type: 'PAYMENT_GATEWAY',
+              token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+            },
+            type: 'CARD'
+          }
+        },
+        payerEmail: 'name@email.test',
+        payerName: 'Some Name'
+      }
+    }
+
+    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload }, 'adyen')
+    expect(normalisedPayload).to.eql(
+      {
+        payment_info: {
+          last_digits_card_number: '4242',
+          brand: 'master-card',
+          cardholder_name: 'Some Name',
+          email: 'name@email.test',
+          worldpay_3ds_flex_ddc_result: null,
+          accept_header: 'text/html;q=1.0, */*;q=0.9',
+          user_agent_header: 'Mozilla/5.0',
+          ip_address: '203.0.113.1',
+          js_enabled: true,
+          js_navigator_language: 'en-GB',
+          js_screen_color_depth: 24,
+          js_screen_height: 1024,
+          js_screen_width: 2048,
+          js_timezone_offset_mins: -60
+        },
+        token: JSON.stringify(keysToSnakeCase(
+          JSON.parse(
+            '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
+          )))
+      }
+    )
+
+    const loggingPayload = {
+      selected_payload_properties:
+        {
+          paymentResponse: {
+            details: {
+              paymentMethodData: {
+                info: {
+                  cardDetails: '4242',
+                  cardNetwork: 'MASTERCARD'
+                }
+              }
+            },
+            payerName: '(redacted non-blank string)',
+            payerEmail: '(redacted non-blank string)'
+          }
         }
     }
 
@@ -172,7 +252,7 @@ describe('normalise Google Pay payload', () => {
         }
       }
     }
-    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload })
+    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload }, 'sandbox')
     expect(normalisedPayload).to.eql(
       {
         payment_info: {
@@ -233,7 +313,7 @@ describe('normalise Google Pay payload', () => {
         }
       }
     }
-    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload })
+    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload }, 'sandbox')
     expect(normalisedPayload).to.eql(
       {
         payment_info: {
@@ -276,7 +356,7 @@ describe('normalise Google Pay payload', () => {
         }
       }
     }
-    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload })
+    const normalisedPayload = normalise({ headers: headers, body: googlePayPayload }, 'sandbox')
     expect(normalisedPayload).to.eql(
       {
         payment_info: {


### PR DESCRIPTION
- Added Adyen browser detail to `paymentInfo` object if the `paymentProvider` is Adyen
- Added `performDeviceDataCollectionForAdyen` method in `normalise-google-pay-payload` to append the values mentioned above
- Added to the `normalise-google-pay-payload` test cases


