### PR TITLE
PP-15765: add entrypoint module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pay-frontend",
   "description": "Payments Frontend application",
   "version": "0.0.1",
+  "main": "start.js",
   "private": true,
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
When running frontend locally with pay-cli, we attempt to [enable the Node inspector](https://nodejs.org/learn/getting-started/debugging#enable-inspector) with the `--inspect` flag. However, we pass the flag to [nodemon](https://nodemon.io/), which starts the application in the following way:
1. Looks for "main" in `package.json` and passes the specified module to `node`, followed by any flags
2. If there is no "main", it runs the "start" script, followed by any flags

In the case of products-ui the result is a command line like this:

`node start.js --inspect=<inspector-host-and-port>`

Since the module appears before the flag, the debugger is not started.

With this change the command line is:

`node --inspect=<inspector-host-and-port> start.js`

and the debugger runs as expected.