### PR TITLE
PP-15783: Pin chokidar to version 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "chai-string": "^1.4.0",
         "cheerio": "^1.0.0-rc.12",
         "chokidar": "^3.5.3",
-        "chokidar-cli": "*",
+        "chokidar-cli": "3.0.0",
         "cypress": "^15.20.0",
         "dotenv": "^16.3.1",
         "govuk-country-and-territory-autocomplete": "^2.0.0",
@@ -2391,9 +2391,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2408,9 +2405,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2425,9 +2419,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2442,9 +2433,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2603,9 +2591,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2627,9 +2612,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2651,9 +2633,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2675,9 +2654,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2699,9 +2675,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2723,9 +2696,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8268,6 +8238,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12382,9 +12353,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "chai-string": "^1.4.0",
     "cheerio": "^1.0.0-rc.12",
     "chokidar": "^3.5.3",
-    "chokidar-cli": "latest",
+    "chokidar-cli": "3.0.0",
     "cypress": "^15.20.0",
     "dotenv": "^16.3.1",
     "govuk-country-and-territory-autocomplete": "^2.0.0",


### PR DESCRIPTION
## WHAT
In this PR, I have pinned the version of chokidar to version 3.0.0 as the "latest" linked repository had been moved, another github user was name squatting the now unused package name. The link to the issue can be found [here](https://github.com/open-cli-tools/chokidar-cli/issues/118). As part of this change I have also resolved a high vulnerability which was being flagged from the auditter.
## HOW 
_Steps to test or reproduce:_
N/A


