### PR TITLE
PP-15812 Fix Adyen payment normalisation error

### DIFF
--- a/app/assets/javascripts/browsered/web-payments/google-pay.js
+++ b/app/assets/javascripts/browsered/web-payments/google-pay.js
@@ -114,6 +114,7 @@ const processPayment = paymentData => {
 
   if (payment_provider === 'adyen' && Charge.collect_additional_browser_info_adyen === true) { // eslint-disable-line camelcase
     paymentData.browser_info = getBrowserInfo()
+    paymentData.browser_info.js_enabled = true
   }
 
   // attempt device data collection for worldpay only

--- a/app/assets/javascripts/browsered/web-payments/helpers.js
+++ b/app/assets/javascripts/browsered/web-payments/helpers.js
@@ -125,15 +125,30 @@ const getGooglePaymentsConfiguration = (paymentProvider) => {
 }
 
 const getBrowserInfo = () => {
-  const timezoneOffset = new Date().getTimezoneOffset()
-  return {
-    js_enabled: true,
-    js_navigator_language: typeof navigator.language === 'string' ? navigator.language : null,
-    js_screen_color_depth: typeof window.screen.colorDepth === 'number' ? window.screen.colorDepth : null,
-    js_screen_height: typeof window.screen.height === 'number' ? window.screen.height : null,
-    js_screen_width: typeof window.screen.width === 'number' ? window.screen.width : null,
-    js_timezone_offset_mins: typeof timezoneOffset === 'number' ? timezoneOffset : null
+  let browserInfo = {}
+
+  if (typeof navigator.language === 'string') {
+    browserInfo.js_navigator_language = navigator.language
   }
+
+  if (typeof window.screen.colorDepth === 'number') {
+    browserInfo.js_screen_color_depth = window.screen.colorDepth
+  }
+
+  if (typeof window.screen.height === 'number') {
+    browserInfo.js_screen_height = window.screen.height
+  }
+
+  if (typeof window.screen.height === 'number') {
+    browserInfo.js_screen_width = window.screen.width
+  }
+
+  const timezoneOffset = new Date().getTimezoneOffset()
+  if (typeof timezoneOffset === 'number') {
+    browserInfo.js_timezone_offset_mins = timezoneOffset
+  }
+
+  return browserInfo
 }
 
 module.exports = {

--- a/test/cypress/integration/adyen/collect-additional-browser-info-adyen.test.cy.js
+++ b/test/cypress/integration/adyen/collect-additional-browser-info-adyen.test.cy.js
@@ -7,6 +7,21 @@ describe('Enter card details page - browser info collection', () => {
   const sessionOpts = {}
 
   it('should collect extra browser information for an Adyen non-MOTO payment', () => {
+    const validPayment = {
+      cardNumber: '4444333322221111',
+      expiryMonth: '01',
+      expiryYear: '30',
+      name: 'Valid Paying Name',
+      securityCode: '012',
+      addressLine1: '10 Valid Paying Address',
+      city: 'London',
+      postcode: 'E1 8QS',
+      email: 'test@test.test'
+    }
+
+    const checkCardDetailsStubs = cardPaymentStubs.checkCardDetailsStubs(chargeId)
+    const confirmPaymentDetailsStubs = cardPaymentStubs.confirmPaymentDetailsStubs(chargeId, validPayment, gatewayAccountId)
+
     const providerOpts = {
       paymentProvider: 'adyen'
     }
@@ -43,6 +58,32 @@ describe('Enter card details page - browser info collection', () => {
       cy.get('#card-details input[name=jsEnabled]').should('exist')
       cy.get('#card-details input[name=jsEnabled]').should('have.attr', 'value', 'true')
     })
+
+    cy.log('Submitting valid payment details to check the hidden form fields are processed without error')
+
+    cy.task('clearStubs')
+    cy.task('setupStubs', checkCardDetailsStubs)
+
+    cy.intercept('POST', `/check_card/${chargeId}`).as('checkCard')
+
+    cy.get('#card-no').type(validPayment.cardNumber)
+    cy.get('#card-no').blur()
+    cy.wait('@checkCard')
+    cy.get('#expiry-month').type(validPayment.expiryMonth)
+    cy.get('#expiry-year').type(validPayment.expiryYear)
+    cy.get('#cardholder-name').type(validPayment.name)
+    cy.get('#cvc').type(validPayment.securityCode)
+    cy.get('#address-line-1').type(validPayment.addressLine1)
+    cy.get('#address-city').type(validPayment.city)
+    cy.get('#address-postcode').type(validPayment.postcode)
+    cy.get('#email').type(validPayment.email)
+
+    cy.task('clearStubs')
+    cy.task('setupStubs', confirmPaymentDetailsStubs)
+
+    cy.get('#card-details').submit()
+    cy.location('pathname').should('eq', `/card_details/${chargeId}/confirm`)
+    cy.get('#confirm').should('exist')
   })
 
   it('should not collect extra browser information on the page for an Adyen MOTO payment', () => {


### PR DESCRIPTION
Fix error normalising entered payment data when making an Adyen payment introduced by commit 81c1c66f656017a051303a7115d47b5dbe84e9fb.

The error was caused by the client-side JavaScript adding a duplicate hidden form field with the name `jsEnabled`, which Node.js handles by combining the two values into an object, which means it’s not a string when later code tries to trim it.

Fix the problem by making sure that there is only one `jsEnabled` hidden form field (or `js_enabled` JSON property in the case of Google Pay payments). Enhance the existing Cypress test that tests these hidden form fields by making it submit the form to ensure they’re actually processed correctly on the server side.