### PR TITLE
PP-15836 add Dependabot exclude cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
   - govuk-pay
   - dependencies
   - javascript
+  cooldown:
+    exclude:
+      - "@govuk-pay/*"
   ignore:
   - dependency-name: "@aws-crypto/decrypt-node"
     versions: ["2.x", "3.x", "4.x"]


### PR DESCRIPTION
## WHAT

Exclude pay-js-commons from the cooldown period of dependabot updates.


