### PR TITLE
PP-15765: remove npm and yarn from final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ FROM base AS builder
 RUN npm install -g npm@11.18.0
 
 WORKDIR /build-stage
-COPY . ./
+COPY package.json package-lock.json .npmrc ./
 RUN npm ci --quiet
+COPY . ./
 RUN npm run compile
 RUN npm prune --omit=dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,45 @@
-FROM node:22.23.2-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS builder
+FROM node:22.23.2-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS base
 
-WORKDIR /app
+RUN apk upgrade --no-cache \
+    && apk add --no-cache tini
+
+FROM base AS builder
 
 # Upgrade npm — if updating the Node.js version, check if this
 # is still necessary and make sure it never downgrades npm
 RUN npm install -g npm@11.18.0
 
-COPY package.json .
-COPY package-lock.json .
+WORKDIR /build-stage
+COPY . ./
 RUN npm ci --quiet
-
-COPY . .
 RUN npm run compile
 
-FROM node:22.23.2-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS final
-
-RUN ["apk", "--no-cache", "upgrade"]
-
-RUN ["apk", "add", "--no-cache", "tini"]
+FROM base AS final
 
 WORKDIR /app
-
-# Upgrade npm — if updating the Node.js version, check if this
-# is still necessary and make sure it never downgrades npm
-RUN npm install -g npm@11.18.0
-
-COPY . .
-RUN rm -rf ./test
 # Copy in compile assets and deps from build container
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/govuk_modules ./govuk_modules
-COPY --from=builder /app/public ./public
-RUN npm prune --omit=dev
+COPY --from=builder /build-stage/node_modules ./node_modules
+COPY --from=builder /build-stage/govuk_modules ./govuk_modules
+COPY --from=builder /build-stage/public ./public
+COPY --from=builder /build-stage/app ./app
+COPY --from=builder /build-stage/config ./config
+COPY --from=builder /build-stage/locales ./locales
+COPY --from=builder /build-stage/server.js ./
+COPY --from=builder /build-stage/start.js ./
+COPY --from=builder /build-stage/.npmrc ./
+
+RUN npm prune --omit=dev \
+    && rm -rf /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack \
+        /opt/yarn-* \
+        /usr/local/bin/yarn \
+        /usr/local/bin/yarnpkg
 
 ENV PORT=9000
 EXPOSE 9000
-
+USER 1000
 ENTRYPOINT ["tini", "--"]
-
-CMD ["npm", "start"]
+CMD ["node", "start.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /build-stage
 COPY . ./
 RUN npm ci --quiet
 RUN npm run compile
+RUN npm prune --omit=dev
 
 FROM base AS final
 
@@ -26,20 +27,17 @@ COPY --from=builder /build-stage/config ./config
 COPY --from=builder /build-stage/locales ./locales
 COPY --from=builder /build-stage/server.js ./
 COPY --from=builder /build-stage/start.js ./
-COPY --from=builder /build-stage/.npmrc ./
 
-RUN npm prune --omit=dev \
-    && rm -rf /usr/local/lib/node_modules/npm \
-        /usr/local/lib/node_modules/corepack \
-        /usr/local/bin/npm \
-        /usr/local/bin/npx \
-        /usr/local/bin/corepack \
-        /opt/yarn-* \
-        /usr/local/bin/yarn \
-        /usr/local/bin/yarnpkg
+RUN rm -rf /usr/local/lib/node_modules/npm \
+    /usr/local/lib/node_modules/corepack \
+    /usr/local/bin/npm \
+    /usr/local/bin/npx \
+    /usr/local/bin/corepack \
+    /opt/yarn-* \
+    /usr/local/bin/yarn \
+    /usr/local/bin/yarnpkg
 
 ENV PORT=9000
 EXPOSE 9000
-USER 1000
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "start.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:22.23.2-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS base
 
-RUN apk upgrade --no-cache \
-    && apk add --no-cache tini
+RUN apk upgrade --no-cache
 
 FROM base AS builder
 
@@ -28,14 +27,15 @@ COPY --from=builder /build-stage/locales ./locales
 COPY --from=builder /build-stage/server.js ./
 COPY --from=builder /build-stage/start.js ./
 
-RUN rm -rf /usr/local/lib/node_modules/npm \
-    /usr/local/lib/node_modules/corepack \
-    /usr/local/bin/npm \
-    /usr/local/bin/npx \
-    /usr/local/bin/corepack \
-    /opt/yarn-* \
-    /usr/local/bin/yarn \
-    /usr/local/bin/yarnpkg
+RUN apk add --no-cache tini \
+    && rm -rf /usr/local/lib/node_modules/npm \
+        /usr/local/lib/node_modules/corepack \
+        /usr/local/bin/npm \
+        /usr/local/bin/npx \
+        /usr/local/bin/corepack \
+        /opt/yarn-* \
+        /usr/local/bin/yarn \
+        /usr/local/bin/yarnpkg
 
 ENV PORT=9000
 EXPOSE 9000


### PR DESCRIPTION
This PR removes npm, corepack and yarn from the final image, following the pattern of alphagov/pay-selfservice#5001. The following are removed:

- `/usr/local/lib/node_modules/npm` - the global npm installation
- `/usr/local/lib/node_modules/corepack` - the global corepack installation
- `/usr/local/bin/npm` - symlink to `/usr/local/lib/node_modules/npm/bin/npm-cli.js`
- `/usr/local/bin/npx` - symlink to `/usr/local/lib/node_modules/npm/bin/npx-cli.js`
- `/usr/local/bin/corepack` - symlink to `/usr/local/lib/node_modules/corepack/dist/corepack.js`
- `/opt/yarn-*` - global yarn installation(s)
- `/usr/local/bin/yarn` - symlink to `/opt/yarn-<current-version>/bin/yarn`
- `/usr/local/bin/yarnpkg` - symlink to `/opt/yarn-<current-version>/bin/yarnpkg`

Note that yarn has been [removed from the Node.js 26+ images](https://github.com/nodejs/docker-node/issues/2264), and corepack is not included from Node 25.

This introduces the 3 stage build approach from alphagov/pay-selfservice.

1. We perform an upgrade operation and install `tini` in a "base" stage
2. We upgrade the global `npm`, copy the entire project, install, compile and prune `node_modules` in the "builder" stage, as before
3. In the "final" stage we copy **only the required files** from the build stage, and remove npm and yarn
4. The CMD instruction now becomes `["node", "start.js"]`, i.e. the content of the "start" npm script.

Additionally:
* Uses a WORKDIRs with a more descriptive name in the "builder" stage, for clarity