### PR TITLE
PP-15719 send request to connector on adyen specific api route

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -150,56 +150,56 @@
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "13cba698ab03d9438b0107161da540794080a05d",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "2754f1945444194c8b917ab84e5d66b80543d602",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "50c4c64012c3e907a1c2c4ab059b6cc8816ca2bb",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "9cd1bb92c6f70ea29e7d0dc3f132b4de8f0658a3",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 39
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1af9a059666b095ca066171bfa93b84e895134d8",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 65
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "1ee4b74cf4b89c3cd9792a34a1fdfed2c8d4b71d",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 67
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "29537aaf22996353c2fe981aaa72e960b2ed2d70",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 67
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js",
         "hashed_secret": "6464ec4579ee376ccaa76867f536aa1061bc89bf",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 67
       }
     ],
     "test/cypress/integration/card/payment.test.cy.js": [
@@ -380,5 +380,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-19T14:06:28Z"
+  "generated_at": "2026-08-26T08:03:03Z"
 }

--- a/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
+++ b/app/controllers/web-payments/google-pay/normalise-google-pay-payload.js
@@ -94,8 +94,8 @@ module.exports = (req, paymentProvider) => {
     ip_address: userIpAddress(req)
   }
 
-  const paymentData = keysToSnakeCase(JSON.parse(payload.paymentResponse.details.paymentMethodData.tokenizationData.token))
-
+  const token = payload.paymentResponse.details.paymentMethodData.tokenizationData.token
+  const paymentData = keysToSnakeCase(JSON.parse(token))
   delete payload.paymentResponse.details.paymentMethodData
 
   switch (paymentProvider) {
@@ -113,7 +113,7 @@ module.exports = (req, paymentProvider) => {
       paymentInfo.js_timezone_offset_mins = payload.paymentResponse.browser_info.js_timezone_offset_mins
       return {
         payment_info: paymentInfo,
-        token: JSON.stringify(paymentData)
+        token: token
       }
     case 'sandbox':
     case 'worldpay':

--- a/app/controllers/web-payments/payment-auth-request.controller.js
+++ b/app/controllers/web-payments/payment-auth-request.controller.js
@@ -40,7 +40,7 @@ module.exports = (req, res, next) => {
     payload
   }
 
-  return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet(chargeOptions, getLoggingFields(req))
+  return connectorClient({ correlationId: req.headers[CORRELATION_HEADER] }).chargeAuthWithWallet(chargeOptions, paymentProvider, getLoggingFields(req))
     .then(response => {
       setSessionVariable(req, `ch_${(chargeId)}.webPaymentAuthResponse`, {
         statusCode: response.status,

--- a/app/services/clients/connector.client.js
+++ b/app/services/clients/connector.client.js
@@ -30,11 +30,18 @@ const _getFindChargeUrlFor = chargeId => baseUrl + CARD_CHARGE_PATH.replace('{ch
 const _getAuthUrlFor = chargeId => baseUrl + CARD_AUTH_PATH.replace('{chargeId}', chargeId)
 
 /** @private */
-const _getWalletAuthUrlFor = (chargeId, walletType) => {
-  const walletAuthUrl = baseUrl + WALLET_AUTH_PATH
+const _getWalletAuthUrlFor = (chargeId, walletType, paymentProvider) => {
+  let pathSuffix = ''
+
+  if (paymentProvider === 'adyen' && walletType === 'google') {
+    pathSuffix = '/adyen'
+  }
+
+  const path = WALLET_AUTH_PATH
     .replace('{chargeId}', chargeId)
     .replace('{walletType}', walletType)
-  return walletAuthUrl
+
+  return baseUrl + path + pathSuffix
 }
 
 /** @private */
@@ -178,8 +185,8 @@ const chargeAuth = (chargeOptions, loggingFields = {}) => {
   return _postConnector(authUrl, chargeOptions.payload, 'create charge', loggingFields, 'chargeAuth')
 }
 
-const chargeAuthWithWallet = (chargeOptions, loggingFields = {}) => {
-  const authUrl = _getWalletAuthUrlFor(chargeOptions.chargeId, chargeOptions.wallet)
+const chargeAuthWithWallet = (chargeOptions, paymentProvider, loggingFields = {}) => {
+  const authUrl = _getWalletAuthUrlFor(chargeOptions.chargeId, chargeOptions.wallet, paymentProvider)
   return _postConnector(authUrl, chargeOptions.payload, 'create charge using e-wallet payment', loggingFields, 'chargeAuthWithWallet')
 }
 

--- a/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
+++ b/test/controllers/web-payments/google-pay/normalise-google-pay-payload.test.js
@@ -1,7 +1,6 @@
 const expect = require('chai').expect
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-const { keysToSnakeCase } = require('../../../../app/utils/key-camelizer')
 
 const loggerInfoMock = sinon.spy()
 
@@ -144,10 +143,7 @@ describe('normalise Google Pay payload', () => {
           js_screen_width: 2048,
           js_timezone_offset_mins: -60
         },
-        token: JSON.stringify(keysToSnakeCase(
-          JSON.parse(
-            '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
-          )))
+        token: '{"signature":"MEQCIB54h8T/hWY3864Ufkwo4SF5IjhoMV9hjpJRIsqbAn4LAiBZz1VBZ+aiaduX8MN3dBtzyDOZVstwG/8bqJZDbrhKfQ\\u003d","protocolVersion":"ECv1","signedMessage":"{\\"encryptedMessage\\":\\"I2fg4rbEzgRHpvJqN4pHa7Zh93eGePLCKwHljtTfgWELsLOx0Or1cBQ6giKNUrJza3DqhS0AO+Qoar44J2HBryMRaiuSIi/un0zsNV9cfmiLSHNjHNnATkYrfY4u/Or2uSeuAaxLEt3d91NhHWKqf6BelNme182onG23GvOqd4RAukUW7RJ04eouaCIvBisdt866uq/9B3jJb0QiT91ifZ8C/bfScnBFPL4AX0X3G+B7418wSTtUYrMVBnyhNJS8T2Aw9oW8s7c9pra4PI9cHfcu22opRxzSS9snBF39uTwk8c+Pjj3G8yfNI0biDkHNAUiA1YuBW5CgHeJZ/FhayAsAPzfMmI4qei9nTzIEPlDkkGsqFnamCYIg8N9SM51YV8NGS0MQTIYmJg3GHl2D/We30D6dvYSWfLDDJNATAgb3l+4powoxogb28cwE9vLjFhOF/GChrGRpM845E9r1q0tNfg\\\\u003d\\\\u003d\\",\\"ephemeralPublicKey\\":\\"BC9B7aoVhvPzR54m8P1CkGFDSyuxl04iqu22SvnrlLgZEoH3EvpBNKPyMS/nLIe3mJ+cw26GglqMs00B7EEEs0I\\\\u003d\\",\\"tag\\":\\"lOylJZZF3xdVpsqpl5bKgZdsxRPetMRvcKu9WnmFQ/k\\\\u003d\\"}"}'
       }
     )
 

--- a/test/controllers/web-payments/payment-auth-request.controller.test.js
+++ b/test/controllers/web-payments/payment-auth-request.controller.test.js
@@ -123,8 +123,7 @@ describe('The web payments auth request controller', () => {
         expect(res.send.calledWith({ url: `/handle-payment-response/google/${chargeId}` })).to.be.ok // eslint-disable-line
         expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
         done()
-      }
-      )
+      })
     })
 
     it('should set error identifier in the session for declined transaction, if it is present in the response body ' +
@@ -149,8 +148,7 @@ describe('The web payments auth request controller', () => {
           expect(res.send.calledWith({ url: `/handle-payment-response/google/${chargeId}` })).to.be.ok // eslint-disable-line
           expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
         done()
-      }
-      )
+      })
     })
 
     it('should not set payload in the session and return handle payment url if error', done => {
@@ -169,8 +167,7 @@ describe('The web payments auth request controller', () => {
         expect(res.send.calledWith({ url: `/handle-payment-response/google/${chargeId}` })).to.be.ok // eslint-disable-line
         expect(mockCookies.setSessionVariable.called).to.be.false // eslint-disable-line
         done()
-      }
-      )
+      })
     })
 
     it('should call the `next` function when the Google Pay normalise function throws an error', done => {
@@ -191,6 +188,53 @@ describe('The web payments auth request controller', () => {
       sinon.assert.calledWith(next, error)
 
       done()
+    })
+  })
+
+  describe('when processing an Adyen Google Pay payment', () => {
+    const wallet = 'google'
+    const req = {
+      headers: {
+        'x-request-id': 'aaa'
+      },
+      chargeId,
+      chargeData: paymentFixtures.validChargeDetails({ paymentProvider: 'adyen' }),
+      params: {
+        wallet
+      },
+      body: {}
+    }
+
+    const requirePaymentAuthRequestController = (mockedNormalise, mockedCookies) => {
+      const proxyquireMocks = {
+        '../../utils/cookies': mockedCookies,
+        './google-pay/normalise-google-pay-payload': mockedNormalise
+      }
+
+      return proxyquire('../../../app/controllers/web-payments/payment-auth-request.controller.js', proxyquireMocks)
+    }
+
+    it('should set payload in the session and return handle payment url when payment provider is Adyen', done => {
+      const res = {
+        status: sinon.spy(),
+        send: sinon.spy()
+      }
+
+      const mockCookies = {
+        setSessionVariable: sinon.spy()
+      }
+      const expectedBodySavedInSession = {
+        statusCode: 200
+      }
+      nock(process.env.CONNECTOR_HOST)
+        .post(`/v1/frontend/charges/${chargeId}/wallets/google/adyen`)
+        .reply(200)
+      requirePaymentAuthRequestController(mockNormalise, mockCookies)(req, res).then(() => {
+        expect(res.status.calledWith(200)).to.be.ok // eslint-disable-line
+        expect(res.send.calledWith({ url: `/handle-payment-response/google/${chargeId}` })).to.be.ok // eslint-disable-line
+        expect(mockCookies.setSessionVariable.calledWith(req, `ch_${chargeId}.webPaymentAuthResponse`, expectedBodySavedInSession)).to.be.ok // eslint-disable-line
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
- Add functionallity to allow payment-auth-request.controller to send data to the correct connector route
- Add Adyen Google Pay methods to connector.client